### PR TITLE
Refactor run_scenarios to improve when running multiple rcps

### DIFF
--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -197,7 +197,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Collect defined RCPs
     rcps = string.(unique(scen_spec, "RCP")[!, "RCP"])
-    log_location::String = result_location(domain, rcps)
+    log_location::String = _result_location(domain, rcps)
 
     z_store = DirectoryStore(log_location)
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -264,7 +264,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             fill_value=nothing, fill_as_missing=false,
             path=joinpath(z_store.folder, RESULTS, string(m_name)), chunks=(result_dims[1:end-1]..., 1),
             attrs=dim_struct,
-            compressor=compressor)
+            compressor=COMPRESSOR)
         for m_name in met_names
     ]
 
@@ -277,7 +277,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             attrs=Dict(
                 :structure => string.(ADRIA.metrics.relative_taxa_cover.dims)
             ),
-            compressor=compressor))
+            compressor=COMPRESSOR))
     push!(met_names, :relative_taxa_cover)
 
     # dhw and wave zarrays

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -165,7 +165,10 @@ Sets up an on-disk result store.
 │   ├───seed
 │   └───shade
 ├───results
-│   ├───relative_cover
+|   ├───juvenile_indicator
+|   ├───relative_juveniles
+│   ├───relative_taxa_cover
+│   ├───total_absolute_cover
 │   ├───relative_shelter_volume
 │   └───absolute_shelter_volume
 ├───site_data

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -222,11 +222,12 @@ function setup_result_store!(domain::Domain, param_df::DataFrame)::Tuple
         GDF.write(geo_fn, domain.site_data; geom_columns=(:geom,), driver="geojson")
     end
 
-    inputs = zcreate(Float64, input_dims...; fill_value=-9999.0, fill_as_missing=false, path=input_loc, chunks=input_dims, attrs=attrs)
-
     # Store copy of model specification as CSV
     mkdir(joinpath(log_location, "model_spec"))
     model_spec(domain, joinpath(log_location, "model_spec", "model_spec.csv"))
+
+    # Create store for scenario spec
+    inputs = zcreate(Float64, input_dims...; fill_value=-9999.0, fill_as_missing=false, path=input_loc, chunks=input_dims, attrs=attrs)
 
     # Store post-processed table of input parameters.
     # +1 skips the RCP column

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -1,3 +1,6 @@
+const COMPRESSOR = Zarr.BloscCompressor(cname="zstd", clevel=2, shuffle=true)
+
+
 function get_geometry(df::DataFrame)
     if columnindex(df, :geometry) > 0
         return df.geometry
@@ -251,8 +254,6 @@ function setup_result_store!(domain::Domain, param_df::DataFrame)::Tuple
         return (dl...,)
     end
 
-    compressor = Zarr.BloscCompressor(cname="zstd", clevel=2, shuffle=true)
-
     met_names = [:total_absolute_cover, :relative_shelter_volume,
         :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator]
 
@@ -296,7 +297,6 @@ function setup_result_store!(domain::Domain, param_df::DataFrame)::Tuple
     return domain, (; zip((met_names..., :site_ranks, :seed_log, :fog_log, :shade_log,), stores)...)
 end
 
-const COMPRESSOR = Zarr.BloscCompressor(cname="zstd", clevel=2, shuffle=true)
 
 """
     setup_dhw_store(domain::Domain, rcps::Array{String})

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -330,7 +330,6 @@ end
 """
     load_results(result_loc::String)::ResultSet
     load_results(domain::Domain)::ResultSet
-    load_results(domain::Domain, rcps::Array{String})::ResultSet
 
 Create interface to a given Zarr result set.
 """
@@ -435,19 +434,21 @@ end
 function load_results(domain::Domain)::ResultSet
     return load_results(result_location(domain))
 end
-function load_results(domain::Domain, rcps::Array{String})::ResultSet
-    return load_results(result_location(domain, rcps))
-end
 
 """
     result_location(d::Domain)::String
-    result_location(d::Domain, rcps::Array{String})::String
 
 Generate path to the data store of results for the given Domain.
 """
 function result_location(d::Domain)::String
     return joinpath(ENV["ADRIA_OUTPUT_DIR"], "$(d.name)__RCPs$(d.RCP)__$(d.scenario_invoke_time)")
 end
-function result_location(d::Domain, rcps::Array{String})::String
+
+"""
+    _result_location(d::Domain, rcps::Vector{String})::String
+
+Generate path to the data store of results for the given Domain and RCPs names.
+"""
+function _result_location(d::Domain, rcps::Vector{String})::String
     return joinpath(ENV["ADRIA_OUTPUT_DIR"], "$(d.name)__RCPs_$(join(rcps, "_"))__$(d.scenario_invoke_time)")
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -37,9 +37,8 @@ end
 
 
 """
-    run_scenarios(param_df::DataFrame, domain::Domain; remove_workers=true)
-    run_scenarios(param_df::DataFrame, domain::Domain, rcp::String; remove_workers=true)
-    run_scenarios(param_df::DataFrame, domain::Domain, rcp::Array{String}; remove_workers=true)
+    run_scenarios(param_df::DataFrame, domain::Domain, RCP::String; show_progress=true, remove_workers=true)
+    run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String}; show_progress=true, remove_workers=true)
 
 Run scenarios defined by the parameter table storing results to disk.
 Scenarios are run in parallel where the number of scenarios > 256.
@@ -54,104 +53,32 @@ Scenarios are run in parallel where the number of scenarios > 256.
 ...
 julia> rs_45 = ADRIA.run_scenarios(p_df, dom, "45")
 julia> rs_45_60 = ADRIA.run_scenarios(p_df, dom, ["45", "60"])
-julia> rs_all = ADRIA.run_scenarios(p_df, dom)
 ```
 
 # Arguments
 - param_df : DataFrame of scenarios to run
 - domain : Domain, to run scenarios with
-- rcp : ID of RCP(s) to run scenarios under.
-- remove_workers : if running in parallel, removes workers after completion
+- RCP : ID or list of of RCP(s) to run scenarios under.
+- show_progress : Display progress
+- remove_workers : If running in parallel, removes workers after completion
 
 # Returns
 ResultSet
 """
-function run_scenarios(param_df::DataFrame, domain::Domain; remove_workers=true)::ResultSet
-    # Identify available data
-    avail_data::Vector{String} = readdir(joinpath(domain.env_layer_md.dpkg_path, "DHWs"))
-    RCP_ids = replace.(avail_data, "dhwRCP" => "", ".nc" => "")
-
-    @info "Running scenarios for RCPs: $(RCP_ids)"
-    return run_scenarios(param_df, domain, RCP_ids::Array{String}; remove_workers=remove_workers)
-end
 function run_scenarios(param_df::DataFrame, domain::Domain, RCP::String; show_progress=true, remove_workers=true)::ResultSet
-    setup()
-    parallel = (nrow(param_df) > 128) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
-    if parallel
-        _setup_workers()
-        sleep(2)  # wait a bit while workers spin-up
-        @eval @everywhere using ADRIA
-    end
-
-    domain = switch_RCPs!(domain, RCP)
-    domain, data_store = ADRIA.setup_result_store!(domain, param_df)
-
-    cache = setup_cache(domain)
-    run_msg = "Running $(nrow(param_df)) scenarios for RCP $RCP"
-
-    # Convert to named matrix for faster iteration
-    scen_mat = NamedDimsArray(Matrix(param_df); scenarios=1:nrow(param_df), factors=names(param_df))
-
-    # Batch run scenarios
-    func = (dfx) -> run_scenario(dfx..., domain, data_store, cache)
-    if parallel
-        if show_progress
-            @showprogress run_msg 4 pmap(func, enumerate(eachrow(scen_mat)))
-        else
-            pmap(func, enumerate(eachrow(scen_mat)))
-        end
-
-        if remove_workers
-            _remove_workers()
-        end
-    else
-        if show_progress
-            @showprogress run_msg 4 map(func, enumerate(eachrow(scen_mat)))
-        else
-            map(func, enumerate(eachrow(scen_mat)))
-        end
-    end
-
-    return load_results(domain)
+    return run_scenarios(param_df, domain, [RCP]; show_progress, remove_workers)
 end
-function run_scenarios(param_df::DataFrame, domain::Domain, RCP_ids::Array{String}; show_progress=true, remove_workers=true)::ResultSet
-    @info "Running $(nrow(param_df)) scenarios across $(length(RCP_ids)) RCPs"
-
-    setup()
-    output_dir = ENV["ADRIA_OUTPUT_DIR"]
-
-    result_sets::Vector{ResultSet} = Vector{ResultSet}(undef, length(RCP_ids))
-    for (i, RCP) in enumerate(RCP_ids)
-        tmp_dir = mktempdir(prefix="ADRIA_")
-        ENV["ADRIA_OUTPUT_DIR"] = tmp_dir
-
-        result_sets[i] = run_scenarios(param_df, domain, RCP; show_progress=show_progress, remove_workers=false)
-    end
-
-    if remove_workers
-        _remove_workers()
-    end
-
-    ENV["ADRIA_OUTPUT_DIR"] = output_dir
-
-    rs = combine_results(result_sets...)
-
-    # Remove temporary result dirs
-    for t in result_sets
-        rm(result_location(t); force=true, recursive=true)
-    end
-
-    return rs
-end
-
-function new_run_scenarios(param_df::DataFrame, domain::Domain, rcps::Array{String}; show_progress=true, remove_workers=true)::ResultSet
+function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String}; show_progress=true, remove_workers=true)::ResultSet
     # Initialize ADRIA configuration options
     setup()
+    
+    # Sort RCPs so the dataframe order match the output filepath 
+    RCP = sort(RCP)
 
-    @info "Running $(nrow(param_df)) scenarios over $(length(rcps)) RCPs: $rcps"
+    @info "Running $(nrow(param_df)) scenarios over $(length(RCP)) RCPs: $RCP"
 
     # Cross product between rcps and param_df to have every row of param_df for each rcp
-    rcps_df = DataFrame(RCP=parse.(Int64, rcps))
+    rcps_df = DataFrame(RCP=parse.(Int64, RCP))
     scenarios_df = crossjoin(param_df, rcps_df)
     sort!(scenarios_df, :RCP)
 
@@ -193,7 +120,7 @@ function new_run_scenarios(param_df::DataFrame, domain::Domain, rcps::Array{Stri
     # Define local helper
     func = (dfx) -> run_scenario(dfx..., domain, data_store, cache)
 
-    for rcp in rcps
+    for rcp in RCP
         run_msg = "Running $(nrow(param_df)) scenarios for RCP $rcp"
 
         # Switch RCPs so correct data is loaded

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -180,7 +180,7 @@ function new_run_scenarios(param_df::DataFrame, domain::Domain, rcps::Array{Stri
             @everywhere @eval func = (dfx) -> run_scenario(dfx..., domain, data_store, cache)
         end
 
-        @info "Time taken to spin up workers: $(spinup_time)"
+        @info "Time taken to spin up workers: $(spinup_time) seconds"
 
         # Define number of scenarios to run before returning results to main
         # https://discourse.julialang.org/t/parallelism-understanding-pmap-and-the-batch-size-parameter/15604/2

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -168,7 +168,7 @@ function new_run_scenarios(param_df::DataFrame, domain::Domain, rcps::Array{Stri
     # Setup cache to reuse for each scenario run
     cache = setup_cache(domain)
 
-    parallel = (nrow(param_df) >= 1024) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
+    parallel = (nrow(param_df) >= 4096) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -137,7 +137,7 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
         _remove_workers()
     end
 
-    return load_results(domain, rcps)
+    return load_results(_result_location(domain, RCP))
 end
 
 """

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -63,7 +63,7 @@ end
 
 """Remove workers and free up memory."""
 function _remove_workers()::Nothing
-    if nprocs() > 1
+    if nworkers() > 1
         rmprocs(workers()...)
     end
 


### PR DESCRIPTION
When running  `run_scenarios` passing multiple RCPs as arguments, it was creating one dataset folder for each RCP and then consolidating at the end. Now it only creating one folder, once, and skipping the consolidation step. Close #342.