### PR TITLE
Correct issue with size of NamedDims array for storing ranks in `run_site_selection()`

### DIFF
--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -7,11 +7,12 @@ using DataFrames
 here = @__DIR__
 dom = ADRIA.load_domain(joinpath(here, "Example_domain"))
 
-criteria_df = ADRIA.sample(dom, 5) # get scenario dataframe
+criteria_df = ADRIA.sample(dom, 8) # get scenario dataframe
 
 area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
 ts = 5  # time step to perform site selection at
 
 # initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites))
-sum_cover = fill(0.1, nrow(criteria_df), nrow(dom.site_data))
-ranks = run_site_selection(dom, criteria_df[criteria_df.guided.>0, :], sum_cover[criteria_df.guided.>0, :], area_to_seed, ts)
+sum_cover = repeat(sum(dom.init_coral_cover, dims=1), size(criteria_df, 1))
+
+ranks = run_site_selection(dom, criteria_df, sum_cover, area_to_seed, ts)

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -7,7 +7,7 @@ using DataFrames
 here = @__DIR__
 dom = ADRIA.load_domain(joinpath(here, "Example_domain"))
 
-criteria_df = ADRIA.sample(dom, 8) # get scenario dataframe
+criteria_df = ADRIA.sample_site_selection(dom, 8) # get scenario dataframe
 
 area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
 ts = 5  # time step to perform site selection at

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -9,7 +9,7 @@ dom = ADRIA.load_domain(joinpath(here, "Example_domain"))
 
 criteria_df = ADRIA.sample_site_selection(dom, 8) # get scenario dataframe
 
-area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
+area_to_seed = 962.11  # area of seeded corals in m^2
 ts = 5  # time step to perform site selection at
 
 # initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites))

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -794,7 +794,7 @@ function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::Abst
     ranks_store = NamedDimsArray(
         zeros(nrow(criteria), length(domain.site_ids), 3),
         scenarios=1:nrow(criteria),
-        sites=1:length(domain.site_ids),
+        sites=domain.site_ids,
         ranks=["site_id", "seed_rank", "shade_rank"],
     )
 
@@ -818,7 +818,7 @@ function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::Abst
             sum_cover[cover_ind, :, :],
             area_to_seed
         )
-        ranks_store[cover_ind, depth_priority, :] = ranks_temp
+        ranks_store(scenarios=cover_ind, sites=domain.site_ids[depth_criteria]) .= ranks_temp
     end
 
     return ranks_store

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -815,7 +815,7 @@ function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::Abst
             wave_scens[timestep, :, criteria.wave_scenario[cover_ind]],
             dhw_scens[timestep, :, criteria.dhw_scenario[cover_ind]],
             depth_priority,
-            sum_cover[cover_ind, :, :],
+            sum_cover[cover_ind, :],
             area_to_seed
         )
         ranks_store(scenarios=cover_ind, sites=domain.site_ids[depth_criteria]) .= ranks_temp

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -818,7 +818,7 @@ function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::Abst
             sum_cover[cover_ind, :, :],
             area_to_seed
         )
-        ranks_store[cover_ind, 1:size(ranks_temp, 1), :] = ranks_temp
+        ranks_store[cover_ind, depth_priority, :] = ranks_temp
     end
 
     return ranks_store

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -792,9 +792,9 @@ Perform site selection for a given domain for multiple scenarios defined in a da
 """
 function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::AbstractArray, area_to_seed::Float64, timestep::Int64)
     ranks_store = NamedDimsArray(
-        zeros(nrow(criteria), domain.sim_constants.n_site_int, 3),
+        zeros(nrow(criteria), length(domain.site_ids), 3),
         scenarios=1:nrow(criteria),
-        sites=1:domain.sim_constants.n_site_int,
+        sites=1:length(domain.site_ids),
         ranks=["site_id", "seed_rank", "shade_rank"],
     )
 

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -807,7 +807,7 @@ function run_site_selection(domain::Domain, criteria::DataFrame, sum_cover::Abst
 
     for (cover_ind, scen_criteria) in enumerate(eachrow(criteria))
         depth_criteria = (site_data.depth_med .<= scen_criteria.max_depth) .& (site_data.depth_med .>= scen_criteria.depth_min)
-        depth_priority = (1:nrow(site_data))[depth_criteria]
+        depth_priority = findall(depth_criteria)
 
         ranks_temp = site_selection(
             domain,

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -812,8 +812,8 @@ function run_site_selection(domain::Domain, scenarios::DataFrame, sum_cover::Abs
         ranks_temp = site_selection(
             domain,
             scenario_criteria,
-            wave_scens[timestep, :, criteria.wave_scenario[cover_ind]],
-            dhw_scens[timestep, :, criteria.dhw_scenario[cover_ind]],
+            wave_scens[timestep, :, scenarios.wave_scenario[cover_ind]],
+            dhw_scens[timestep, :, scenarios.dhw_scenario[cover_ind]],
             depth_priority,
             sum_cover[cover_ind, :],
             area_to_seed

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -17,7 +17,23 @@ end
 
     # ranks = ADRIA.site_selection(dom, p_tbl, 1, 10, 1)
 end
+@testset "MCDA variable constructor" begin
+    dom = ADRIA.load_domain(EXAMPLE_DOMAIN_PATH, 45)
+    criteria_df = ADRIA.sample_site_selection(dom, 1) # get scenario dataframe
+    site_ids = collect(1:length(dom.site_ids))
+    sum_cover = fill(0.1, nrow(criteria_df), nrow(dom.site_data))
 
+    area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
+    dhw_scens = dom.dhw_scens[1, :, criteria_df.dhw_scenario[1]]
+    wave_scens = dom.wave_scens[1, :, criteria_df.wave_scenario[1]]
+
+    mcda_vars = ADRIA.DMCDA_vars(dom, criteria_df[1, :], site_ids, sum_cover, area_to_seed, wave_scens, dhw_scens)
+    n_sites = length(mcda_vars.site_ids)
+    @test (length(mcda_vars.in_conn) == n_sites) && (length(mcda_vars.out_conn) == n_sites) || "Connectivity input is incorrect size."
+    @test length(mcda_vars.dam_prob) == n_sites || "Wave damage input is incorrect size."
+    @test length(mcda_vars.heat_stress_prob) == n_sites || "Heat stress input is incorrect size."
+    @test length(mcda_vars.sum_cover) == n_sites || "Initial cover input is incorrect size."
+end
 @testset "Unguided site selection" begin
     n_intervention_sites = 5
     prefseedsites = zeros(Int, n_intervention_sites)

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -49,6 +49,7 @@ end
     ranks = ADRIA.run_site_selection(dom, criteria_df, sum_cover, area_to_seed, ts)
 
     @test size(ranks, 1) == sum(criteria_df.guided .> 0) || "Specified number of scenarios was not carried out."
+    @test size(ranks, 2) == length(dom.site_ids) || "Ranks storage is not correct size for this domain."
 
     sel_sites = unique(ranks)
     sel_sites = sel_sites[sel_sites.!=0.0]

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -58,7 +58,7 @@ end
     N = 2^3
     criteria_df = ADRIA.sample_site_selection(dom, N)  # get scenario dataframe
 
-    area_to_seed = 1.5 * 10^-6  # area of seeded corals in km^2
+    area_to_seed = 662.11  # area of seeded corals in m^2
     ts = 5  # time step to perform site selection at
 
     sum_cover = fill(0.1, N, ADRIA.n_locations(dom))


### PR DESCRIPTION
Closes #308, where the storage NamedDimsArray for ranks in `run_site_selection()` was set to n_site_int instead of n_sites (which did not throw an error in tests because the filtered example site set has 5 sites).

Also adds proper indexing for site storage which accounts for filtered sites.