### PR TITLE
Reduce allocations in `load_domain()`

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -97,14 +97,18 @@ function site_distances(site_data::DataFrame)::Tuple{Matrix{Float64},Float64}
     longitudes = first.(site_centroids)
     latitudes = last.(site_centroids)
 
-    nsites = size(site_data)[1]
-    dist = zeros(nsites, nsites)
-    @inbounds for jj = 1:nsites
-        @inbounds for ii = 1:nsites
-            dist[ii, jj] = haversine([longitudes[ii], latitudes[ii]], [longitudes[jj], latitudes[jj]])
+    nsites = size(site_data, 1)
+    dist = fill(NaN, nsites, nsites)
+    for jj in axes(dist, 2)
+        for ii in axes(dist, 1)
+            if ii == jj
+                continue
+            end
+
+            @inbounds dist[ii, jj] = haversine((longitudes[ii], latitudes[ii]), (longitudes[jj], latitudes[jj]))
         end
     end
-    dist[diagind(dist)] .= NaN
+
     median_site_dist = median(dist[.!isnan.(dist)])
     return dist, median_site_dist
 end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -224,20 +224,23 @@ function load_domain(path::String, rcp::String)::Domain
     dpkg_version = dpkg_details["version"]
 
     # Handle compatibility
-    this_version = parse(VersionNumber, dpkg_version)
+    this_version::VersionNumber = parse(VersionNumber, dpkg_version)
     if this_version >= v"0.2.1"
         # Extract the time frame represented in this data package
-        timeframe = dpkg_details["simulation_metadata"]["timeframe"]
+        md_timeframe::Tuple{Int64,Int64} = Tuple(dpkg_details["simulation_metadata"]["timeframe"])
     else
         # Default to 2025-2099
-        timeframe = (2025, 2099)
+        md_timeframe = (2025, 2099)
     end
 
-    if length(timeframe) == 2
-        @assert timeframe[1] < timeframe[2] "Start date/year specified in data package must be < end date/year"
+    if length(md_timeframe) == 2
+        @assert md_timeframe[1] < md_timeframe[2] "Start date/year specified in data package must be < end date/year"
         # If only two elements, assume a range is specified.
         # Collate the time steps as a full list if necessary
-        timeframe = collect(timeframe[1]:timeframe[2])
+        timeframe::Vector{Int64} = collect(md_timeframe[1]:md_timeframe[2])
+    else
+        # Otherwise assume entry specifies yearly timesteps
+        timeframe = parse.(Int64, md_timeframe)
     end
 
     conn_path::String = joinpath(path, "connectivity/")
@@ -246,13 +249,8 @@ function load_domain(path::String, rcp::String)::Domain
     site_path::String = joinpath(site_data, "$(domain_name).gpkg")
     init_coral_cov::String = joinpath(site_data, "coral_cover.nc")
 
-    if !isempty(rcp)
-        dhw::String = joinpath(path, "DHWs", "dhwRCP$(rcp).nc")
-        wave::String = joinpath(path, "waves", "wave_RCP$(rcp).nc")
-    else
-        dhw = ""
-        wave = ""
-    end
+    dhw::String = !isempty(rcp) ? joinpath(path, "DHWs", "dhwRCP$(rcp).nc") : ""
+    wave::String = !isempty(rcp) ? joinpath(path, "waves", "wave_RCP$(rcp).nc") : ""
 
     return Domain(
         domain_name,

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -11,7 +11,7 @@ Checks for version compatibility.
 """
 function _check_compat(dpkg_details::Dict{String,Any})::Nothing
     if haskey(dpkg_details, "version") || haskey(dpkg_details, "dpkg_version")
-        dpkg_version = dpkg_details["version"]
+        dpkg_version::String = dpkg_details["version"]
         if dpkg_version ∉ COMPAT_DPKG
             error("Incompatible Domain data package. Detected $(dpkg_version), but only support one of $(COMPAT_DPKG)")
         end

--- a/src/sites/connectivity.jl
+++ b/src/sites/connectivity.jl
@@ -33,47 +33,45 @@ NamedTuple:
 function site_connectivity(file_loc::String, unique_site_ids::Vector{String};
     con_cutoff::Float64=1e-6, agg_func::Function=mean, swap::Bool=false)::NamedTuple
 
-    local extracted_TP = []
+    local extracted_TP::Matrix{Float64}
     if isdir(file_loc)
-        con_file1 = nothing
-        con_files::Vector{String} = String[]
-        for (root, _, files) in walkdir(file_loc)
-            append!(con_files, map((x) -> joinpath(root, x), files))
-            conn_data = [
-                # We skip the first column (with drop=[1]) as this is the source site index column
-                Matrix(CSV.read(fn, DataFrame, comment="#", missingstring=["NA"], transpose=swap, types=Float64, drop=[1]))
-                for fn in con_files
+        # Get connectivity years available in data store
+        years::Vector{String} = getindex(first(walkdir(file_loc)), 2)
+        year_conn_fns = NamedTuple{Tuple(Symbol.(years))}(
+            [[joinpath.(first(fl), last(fl))
+              for fl in walkdir(joinpath(file_loc, yr))][1]
+             for yr in years]
+        )
+
+        con_files::Vector{String} = vcat([x for x in values(year_conn_fns)]...)
+        con_file1::DataFrame = CSV.read(con_files[1], DataFrame, comment="#", missingstring="NA", transpose=swap, types=Float64, drop=[1])
+
+        # Pre-allocate store
+        tmp_store::Vector{Matrix{Float64}} = Vector{Matrix{Float64}}(undef, length(years))
+
+        # Get average connectivity for each represented year
+        for (i, yr) in enumerate(Symbol.(years))
+            conn_data::Vector{Matrix} = [
+                Matrix(CSV.read(fn, DataFrame, comment="#", missingstring="NA", transpose=swap, types=Float64, drop=[1]))
+                for fn in year_conn_fns[yr]
             ]
 
-            if length(conn_data) > 0
-                # Add mean TP for a single year
-                push!(extracted_TP, agg_func(conn_data))
-            end
-
-            if isnothing(con_file1) && length(con_files) > 0
-                # Keep first file
-                # We skip the first column (with drop=[1]) as this is the source site index column
-                con_file1 = CSV.read(con_files[1], DataFrame, comment="#", missingstring=["NA"], transpose=swap, types=Float64, drop=[1])
-            end
-
-            con_files = String[]
+            tmp_store[i] = agg_func(conn_data)
         end
 
         # Mean of across all years
-        extracted_TP = agg_func(extracted_TP)
+        extracted_TP = agg_func(tmp_store)
 
     elseif isfile(file_loc)
         con_files = String[file_loc]
-
-        con_file1 = CSV.read(con_files[1], DataFrame, comment="#", missingstring=["NA"], transpose=swap, types=Float64, drop=[1])
-        extracted_TP = Matrix(file1)
+        con_file1 = CSV.read(con_files[1], DataFrame, comment="#", missingstring="NA", transpose=swap, types=Float64, drop=[1])
+        extracted_TP = Matrix(con_file1)
     else
         error("Could not find location: $(file_loc)")
     end
 
     # Get site ids from first file
-    con_site_ids::Vector{String} = names(con_file1)
-    con_site_ids = [x[1] for x in split.(con_site_ids, "_v"; limit=2)]
+    con_site_ids::Vector{String} = [x[1] for x in split.(names(con_file1), "_v"; limit=2)]
 
     # Get IDs missing in con_site_ids
     invalid_ids::Vector{String} = setdiff(con_site_ids, unique_site_ids)
@@ -82,11 +80,11 @@ function site_connectivity(file_loc::String, unique_site_ids::Vector{String};
     append!(invalid_ids, setdiff(unique_site_ids, con_site_ids))
 
     # Identify IDs that do not appear in `invalid_ids`
-    valid_ids = [x ∉ invalid_ids ? x : missing for x in unique_site_ids]
+    valid_ids::Vector{String} = [x ∉ invalid_ids ? x : missing for x in unique_site_ids]
     valid_idx = .!ismissing.(valid_ids)
 
     # Align IDs
-    unique_site_ids = coalesce(unique_site_ids[valid_idx])
+    unique_site_ids::Vector{String} = coalesce(unique_site_ids[valid_idx])
     site_order = [findfirst(c_id .== con_site_ids) for c_id in unique_site_ids]
 
     if length(invalid_ids) > 0


### PR DESCRIPTION
Initial call to `load_domain()` is very slow (~30secs), largely due to the initial call to the CSV.jl package (and the number of connectivity files being read in).

This PR adjusts the data loading process so fewer allocations are made, and adds additional type information to improve readability, to reduce the initial precompilation load.