### PR TITLE
Adjust coral wave mortalities following recommendation by Ken

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -346,8 +346,8 @@ function coral_spec()::NamedTuple
     wavemort90 = Array{Float64,2}([
         0.0 0.0 0.0 0.0 0.05 0.1  # Tabular Acropora Enhanced
         0.0 0.0 0.0 0.0 0.05 0.1  # Tabular Acropora Unenhanced
-        0.0 0.0 0.0 0.0 0.03 0.05  # Corymbose Acropora Enhanced
-        0.0 0.0 0.0 0.0 0.04 0.05  # Corymbose Acropora Unenhanced
+        0.0 0.0 0.0 0.0 0.02 0.05  # Corymbose Acropora Enhanced
+        0.0 0.0 0.0 0.0 0.02 0.05  # Corymbose Acropora Unenhanced
         0.0 0.0 0.0 0.0 0.0 0.0  # small massives and encrusting
         0.0 0.0 0.0 0.0 0.0 0.0])  # large massives
 


### PR DESCRIPTION
- only explicitly add wave mortalities for Acropora in size class 5 and 6.
- mortalities for remaining size classes and species are assumed to be covered by background mortalities.