### PR TITLE
Support extraction of geometry data from inconsistent column names

### DIFF
--- a/Aviz/src/Aviz.jl
+++ b/Aviz/src/Aviz.jl
@@ -235,7 +235,7 @@ function gui_analysis(rs::ADRIA.ResultSet)
     hidespines!(scen_hist)
 
     # Display map
-    map_coords = GeoInterface.coordinates.(rs.site_data.geometry)
+    map_coords = GeoInterface.coordinates.(ADRIA.get_geometry(rs.site_data))
     plot_poly!.(map_display, map_coords)
 
     # Fill pairplot

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -1,3 +1,13 @@
+function get_geometry(df::DataFrame)
+    if "geometry" in names(df)
+        return df.geometry
+    elseif "geom" in names(df)
+        return df.geom
+    end
+
+    error("No geometry data found")
+end
+
 """
     centroids(df::DataFrame)
 
@@ -10,7 +20,7 @@ df : GeoDataFrame
 Array of tuples (x, y), where x and y relate to long and lat respectively.
 """
 function centroids(df::DataFrame)::Array
-    site_centroids = AG.centroid.(df.geometry)
+    site_centroids = AG.centroid.(get_geometry(df::DataFrame))
     return collect(zip(AG.getx.(site_centroids, 0), AG.gety.(site_centroids, 0)))
 end
 


### PR DESCRIPTION
Non-breaking change.

Different libraries read/write geometry data into `geom` or `geometry`.

This PR adds a function to check for one or the other and read in data from the appropriate column.

