### PR TITLE
Remove Copras method due to erroring

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -33,7 +33,6 @@ include("ecosystem/corals/spec.jl")
 include("ecosystem/const_params.jl")
 
 include("Domain.jl")
-include("ExtInterface/ADRIA/Domain.jl")
 
 include("io/inputs.jl")
 
@@ -55,6 +54,7 @@ include("optimization.jl")
 include("analysis/analysis.jl")
 include("analysis/sensitivity.jl")
 
+include("ExtInterface/ADRIA/Domain.jl")
 include("ExtInterface/ReefMod/Domain.jl")
 include("ExtInterface/ReefMod/scenarios.jl")
 

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -45,7 +45,7 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Integer values have a +1 offset to allow for discrete value mapping
     # (see `set()` and `map_to_discrete()` methods)
     # Bounds are defined as floats to maintain type stability
-    guided::N = Param(0, ptype="integer", bounds=(-1.0, 20.0 + 1.0), dists="unif",
+    guided::N = Param(0, ptype="integer", bounds=(-1.0, length(methods_mcda) + 1.0), dists="unif",
         name="Guided", description="Choice of MCDA approach.")
     seed_TA::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
         name="Seeded Tabular Acropora", description="Number of enhanced Tabular Acropora to seed per deployment year.")

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -45,7 +45,7 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Integer values have a +1 offset to allow for discrete value mapping
     # (see `set()` and `map_to_discrete()` methods)
     # Bounds are defined as floats to maintain type stability
-    guided::N = Param(0, ptype="integer", bounds=(-1.0, 21.0 + 1.0), dists="unif",
+    guided::N = Param(0, ptype="integer", bounds=(-1.0, 20.0 + 1.0), dists="unif",
         name="Guided", description="Choice of MCDA approach.")
     seed_TA::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
         name="Seeded Tabular Acropora", description="Number of enhanced Tabular Acropora to seed per deployment year.")

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -8,6 +8,25 @@ using InteractiveUtils: subtypes
 using ADRIA: order_ranking, adria_vikor, adria_topsis
 
 
+jmcdm_ignore = [
+    JMcDM.CRITIC.CriticMethod,
+    JMcDM.COPRAS.CoprasMethod,
+    JMcDM.MOOSRA.MoosraMethod,
+    JMcDM.MEREC.MERECMethod,
+    JMcDM.ELECTRE.ElectreMethod,
+    JMcDM.PROMETHEE.PrometheeMethod,
+    JMcDM.Topsis.TopsisMethod,
+    JMcDM.VIKOR.VikorMethod
+]
+
+const jmcdm_methods = subtypes(MCDMMethod)
+const methods_mcda = [
+    order_ranking,
+    adria_vikor,
+    adria_topsis,
+    setdiff(jmcdm_methods, jmcdm_ignore)...
+]
+
 struct DMCDA_vars  # {V, I, F, M} where V <: Vector
     site_ids  # ::V
     n_site_int  # ::I
@@ -41,23 +60,6 @@ struct DMCDA_vars  # {V, I, F, M} where V <: Vector
     wt_zones_shade # ::F
 end
 
-const jmcdm_methods = subtypes(MCDMMethod)
-
-jmcdm_ignore = [
-    JMcDM.CRITIC.CriticMethod,
-    JMcDM.COPRAS.CoprasMethod,
-    JMcDM.MOOSRA.MoosraMethod,
-    JMcDM.MEREC.MERECMethod,
-    JMcDM.ELECTRE.ElectreMethod,
-    JMcDM.PROMETHEE.PrometheeMethod
-]
-
-const methods_mcda = [
-    order_ranking,
-    adria_vikor,
-    adria_topsis,
-    setdiff(jmcdm_methods, jmcdm_ignore)...
-]
 
 """
     DMCDA_vars(domain::Domain, criteria::NamedDimsArray,

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -226,7 +226,7 @@ end
 function retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Type{<:MCDMMethod})
     fns = fill(maximum, length(weights))
     results = mcdm(MCDMSetting(S, weights, fns), mcda_func())
-    maximize = results.bestIndex == findall(results.scores .== maximum(results.scores))[1]
+    maximize = results.bestIndex == argmax(results.scores)
 
     return retrieve_ranks(S, site_ids, results.scores, maximize)
 end

--- a/src/sites/dMCDA.jl
+++ b/src/sites/dMCDA.jl
@@ -45,6 +45,7 @@ const jmcdm_methods = subtypes(MCDMMethod)
 
 jmcdm_ignore = [
     JMcDM.CRITIC.CriticMethod,
+    JMcDM.COPRAS.CoprasMethod,
     JMcDM.MOOSRA.MoosraMethod,
     JMcDM.MEREC.MERECMethod,
     JMcDM.ELECTRE.ElectreMethod,


### PR DESCRIPTION
Closes #357

Copras method was causing issues due to giving all NaNs for the criteria scores, so that rankings were meaningless. On further research it seems the Copras method is a weighted linear combination of the score for criteria to be maximised divided by the maximum criteria score and score for criteria to be minimised divided by minimum criteria score. It seems that maybe because ADRIA only has maximising criteria this was giving NaN scores (all other methods were found to not error with the same decision matrix and the error occured for any decision matrix with the Copras method). To fix this issue, Copras is removed from the available set of methods in this PR.

All other methods were tested for their outputs  to verify that they should not error (given reasonable decision matrix and weightings) and compared to the JMcDM docs.