### PR TITLE
Remove use of batch sizes when running parallel scenarios

### DIFF
--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -66,7 +66,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::Vector{Float6
     @views cover[seed_sc, seed_locs] .+= scaled_seed
     Yseed[:, seed_locs] .= scaled_seed
 
-    # Calculate w_taxa using vectorized operations
+    # Calculate w_taxa using proportion of area (used as priors for MixtureModel)
     w_taxa::Matrix{Float64} = scaled_seed ./ cover[seed_sc, seed_locs]
 
     # Update critical DHW distribution for deployed size classes

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -97,7 +97,6 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin
             _setup_workers()
-            sleep(2)  # wait a bit while workers spin-up
 
             # load ADRIA on workers and define helper function
             @everywhere @eval using ADRIA

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -104,14 +104,7 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
             @everywhere @eval func = (dfx) -> run_scenario(dfx..., domain, data_store, cache)
         end
 
-        @info "Time taken to spin up workers: $(spinup_time) seconds"
-
-        # Define number of scenarios to run before returning results to main
-        # https://discourse.julialang.org/t/parallelism-understanding-pmap-and-the-batch-size-parameter/15604/2
-        # https://techytok.com/lesson-parallel-computing/
-        b_size = 2
-    else
-        b_size = 1
+        @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
     # Define local helper
@@ -124,9 +117,9 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
         domain = switch_RCPs!(domain, rcp)
         target_rows = findall(scenarios_matrix("RCP") .== parse(Float64, rcp))
         if show_progress
-            @showprogress run_msg 4 pmap(func, zip(target_rows, eachrow(scenarios_matrix[target_rows, :])), batch_size=b_size)
+            @showprogress run_msg 4 pmap(func, zip(target_rows, eachrow(scenarios_matrix[target_rows, :])))
         else
-            pmap(func, zip(target_rows, eachrow(scenarios_matrix[target_rows, :])), batch_size=b_size)
+            pmap(func, zip(target_rows, eachrow(scenarios_matrix[target_rows, :])))
         end
     end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -435,9 +435,9 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     a_adapt[a_adapt.>0.0] .+= corals.dist_mean[a_adapt.>0.0]
 
     ## Extract other parameters
-    LPdhwcoeff = sim_params.LPdhwcoeff # shape parameters relating dhw affecting cover to larval production
-    DHWmaxtot = sim_params.DHWmaxtot # max assumed DHW for all scenarios.  Will be obsolete when we move to new, shared inputs for DHW projections
-    LPDprm2 = sim_params.LPDprm2 # parameter offsetting LPD curve
+    # LPdhwcoeff = sim_params.LPdhwcoeff # shape parameters relating dhw affecting cover to larval production
+    # DHWmaxtot = sim_params.DHWmaxtot # max assumed DHW for all scenarios.  Will be obsolete when we move to new, shared inputs for DHW projections
+    # LPDprm2 = sim_params.LPDprm2 # parameter offsetting LPD curve
 
     # TODO: Better conversion of Ub to wave mortality
     #       Currently scaling significant wave height by its max to non-dimensionalize values

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -434,11 +434,6 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     # Treat as enhancement from mean of "natural" DHW tolerance
     a_adapt[a_adapt.>0.0] .+= corals.dist_mean[a_adapt.>0.0]
 
-    ## Extract other parameters
-    # LPdhwcoeff = sim_params.LPdhwcoeff # shape parameters relating dhw affecting cover to larval production
-    # DHWmaxtot = sim_params.DHWmaxtot # max assumed DHW for all scenarios.  Will be obsolete when we move to new, shared inputs for DHW projections
-    # LPDprm2 = sim_params.LPDprm2 # parameter offsetting LPD curve
-
     # TODO: Better conversion of Ub to wave mortality
     #       Currently scaling significant wave height by its max to non-dimensionalize values
     wave_scen::Matrix{Float64} = Matrix{Float64}(domain.wave_scens[:, :, wave_idx]) ./ maximum(domain.wave_scens[:, :, wave_idx])


### PR DESCRIPTION
Batch sizes seem to lead to issues with values being overwritten with cache matrices when using threads within parallel runs.

This PR also includes some miscellaneous changes (updating comments, removing dead code, etc).