### PR TITLE
Adds sampler which can sample only parameters needed for site selection

### DIFF
--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -78,7 +78,17 @@ function process_inputs!(d::Domain, df::DataFrame)::Nothing
 
     return nothing
 end
+function process_inputs!(df::DataFrame)::Nothing
+    bnds = df[:, :full_bounds]
+    p_types = df[:, :ptype]
+    @inbounds for (i, dt) in enumerate(p_types)
+        if dt == "integer"
+            df[!, i] .= map_to_discrete.(df[!, i], bnds[i][2])
+        end
+    end
 
+    return nothing
+end
 
 function load_mat_data(data_fn::String, attr::String, site_data::DataFrame)::NamedDimsArray{Float32}
     data = matread(data_fn)

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -78,9 +78,9 @@ function process_inputs!(d::Domain, df::DataFrame)::Nothing
 
     return nothing
 end
-function process_inputs!(df::DataFrame)::Nothing
-    bnds = df[:, :full_bounds]
-    p_types = df[:, :ptype]
+function process_inputs!(spec::DataFrame, df::DataFrame)::Nothing
+    bnds = spec[:, :full_bounds]
+    p_types = spec[:, :ptype]
     @inbounds for (i, dt) in enumerate(p_types)
         if dt == "integer"
             df[!, i] .= map_to_discrete.(df[!, i], bnds[i][2])

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -202,6 +202,19 @@ function sample_cf(d::Domain, n::Int, sampler=SobolSample())::DataFrame
     return adjust_cf_samples(d, df)
 end
 
+"""
+    adjust_guided_bounds(guided_spec::DataFrame, lower::Int64)::DataFrame
+    
+Adjust lower bound of guided parameter spec to alter sampling range.
+"""
+function adjust_guided_bounds(guided_spec::DataFrame, lower::Int64)::DataFrame
+    guided_col = guided_spec.fieldname .== :guided
+    g_upper = guided_spec[:, :upper_bound][1]
+    guided_spec[guided_col, :val] .= lower
+    guided_spec[guided_col, :lower_bound] .= lower
+    guided_spec[guided_col, :full_bounds] .= [(lower, g_upper)]
+    return guided_spec
+end
 
 """
     sample_guided(d::Domain, n::Int, sampler=SobolSample())::DataFrame

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -181,6 +181,7 @@ function sample_site_selection(d::Domain, n::Int, sampler=SobolSample())::DataFr
     env_sample = sample(env_spec, n, sampler)
 
     int_spec = component_params(d.model, Intervention)
+    insertcols!(int_spec, :val, :bounds => copy([int_spec[:, :full_bounds]...]))
     guided_spec = adjust_guided_bounds(int_spec[int_spec[:, :fieldname].==:guided, :], 1)
     guided_sample = sample(guided_spec, n, sampler)
 
@@ -212,6 +213,7 @@ function adjust_guided_bounds(guided_spec::DataFrame, lower::Int64)::DataFrame
     g_upper = guided_spec[:, :upper_bound][1]
     guided_spec[guided_col, :val] .= lower
     guided_spec[guided_col, :lower_bound] .= lower
+    guided_spec[guided_col, :bounds] .= [(lower, g_upper)]
     guided_spec[guided_col, :full_bounds] .= [(lower, g_upper)]
     return guided_spec
 end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -236,7 +236,7 @@ function sample_guided(d::Domain, n::Int, sampler=SobolSample())::DataFrame
     samples = adjust_samples(d, samples)
 
     # Note: updating with spec_df does not work.
-    mod_df = adjust_guided_spec(mod_df, 0)
+    mod_df = adjust_guided_bounds(mod_df, 0)
 
     ADRIA.update!(d.model, mod_df)
 

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -34,13 +34,13 @@ end
 
 @testset "Guided site selection without ADRIA ecological model" begin
     dom = ADRIA.load_domain(joinpath(@__DIR__, "..", "examples", "Example_domain"), 45)
-    criteria_df = ADRIA.sample(dom, 5)  # get scenario dataframe
+    criteria_df = ADRIA.sample_site_selection(dom, 5)  # get scenario dataframe
 
     area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
     ts = 5  # time step to perform site selection at
 
     sum_cover = 0.1 .* ones(5, size(dom.site_data, 1))
-    ranks = ADRIA.run_site_selection(dom, criteria_df[criteria_df.guided.>0, :], sum_cover, area_to_seed, ts)
+    ranks = ADRIA.run_site_selection(dom, criteria_df, sum_cover, area_to_seed, ts)
 
     @test size(ranks, 1) == sum(criteria_df.guided .> 0) || "Specified number of scenarios was not carried out."
 


### PR DESCRIPTION
- changes to sample() to allow specific model components to be sampled
- addition of sample_site_selection, which allows sampling of only parameters needed for site selection.
- Addresses issue #296