### PR TITLE
Fix excessive memory use (#405)

### DIFF
--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -38,7 +38,7 @@ Modifies arrays in-place.
 - `cover_tmp` : Temporary cache matrix used to hold sum over species. Avoids memory allocations
 - `max_cover` : Maximum possible coral cover for each site
 """
-function proportional_adjustment!(covers::Matrix{T}, cover_tmp::Vector{T}, max_cover::Array{T})::Nothing where {T<:Float64}
+function proportional_adjustment!(covers::Union{SubArray{T},Matrix{T}}, cover_tmp::Vector{T}, max_cover::Array{T})::Nothing where {T<:Float64}
     # Proportionally adjust initial covers
     cover_tmp .= vec(sum(covers, dims=1))
     if any(cover_tmp .> max_cover)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -461,7 +461,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     # TODO: Better conversion of Ub to wave mortality
     #       Currently scaling significant wave height by its max to non-dimensionalize values
     wave_scen::Matrix{Float64} = copy(domain.wave_scens[:, :, wave_idx])
-    wave_scen .= wave_scens ./ maximum(wave_scen)
+    wave_scen .= wave_scen ./ maximum(wave_scen)
 
     # Pre-calculate proportion of survivers from wave stress
     # Sw_t = wave_damage!(cache.waves, wave_scen, corals.wavemort90, n_species)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -460,7 +460,8 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     # TODO: Better conversion of Ub to wave mortality
     #       Currently scaling significant wave height by its max to non-dimensionalize values
-    wave_scen::Matrix{Float64} = Matrix{Float64}(domain.wave_scens[:, :, wave_idx]) ./ maximum(domain.wave_scens[:, :, wave_idx])
+    wave_scen::Matrix{Float64} = copy(domain.wave_scens[:, :, wave_idx])
+    wave_scen .= wave_scens ./ maximum(wave_scen)
 
     # Pre-calculate proportion of survivers from wave stress
     # Sw_t = wave_damage!(cache.waves, wave_scen, corals.wavemort90, n_species)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -277,7 +277,8 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     MCDA_approach::Int64 = param_set("guided")
 
-    # sim constants
+    # Sim constants
+    sim_params = domain.sim_constants
     tf::Int64 = size(dhw_scen, 1)
     n_site_int::Int64 = sim_params.n_site_int
     n_sites::Int64 = domain.coral_growth.n_sites
@@ -393,7 +394,6 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         max_depth::Float64 = param_set("depth_min") + param_set("depth_offset")
         depth_criteria::BitArray{1} = (site_data.depth_med .>= param_set("depth_min")) .& (site_data.depth_med .<= max_depth)
 
-        # TODO: Include this change in MATLAB version as well
         if any(depth_criteria .> 0)
             # If sites can be filtered based on depth, do so.
             depth_priority = depth_priority[depth_criteria]
@@ -404,7 +404,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     end
 
     if is_guided
-        # pre-allocate rankings
+        # Pre-allocate rankings
         rankings = [depth_priority zeros(Int, length(depth_priority)) zeros(Int, length(depth_priority))]
 
         # Prep site selection


### PR DESCRIPTION
Closes #405 

Includes a number of changes to avoid Julia kernel crashing when running a high number of scenarios.

- Only uses `pmap` in workloads that require multiprocessing, otherwises uses `map`
- Does not create a reusable cache structure when using multiple cores (but does for single core workloads)
- Explicit use of `CachingPool()` to avoid re-serialization of data structures to workers (default behavior in upcoming Julia v1.10 release)
- Forces garbage collector (gc) to run if 95% of available memory is in use. Forcing the gc to run too often can increase runtimes and lead to other issues so I've opted to only run this when absolutely needed

In addition to the above, a key change resolving crashes in multi-processing contexts was (circa L 271 in `scenarios.jl`):

```julia
# dhw_scen::Matrix{Float64} = @view domain.dhw_scens[:, :, dhw_idx]

# Remove the use of array `view` and copy the data for the given DHW scenario instead:
dhw_scen::Matrix{Float64} = copy(domain.dhw_scens[:, :, dhw_idx])
```

I don't have a concrete explanation for this other than I suspect `domain` may be shared across workers and so multiple workers attempting to interact with a "big" object type like `Domain` may have led to issues...

@Rosejoycrocker @Zapiano I'm tagging you both in as reviewers for this, but only need approval from one of you. Just be aware of the changes here please.
 
I have successfully run 8,192 scenarios both using a single core (using the `debug=true` option) and multiple cores (i.e., two).

This is not a concrete fix: you should see large amounts of memory use still but at least Julia itself does not crash and the runs complete.