### PR TITLE
Fix: Metric errors when applied to a single simulation

### DIFF
--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -328,7 +328,8 @@ end
 Extract parameters for a specific model component from exported model specification.
 """
 function component_params(rs::ResultSet, component::T)::DataFrame where {T}
-    return spec[rs.model_spec.component.==string(component), :]
+    spec = rs.model_spec
+    return spec[spec.component.==string(component), :]
 end
 function component_params(rs::ResultSet, components::Vector{T})::DataFrame where {T}
     spec = rs.model_spec

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -336,7 +336,16 @@ function fix_factor!(d::Domain, factor::Symbol, val::Real)::Nothing
 end
 function fix_factor!(d::Domain; factors...)
     for (factor, val) in factors
-        fix_factor!(d, factor, val)
+        try
+            fix_factor!(d, factor, val)
+        catch err
+            if !(err isa MethodError)
+                rethrow(err)
+            end
+
+            # Try setting value as an integer
+            fix_factor!(d, factor, Int64(val))
+        end
     end
 end
 

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -12,6 +12,9 @@ TODO: Produce summary stats. Currently returns just the mean.
 
 Calculate the cluster-wide total absolute coral cover for each scenario.
 """
+function _scenario_total_cover(X::AbstractArray; kwargs...)
+    return dropdims(sum(slice_results(X; kwargs...), dims=:sites), dims=:sites)
+end
 function _scenario_total_cover(rs::ResultSet; kwargs...)
     return dropdims(sum(slice_results(total_absolute_cover(rs); kwargs...), dims=:sites), dims=:sites)
 end


### PR DESCRIPTION
Errors get thrown when collecting metrics on a single simulation, as when running a set of scenarios for robustness analysis.