### PR TITLE
Replace use of area attribute/field with call to function `site_area()` to ensure correct values

### DIFF
--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -109,7 +109,7 @@ end
 function scenario_attributes(domain::Domain, param_df::DataFrame)
     return scenario_attributes(domain.name, domain.RCP, names(param_df), domain.scenario_invoke_time,
         domain.env_layer_md, domain.sim_constants,
-        unique_sites(domain), domain.site_data.area, domain.site_data.k, centroids(domain.site_data))
+        unique_sites(domain), site_area(domain), domain.site_data.k, centroids(domain.site_data))
 end
 
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -27,7 +27,7 @@ function setup_cache(domain::Domain)::NamedTuple
         cov_tmp=zeros(size(init_cov)...),  # Cover for previous timestep
         felt_dhw=zeros(size(init_cov)...),  # Store for felt DHW (DHW after reductions)
         depth_coeff=zeros(n_sites),  # store for depth coefficient
-        site_area=Matrix{Float64}(domain.site_data.area'),  # site areas
+        site_area=Matrix{Float64}(site_area(domain)'),  # site areas
         TP_data=Matrix{Float64}(domain.TP_data),  # transition probabilities
         waves=zeros(length(timesteps(domain)), n_species, n_sites)
     )


### PR DESCRIPTION
`site_area()` may be calculated or stored differently based on model or approach so use the function instead of accessing the attribute/field directly.