### PR TITLE
Address mismatched number of elements under certain conditions

### DIFF
--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -347,7 +347,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
             )
 
             band!(ax,
-                unique(fv_s[findall(!ismissing, outcomes(factors=f_name, CI=:lower))]),
+                fv_s[.!ismissing.(outcomes(factors=f_name, CI=:lower))],
                 collect(skipmissing(outcomes(factors=f_name, CI=:lower))),
                 collect(skipmissing(outcomes(factors=f_name, CI=:upper)))
             )


### PR DESCRIPTION
Previously was taking unique index values to avoid duplicate x-tick labels, but it leads to a mismatched number of elements causing plotting to error.

We'll just live with duplicate value labels along the x-axis for now.