### PR TITLE
Include PowerBI post processing file in module

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -38,6 +38,7 @@ include("sites/dMCDA.jl")
 include("io/ResultSet.jl")
 include("metrics/metrics.jl")
 include("io/result_io.jl")
+include("io/result_post_processing.jl")
 
 include("scenario.jl")
 


### PR DESCRIPTION
@Rosejoycrocker 

Can't believe I missed this in the last review but also not sure how the file export function was being used before. Without including it as part of the ADRIA package, there's no way of accessing it:

```julia-repl
julia> ADRIA.create_BI_format_file(rs, ".")
ERROR: UndefVarError: create_BI_format_file not defined
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base .\Base.jl:35
 [2] top-level scope
   @ REPL[3]:1

julia> import ADRIA: create_BI_format_file
WARNING: could not import ADRIA.create_BI_format_file into Main
```