### PR TITLE
Simplify display of model spec

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -552,6 +552,7 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", d::Domain)
 
+    df = model_spec(d)
     println("""
     Domain: $(d.name)
 
@@ -561,8 +562,12 @@ function Base.show(io::IO, mime::MIME"text/plain", d::Domain)
     DHW file: $(d.env_layer_md.DHW_fn)
     Wave file: $(d.env_layer_md.wave_fn)
     Timeframe: $(d.env_layer_md.timeframe[1]) - $(d.env_layer_md.timeframe[end])
+
+    Model Specification:
+    - Parameters: $(nrow(df))
+    - Number of constants: $(nrow(df[df.is_constant .== true, :]))
     """)
 
-    println("\nEcosystem model specification:")
-    show(io, mime, model_spec(d)[:, [:component, :fieldname, :val, :full_bounds, :dists, :is_constant]])
+    # println("\nEcosystem model specification:")
+    # show(io, mime, model_spec(d)[:, [:component, :fieldname, :val, :full_bounds, :dists, :is_constant]])
 end

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -194,7 +194,8 @@ function create_coral_struct(bounds::Tuple{Float64,Float64}=(0.9, 1.1))::Nothing
         for p in base_coral_params
             f_name = c_id * "_" * p
             f_val = x[x.coral_id.==c_id, p][1]
-            struct_fields[f_name] = Param(f_val, ptype="real", bounds=(f_val * bounds[1], f_val * bounds[2], 0.5), dists="triang")
+            struct_fields[f_name] = Param(f_val, ptype="real", bounds=(f_val * bounds[1], f_val * bounds[2], 0.5), dists="triang",
+                name=human_readable_name(f_name, title_case=true), description="")
         end
     end
 
@@ -307,7 +308,7 @@ function coral_spec()::NamedTuple
     tn = repeat(taxa_names; inner=n_classes)
 
     # Create combinations of taxa names and size classes
-    params.name = human_readable_name(tn, true)
+    params.name = human_readable_name(tn; title_case=true)
     params.taxa_id = repeat(1:n_classes; inner=n_classes)
 
     params.class_id = repeat(1:n_classes, n_classes)
@@ -325,10 +326,10 @@ function coral_spec()::NamedTuple
     # we assume similar growth rates for enhanced and unenhanced corals
     # all values in cm/year
     linear_extension = Array{Float64,2}([
-        1.0 3.0 3.0 4.4 4.4 4.4   # Tabular Acropora Enhanced
-        1.0 3.0 3.0 4.4 4.4 4.4   # Tabular Acropora Unenhanced
-        1.0 3.0 3.0 3.0 3.0 3.0         # Corymbose Acropora Enhanced
-        1.0 3.0 3.0 3.0 3.0 3.0         # Corymbose Acropora Unenhanced
+        1.0 3.0 3.0 4.4 4.4 4.4     # Tabular Acropora Enhanced
+        1.0 3.0 3.0 4.4 4.4 4.4     # Tabular Acropora Unenhanced
+        1.0 3.0 3.0 3.0 3.0 3.0     # Corymbose Acropora Enhanced
+        1.0 3.0 3.0 3.0 3.0 3.0     # Corymbose Acropora Unenhanced
         1.0 1.0 1.0 1.0 0.8 0.8     # small massives
         1.0 1.0 1.0 1.0 1.2 1.2])   # large massives
 
@@ -344,7 +345,7 @@ function coral_spec()::NamedTuple
     params.growth_rate .= growth_rate(linear_extension, bin_widths)
 
     # Adjust growth rate for size class 6 to 20% of assumed value.
-    params.growth_rate[params.class_id.==6] .= params.growth_rate[corals.class_id.==6] .* 0.2
+    params.growth_rate[params.class_id.==6] .= params.growth_rate[params.class_id.==6] .* 0.2
 
     # Scope for fecundity as a function of colony area (Hall and Hughes 1996)
     fec_par_a = Float64[1.03; 1.03; 1.69; 1.69; 0.86; 0.86]  # fecundity parameter a

--- a/src/utils/text_display.jl
+++ b/src/utils/text_display.jl
@@ -13,7 +13,7 @@ Returns a copy of original array so input is not modified.
 # Returns
 - converted_names : array[str], of cleaned parameter names
 """
-function human_readable_name(names::Array{String}, title_case::Bool=false)::Array{String}
+function human_readable_name(names::Array{String}; title_case::Bool=false)::Array{String}
     converted_names = names[:]
     converted_names = map((x) -> replace(x, "_" => " "), converted_names)
 
@@ -22,4 +22,11 @@ function human_readable_name(names::Array{String}, title_case::Bool=false)::Arra
     end
 
     return converted_names
+end
+function human_readable_name(name::String; title_case::Bool=false)::String
+    if title_case
+        return titlecase(replace(name, "_" => " "))
+    end
+
+    return replace(name, "_" => " ")
 end


### PR DESCRIPTION
Relying on ModelParameters or DataFrames for the output slows the first time display quite a bit (can be minutes)