### PR TITLE
Adjust samples when use of distance thresholds is turned off

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -64,9 +64,9 @@ Base.@kwdef struct Intervention{N,P,N2,P2} <: EcoModel
         name="Assisted Adaptation", description="Assisted adaptation in terms of DHW resistance.")
     n_adapt::N2 = Param(0.0, ptype="real", bounds=(0.0, 0.05), dists="unif",
         name="Natural Adaptation", description="Natural adaptation rate (yearly increase).")
-    seed_years::P2 = Param(10, ptype="integer", bounds=(5, 74 + 1, 5 / 69), dists="triang",
+    seed_years::P2 = Param(10, ptype="integer", bounds=(5, 74 + 1, 5 / 70), dists="triang",
         name="Years to Seed", description="Number of years to seed for.")
-    shade_years::P2 = Param(10, ptype="integer", bounds=(5, 74 + 1, 5 / 69), dists="triang",
+    shade_years::P2 = Param(10, ptype="integer", bounds=(5, 74 + 1, 5 / 70), dists="triang",
         name="Years to Shade", description="Number of years to shade for.")
     seed_freq::N = Param(5, ptype="integer", bounds=(0, 5 + 1), dists="unif",
         name="Seeding Frequency", description="Frequency of seeding site selection (0 is set and forget).")

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -49,7 +49,8 @@ end
 
 Base.@kwdef struct Intervention{N,P,N2,P2} <: EcoModel
     # Intervention Parameters
-    # Integer values have a +1 offset to allow for discrete value mapping (see `set() method`)
+    # Integer values have a +1 offset to allow for discrete value mapping
+    # (see `set()` and `map_to_discrete()` methods)
     guided::N = Param(0, ptype="integer", bounds=(-1, 3 + 1), dists="unif",
         name="Guided", description="Choice of MCDA approach.")
     seed_TA::N = Param(0, ptype="integer", bounds=(0, 1000000 + 1), dists="unif",

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -28,13 +28,16 @@ function adjust_samples(d::Domain, spec::DataFrame, df::DataFrame)::DataFrame
     df[df.guided.==-1.0, non_depth] .= 0.0
 
     # If no seeding is to occur, set related variables to 0
-    not_seeded = (df.seed_TA .== 0) .& (df.seed_CA .== 0.0)
+    not_seeded = (df.seed_TA .== 0.0) .& (df.seed_CA .== 0.0)
     df[not_seeded, contains.(names(df), "seed_")] .= 0.0
     df[not_seeded, :a_adapt] .= 0.0
 
     # Same for fogging/shading
     not_fogged = (df.fogging .== 0) .& (df.SRM .== 0)
     df[not_fogged, contains.(names(df), "shade_")] .= 0.0
+
+    # If use of distance threshold is off, set `dist_thresh` to 0.0
+    df[df.use_dist.==0, :dist_thresh] .= 0.0
 
     return df
 end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -28,7 +28,7 @@ function adjust_samples(d::Domain, spec::DataFrame, df::DataFrame)::DataFrame
     df[df.guided.==-1.0, non_depth] .= 0.0
 
     # If no seeding is to occur, set related variables to 0
-    not_seeded = (df.seed_TA .== 0.0) .& (df.seed_CA .== 0.0)
+    not_seeded = (df.seed_TA .== 0) .& (df.seed_CA .== 0)
     df[not_seeded, contains.(names(df), "seed_")] .= 0.0
     df[not_seeded, :a_adapt] .= 0.0
 


### PR DESCRIPTION
Something I missed when reviewing #290 - generated samples have to be adjusted such that `dist_thresh` is set to 0 when `use_dist` is set to 0.