### PR TITLE
Add `adaptive=false` specification and remove tolerances

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -565,7 +565,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         p.X_mb .= tmp .* p.mb    # current cover * background mortality
 
         sol::ODESolution = solve(growth, solver, save_everystep=false, save_start=false,
-            alg_hints=[:nonstiff], abstol=1e-6, reltol=1e-6, dt=0.5) 
+            alg_hints=[:nonstiff], adaptive=false, dt=0.5) 
         # Using the last step from ODE above, proportionally adjust site coral cover
         # if any are above the maximum possible (i.e., the site `k` value)
         @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_site_area, 0.0, 1.0)


### PR DESCRIPTION
Sorry to do a final PR for this - I forgot to add the 'adaptive=false` to specify a non-adaptive scheme. Also, the tolerances aren't used for non-adaptive schemes so they can be removed.

To confirm, the previous timings and RSMEs were compared for adaptive and non-adaptive schemes, I just forgot to add the flag in the final PR.