### PR TITLE
Add support for Regional Sensitivity Analysis (RSA)

### DIFF
--- a/Aviz/src/analysis.jl
+++ b/Aviz/src/analysis.jl
@@ -1,7 +1,8 @@
-import ADRIA.sensitivity: pawn, relative_importance
+import ADRIA.analysis: normalize
+import ADRIA.sensitivity: pawn
 
 
 function relative_sensitivities(X, y; S=10, stat=:median)::Vector{Float64}
-    return relative_importance(pawn(X, Array(y); S=S)[:, stat])
+    return normalize(pawn(X, Array(y); S=S)[:, stat])
 end
 

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -35,7 +35,6 @@ include("ecosystem/const_params.jl")
 include("io/inputs.jl")
 include("Domain.jl")
 
-
 include("sites/connectivity.jl")
 include("sites/dMCDA.jl")
 
@@ -46,11 +45,11 @@ include("io/result_io.jl")
 include("io/result_post_processing.jl")
 include("io/sampling.jl")
 include("metrics/metrics.jl")
-include("metrics/sensitivity.jl")
 include("metrics/performance.jl")
 
 include("scenario.jl")
 include("optimization.jl")
+include("analysis/sensitivity.jl")
 include("analysis/analysis.jl")
 
 
@@ -61,8 +60,6 @@ function __init__()
         end
     end
 end
-
-# include("main_app.jl")
 
 
 export fecundity_scope!, bleaching_mortality!

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -49,8 +49,8 @@ include("metrics/performance.jl")
 
 include("scenario.jl")
 include("optimization.jl")
-include("analysis/sensitivity.jl")
 include("analysis/analysis.jl")
+include("analysis/sensitivity.jl")
 
 
 function __init__()

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -20,6 +20,7 @@ end
 
 
 include("pareto.jl")
+include("sensitivity.jl")
 
 
 end

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -6,14 +6,20 @@ import ADRIA: ResultSet
 
 
 """
-    normalize(data::Matrix)::Matrix
+    normalize(data::AbstractArray)::AbstractArray
+    normalize(data::Vector)::Vector
 
-Normalize a matrix so that the data is ∈ [0, 1] relative to values in each column.
+Normalize a matrix (∈ [0, 1]) on a per-column basis.
 """
-function normalize(data::Matrix)::Matrix
-    limits = extrema.(eachcol(data))
+function normalize(data::AbstractMatrix)::AbstractMatrix
+    return hcat(normalize.(eachcol(data))...)
+end
+function normalize(data::AbstractVector)::AbstractVector
+    limits = extrema(data)
+    scaled = let (mi, ma) = limits
+        (data .- mi) ./ (ma - mi)
+    end
 
-    scaled = hcat([(d .- mi) ./ (ma - mi) for (d, (mi, ma)) in zip(eachcol(data), limits)]...)
     replace!(scaled, NaN => 0.0)
     return scaled
 end

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -24,6 +24,30 @@ function normalize(data::AbstractVector)::AbstractVector
     return scaled
 end
 
+"""
+    discretize_outcomes(y; S=20)
+
+Normalize outcomes and discretize them into \$S\$ bins.
+
+Classify as 1 to S where:
+S := 1.0 - 0.9
+S-1 := 0.9 - 0.8
+etc
+"""
+function discretize_outcomes(y; S=20)
+    steps = 0.0:(1/S):1.0
+
+    y_s_hat = normalize(y)
+    y_disc = zeros(size(y)...)
+    for i in axes(steps, 1)[2:end]
+        for j in size(y_s_hat, 2)
+            y_disc[steps[i-1].<y_s_hat[:, j].<=steps[i], j] .= steps[i-j]
+        end
+    end
+
+    return y_disc
+end
+
 
 include("pareto.jl")
 include("sensitivity.jl")

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -85,67 +85,83 @@ function pawn(X::NamedArray, Y::Vector{<:Real}; S::Int64=10)::NamedArray
 end
 
 """
-    rsa(X::DataFrame, Y::Vector{<:Real}; S=20)
+    rsa(X::DataFrame, y::Vector{<:Real}; S=20)::NamedArray
 
 Perform Regional Sensitivity Analysis.
 
 Regional Sensitivity Analysis is a Monte Carlo Filtering approach which aims to
 identify which (group of) factors drive model outputs within or outside of a specified bound.
 Outputs which fall inside the bounds are regarded as "behavioral", whereas those outside
-are "non-behavioral". These behavioral/non-behavioral subsets are compared for each factor.
+are "non-behavioral". The distribution of behavioral/non-behavioral subsets are compared for each factor.
 If the subsets are not similar, then the factor is influential.
 
-The implemented approach splits factor space into \$S\$ bins and iteratively assesses 
-behavioral and non-behavioral subsets. The non-parametric \$k\$-sample Anderson-Darling test is
-applied to compare the subsets, where larger values indicate greater dissimilarity. 
-The Anderson-Darling test places more weight on the tails compared to the 
-Kolmogorov-Smirnov test.
+The implemented approach slices factor space into \$S\$ bins and iteratively assesses
+behavioral and non-behavioral subsets with the non-parametric \$k\$-sample Anderson-Darling test.
+Larger values indicate greater dissimilarity (thus, sensitivity). The Anderson-Darling test
+places more weight on the tails compared to the Kolmogorov-Smirnov test.
 
-This RSA can indicate where in factor space model sensitivities may be.
+RSA can indicate where in factor space model sensitivities may be, and contributes to a
+Value-of-Information (VoI) analysis.
+
 Increasing the value of \$S\$ increases the granularity of the analysis.
 
+# Arguments
+- `X` : scenario specification
+- `y` : scenario outcomes
+- `S` : number of bins to slice factor space into (default: 20)
+
+# Returns
+NamedArray, [factor names, upper bound of bins]
+
+# Examples
+```julia
+ADRIA.sensitivity.rsa(X, y)
+```
+
 # References
-1. Pianosi, F., K. Beven, J. Freer, J. W. Hall, J. Rougier, D. B. Stephenson, and 
-   T. Wagener. 2016. 
-   Sensitivity analysis of environmental models: 
-   A systematic review with practical workflow. 
+1. Pianosi, F., K. Beven, J. Freer, J. W. Hall, J. Rougier, D. B. Stephenson, and
+   T. Wagener. 2016.
+   Sensitivity analysis of environmental models:
+   A systematic review with practical workflow.
    Environmental Modelling & Software 79:214-232.
    https://dx.doi.org/10.1016/j.envsoft.2016.02.008
 
-2. Saltelli, A., M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli, 
-   M. Saisana, and S. Tarantola. 2008. 
+2. Saltelli, A., M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli,
+   M. Saisana, and S. Tarantola. 2008.
    Global Sensitivity Analysis: The Primer.
    Wiley, West Sussex, U.K.
    https://dx.doi.org/10.1002/9780470725184
    Accessible at: http://www.andreasaltelli.eu/file/repository/Primer_Corrected_2022.pdf
 """
-function rsa2(X::DataFrame, Y::Vector{<:Real}; S=20)
-    dimnames = names(X)
+function rsa(X::DataFrame, y::Vector{<:Real}; S=20)::NamedArray
+    factor_names = names(X)
     N, D = size(X)
     step = 1 / S
     seq = 0:step:1
 
     X_di = zeros(N)
     X_q = zeros(S + 1)
+    r_s = NamedArray(zeros(S, D))
 
-    r_s = zeros(D, S)
+    setnames!(r_s, string.(collect(seq)[2:end]), 1)  # label with upper bounds
+    setnames!(r_s, factor_names, 2)
+    setdimnames!(r_s, [:bins, :factors])
 
     for d_i in 1:D
         X_di .= X[:, d_i]
         X_q .= quantile(X_di, seq)
-        for s in 1:S
-            sel = (X_di.>=X_q[s]).&(X_di.<X_q[s+1])
-            Y_sel = Y[sel]
+        Threads.@threads for s in 2:S
+            sel = (X_q[s-1] .< X_di) .& (X_di .<= X_q[s])
+            Y_sel = y[sel]
             if length(Y_sel) == 0
-                r_s[d_i, s] = 0.0
+                r_s[s, d_i] = 0.0
                 continue  # no available samples
             end
 
-            r_s[d_i, s] = KSampleADTest(Y_sel, Y[Not(sel)]).A²k
+            r_s[s, d_i] = KSampleADTest(Y_sel, y[Not(sel)]).A²k
         end
     end
 
-    # TODO: Return NamedArray
     return r_s
 end
 

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -3,37 +3,7 @@ module sensitivity
 using Logging
 using Statistics, Distributions, HypothesisTests, NamedArrays, DataFrames
 
-
-"""
-    relative_importance(x::AbstractVector{<:Real})
-    relative_importance(x::AbstractArray)
-
-Normalize metrics such that the values ∈ [0, 1].
-
-Note: If a matrix is passed in, this calculates the relative importance
-for each column.
-
-# Arguments
-- x : metric values
-
-# Returns
-Normalized values of same shape as x.
-"""
-function relative_importance(x::AbstractVector{<:Real})
-    if (maximum(x) - minimum(x)) == 0.0
-        return 0.0
-    end
-
-    return (x .- minimum(x)) ./ (maximum(x) - minimum(x))
-end
-function relative_importance(x::AbstractArray)
-    S = similar(x)
-    for idx in axes(x, 2)
-        S[:, idx] .= relative_importance(x[:, idx])
-    end
-
-    return S
-end
+import ADRIA.analysis: normalize
 
 
 """

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -1,7 +1,8 @@
 module sensitivity
 
 using Logging
-using Statistics, Distributions, HypothesisTests, NamedArrays, DataFrames
+using Statistics, Distributions, HypothesisTests, Bootstrap
+using NamedArrays, DataFrames
 
 import ADRIA.analysis: normalize
 
@@ -54,8 +55,8 @@ function pawn(X::AbstractArray{<:Real}, Y::Vector{<:Real}, dimnames::Vector{Stri
         for d_i in 1:D
             X_di .= X[:, d_i]
             X_q .= quantile(X_di, seq)
-            for s in 1:S
-                Y_sel = Y[(X_di.>=X_q[s]).&(X_di.<X_q[s+1])]
+            for s in 2:S
+                Y_sel = Y[(X_q[s-1].<X_di).&(X_di.<=X_q[s])]
                 if length(Y_sel) == 0
                     pawn_t[s, d_i] = 0.0
                     continue  # no available samples

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -1,0 +1,181 @@
+module sensitivity
+
+using Logging
+using Statistics, Distributions, HypothesisTests, NamedArrays, DataFrames
+
+
+"""
+    relative_importance(x::AbstractVector{<:Real})
+    relative_importance(x::AbstractArray)
+
+Normalize metrics such that the values ∈ [0, 1].
+
+Note: If a matrix is passed in, this calculates the relative importance
+for each column.
+
+# Arguments
+- x : metric values
+
+# Returns
+Normalized values of same shape as x.
+"""
+function relative_importance(x::AbstractVector{<:Real})
+    if (maximum(x) - minimum(x)) == 0.0
+        return 0.0
+    end
+
+    return (x .- minimum(x)) ./ (maximum(x) - minimum(x))
+end
+function relative_importance(x::AbstractArray)
+    S = similar(x)
+    for idx in axes(x, 2)
+        S[:, idx] .= relative_importance(x[:, idx])
+    end
+
+    return S
+end
+
+
+"""
+    ks_statistic(ks)
+
+Calculate the Kolmogorov-Smirnov test statistic.
+"""
+function ks_statistic(ks)
+    n = (ks.n_x * ks.n_y) / (ks.n_x + ks.n_y)
+
+    return sqrt(n) * ks.δ
+end
+
+
+"""
+    Calculates the PAWN sensitivity index.
+
+# Arguments
+- X : Model inputs
+- Y : Outputs
+- S : Number of slides (default: 10)
+
+# Returns
+NamedDimsArray, of min, mean, median, max, std, and cv summary statistics.
+
+# References
+1. Pianosi, F., Wagener, T., 2018.
+   Distribution-based sensitivity analysis from a generic input-output sample.
+   Environmental Modelling & Software 108, 197-207.
+   https://doi.org/10.1016/j.envsoft.2018.07.019
+
+2. Baroni, G., Francke, T., 2020.
+   GSA-cvd
+   Combining variance- and distribution-based global sensitivity analysis
+   https://github.com/baronig/GSA-cvd
+"""
+function pawn(X::AbstractArray{<:Real}, Y::Vector{<:Real}, dimnames::Vector{String}; S::Int64=10)::NamedArray
+    N, D = size(X)
+    step = 1 / S
+    seq = 0:step:1
+
+    X_di = zeros(N)
+    X_q = zeros(S + 1)
+    pawn_t = zeros(S + 1, D)
+    results = zeros(D, 6)
+    # Hide warnings from HypothesisTests
+    with_logger(NullLogger()) do
+        for d_i in 1:D
+            X_di .= X[:, d_i]
+            X_q .= quantile(X_di, seq)
+            for s in 1:S
+                Y_sel = Y[(X_di.>=X_q[s]).&(X_di.<X_q[s+1])]
+                if length(Y_sel) == 0
+                    pawn_t[s, d_i] = 0.0
+                    continue  # no available samples
+                end
+
+                pawn_t[s, d_i] = ks_statistic(ApproximateTwoSampleKSTest(Y_sel, Y))
+            end
+
+            p_ind = pawn_t[:, d_i]
+            p_mean = mean(p_ind)
+            p_sdv = std(p_ind)
+            p_cv = p_sdv ./ p_mean
+            results[d_i, :] .= (minimum(p_ind), p_mean, median(p_ind), maximum(p_ind), p_sdv, p_cv)
+        end
+    end
+
+    replace!(results, NaN => 0.0, Inf => 0.0)
+
+    return NamedArray(results, (dimnames, [:min, :mean, :median, :max, :std, :cv]))
+end
+function pawn(X::DataFrame, Y::Vector{<:Real}; S::Int64=10)::NamedArray
+    return pawn(Matrix(X), Y, names(X); S=S)
+end
+function pawn(X::NamedArray, Y::Vector{<:Real}; S::Int64=10)::NamedArray
+    return pawn(X, Y, names(X, 2); S=S)
+end
+
+"""
+    rsa(X::DataFrame, Y::Vector{<:Real}; S=20)
+
+Perform Regional Sensitivity Analysis.
+
+Regional Sensitivity Analysis is a Monte Carlo Filtering approach which aims to
+identify which (group of) factors drive model outputs within or outside of a specified bound.
+Outputs which fall inside the bounds are regarded as "behavioral", whereas those outside
+are "non-behavioral". These behavioral/non-behavioral subsets are compared for each factor.
+If the subsets are not similar, then the factor is influential.
+
+The implemented approach splits factor space into \$S\$ bins and iteratively assesses 
+behavioral and non-behavioral subsets. The non-parametric \$k\$-sample Anderson-Darling test is
+applied to compare the subsets, where larger values indicate greater dissimilarity. 
+The Anderson-Darling test places more weight on the tails compared to the 
+Kolmogorov-Smirnov test.
+
+This RSA can indicate where in factor space model sensitivities may be.
+Increasing the value of \$S\$ increases the granularity of the analysis.
+
+# References
+1. Pianosi, F., K. Beven, J. Freer, J. W. Hall, J. Rougier, D. B. Stephenson, and 
+   T. Wagener. 2016. 
+   Sensitivity analysis of environmental models: 
+   A systematic review with practical workflow. 
+   Environmental Modelling & Software 79:214-232.
+   https://dx.doi.org/10.1016/j.envsoft.2016.02.008
+
+2. Saltelli, A., M. Ratto, T. Andres, F. Campolongo, J. Cariboni, D. Gatelli, 
+   M. Saisana, and S. Tarantola. 2008. 
+   Global Sensitivity Analysis: The Primer.
+   Wiley, West Sussex, U.K.
+   https://dx.doi.org/10.1002/9780470725184
+   Accessible at: http://www.andreasaltelli.eu/file/repository/Primer_Corrected_2022.pdf
+"""
+function rsa2(X::DataFrame, Y::Vector{<:Real}; S=20)
+    dimnames = names(X)
+    N, D = size(X)
+    step = 1 / S
+    seq = 0:step:1
+
+    X_di = zeros(N)
+    X_q = zeros(S + 1)
+
+    r_s = zeros(D, S)
+
+    for d_i in 1:D
+        X_di .= X[:, d_i]
+        X_q .= quantile(X_di, seq)
+        for s in 1:S
+            sel = (X_di.>=X_q[s]).&(X_di.<X_q[s+1])
+            Y_sel = Y[sel]
+            if length(Y_sel) == 0
+                r_s[d_i, s] = 0.0
+                continue  # no available samples
+            end
+
+            r_s[d_i, s] = KSampleADTest(Y_sel, Y[Not(sel)]).A²k
+        end
+    end
+
+    # TODO: Return NamedArray
+    return r_s
+end
+
+end

--- a/src/metrics/sensitivity.jl
+++ b/src/metrics/sensitivity.jl
@@ -5,38 +5,6 @@ using Statistics, Distributions, HypothesisTests, NamedArrays, DataFrames
 
 
 """
-    relative_importance(x::AbstractVector{<:Real})
-    relative_importance(x::AbstractArray)
-
-Normalize metrics such that the values ∈ [0, 1].
-
-Note: If a matrix is passed in, this calculates the relative importance
-for each column.
-
-# Arguments
-- x : metric values
-
-# Returns
-Normalized values of same shape as x.
-"""
-function relative_importance(x::AbstractVector{<:Real})
-    if (maximum(x) - minimum(x)) == 0.0
-        return 0.0
-    end
-
-    return (x .- minimum(x)) ./ (maximum(x) - minimum(x))
-end
-function relative_importance(x::AbstractArray)
-    S = similar(x)
-    for idx in axes(x, 2)
-        S[:, idx] .= relative_importance(x[:, idx])
-    end
-
-    return S
-end
-
-
-"""
     ks_statistic(ks)
 
 Calculate the Kolmogorov-Smirnov test statistic.
@@ -46,7 +14,6 @@ function ks_statistic(ks)
 
     return sqrt(n) * ks.δ
 end
-
 
 """
     Calculates the PAWN sensitivity index.


### PR DESCRIPTION
Adds regional analyses of sensitivity and outcomes.

Given inputs (`X`) and corresponding outputs (`y`):

```julia
# Conduct RSA
rsa_analysis = ADRIA.sensitivity.rsa(X, y)

# Map outcomes to factor values
# Factors of interest
foi = [:SRM, :fogging, :a_adapt]

# We'd like to assess scenarios where all metrics are above their median
rule = y -> all(y .> 0.5)

# Map desirable outcomes (defined by the rule above) to the range of input values
roa = ADRIA.sensitivity.outcome_map(X, y, rule, foi)
```

See included docstrings for details, but in the rough indicative plot below we see scenario outcomes increase linearly with an increase to factors 1, 3, 6. 
Higher outcomes are seen with low values of Factor 2, which otherwise appears non-influential.
x-axis indicates the upper bin edge
y-axis is the normalized outputs

![image](https://user-images.githubusercontent.com/4075136/210681319-2912f051-b983-4fc4-ac8c-188dfccafb9a.png)

Next step is to simplify use so that users only have to provide the ResultSet alongside specific options for the analysis.
The same process can then be wrapped to produce plots.

Closes #257 