### PR TITLE
Add capability to fix factors in place

### DIFF
--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -288,6 +288,58 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
 end
 
 
+"""
+    fix_factor(d::Domain, factor::Symbol)
+    fix_factor(d::Domain, factor::Symbol, val::Real)
+    fix_factor(d::Domain, factors...)
+
+Fix a factor so it gets ignored for the purpose of constructing samples.
+If no value is provided, the default is used.
+
+Note: Changes are permanent. To reset, either specify the original value(s)
+      or reload the Domain.
+
+# Examples
+```julia
+# Fix `guided` to default value
+fix_factor!(dom, :guided)
+
+# Fix `guided` to specified value
+fix_factor!(dom, :guided, 3)
+
+# Fix specified factors to provided values
+fix_factor!(dom; guided=3, seed_TA=1e6)
+```
+"""
+function fix_factor!(d::Domain, factor::Symbol)::Nothing
+    params = DataFrame(d.model)
+    default_val = params[params.fieldname.==factor, :val]
+    params[params.fieldname.==factor, :lower_bound] .= default_val
+    params[params.fieldname.==factor, :upper_bound] .= default_val
+
+    bnds = params[params.fieldname.==factor, :bounds][1]
+    new_bnds = Tuple(fill(default_val, length(bnds)))
+    params[params.fieldname.==factor, :bounds] .= [new_bnds]
+
+    update!(d, params)
+end
+function fix_factor!(d::Domain, factor::Symbol, val::Real)::Nothing
+    params = DataFrame(d.model)
+    params[params.fieldname.==factor, :val] .= val
+
+    bnds = params[params.fieldname.==factor, :bounds][1]
+    new_bnds = Tuple(fill(val, length(bnds)))
+    params[params.fieldname.==factor, :bounds] .= [new_bnds]
+
+    update!(d, params)
+end
+function fix_factor!(d::Domain; factors...)
+    for (factor, val) in factors
+        fix_factor!(d, factor, val)
+    end
+end
+
+
 _unzip(a) = map(x -> getfield.(a, x), fieldnames(eltype(a)))
 
 


### PR DESCRIPTION
Allow users to easily fix factors in place (i.e., make them constant).

Note: No resetting is offered yet as what it means for a user to "reset" a domain/model is not entirely clear (revert everything including "sim constants"? Revert just the fixed factors?

For now, if the user wants to start fresh they can simply reload the domain.