### PR TITLE
Changes to ode solver and time step for efficiency improvements

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -283,7 +283,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     wave_scen::Matrix{Float64} = Matrix{Float64}(domain.wave_scens[:, :, wave_idx]) ./ maximum(domain.wave_scens[:, :, wave_idx])
 
     tspan::Tuple = (0.0, 1.0)
-    solver::BS3 = BS3()
+    solver::Euler = Euler()
 
     MCDA_approach::Int64 = param_set("guided")
 
@@ -565,7 +565,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         p.X_mb .= tmp .* p.mb    # current cover * background mortality
 
         sol::ODESolution = solve(growth, solver, save_everystep=false, save_start=false,
-            alg_hints=[:nonstiff], abstol=1e-6, reltol=1e-6)  # , adaptive=false, dt=1.0
+            alg_hints=[:nonstiff], abstol=1e-6, reltol=1e-6,dt=0.5)  # , adaptive=false, dt=1.0
         # Using the last step from ODE above, proportionally adjust site coral cover
         # if any are above the maximum possible (i.e., the site `k` value)
         @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_site_area, 0.0, 1.0)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -565,7 +565,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         p.X_mb .= tmp .* p.mb    # current cover * background mortality
 
         sol::ODESolution = solve(growth, solver, save_everystep=false, save_start=false,
-            alg_hints=[:nonstiff], abstol=1e-6, reltol=1e-6,dt=0.5)  # , adaptive=false, dt=1.0
+            alg_hints=[:nonstiff], abstol=1e-6, reltol=1e-6, dt=0.5) 
         # Using the last step from ODE above, proportionally adjust site coral cover
         # if any are above the maximum possible (i.e., the site `k` value)
         @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_site_area, 0.0, 1.0)


### PR DESCRIPTION
The current ode solver is a BS method, which is an adaptive timestep 3rd order RK method. Adaptive timesteps can reduce efficiency in non-stiff ode solutions. Aditionally, higher order solvers are less efficient if there is neglible trade off in accuracy. Due to this fixed timesteps of varying precision with the lower order Euler scheme were investigated.

Timesteps of size 1/10,1/5, 1/3 and 1/2 were investigated with the Euler solver and the timings and RMSE in comparison to the original solver were compared.

Plot of average time for just the ode solver for 100 timesteps with 200 samples:
![time_vs_solver](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/eb033ad8-ee2b-40fc-ac02-fe1e654bc9e1)

Plot of total time for 256 ADRIA scenarios for each solver:

![time_vs_solver_total](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/b2b66a80-bade-4ba8-a667-0dde4dcefaf9)

Plot of RMSE between the original and Euler solvers:

![RMSE_vs_time](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/9a019810-d471-4945-acc3-c35756efd624)
