### PR TITLE
Fix workers crashing and leaking memory when running scenarios in parallel

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -105,6 +105,10 @@ end
 
     @compile_workload begin
 
+        # Force precompiling of code that handles distributed infrastructure
+        addprocs(1)
+        @everywhere 1 + 1
+
         f() = begin
             @showprogress 1 for _ in 1:10
             end

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -119,8 +119,12 @@ end
         ADRIA.sample(dom, 16)
         ADRIA.model_spec(dom)
 
+        ENV["ADRIA_DEBUG"] = "false"
+
         p_df = ADRIA.param_table(dom)
         rs1 = ADRIA.run_scenario(p_df[1, :], dom)
+
+        delete!(ENV, "ADRIA_DEBUG")
 
         # ENV["ADRIA_THRESHOLD"] = 1e-6
         # run_scenario(p_df[1, :], dom)

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -191,9 +191,9 @@ function bleaching_mortality!(Y::AbstractArray{Float64,2},
 end
 
 """
-    bleaching_mortality!(Y::AbstractArray{Float64,2}, dhw::AbstractArray{Float64},
-        depth_coeff::Vector{Float64}, dist::Matrix{Distribution},
-        dist_t1::Matrix{Distribution}, prop_mort::AbstractArray{Float64})::Nothing
+    bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
+        depth_coeff::Vector{Float64}, stdev::Vector{Float64}, dist_t_1::Matrix,
+        dist_t::Matrix, prop_mort::SubArray{Float64})::Nothing
 
 Applies bleaching mortality by assuming critical DHW thresholds are normally distributed for
 all non-Juvenile (> 5cm diameter) size classes. Distributions are informed by learnings from
@@ -208,9 +208,9 @@ with a depth-adjusted coefficient (from Baird et al., [4]).
 - `dhw` : DHW for all represented locations
 - `depth_coeff` : Pre-calculated depth coefficient for all locations
 - `stdev` : Standard deviation of DHW tolerance
-- `dist` : Critical DHW threshold distribution for current timestep, for all species and
+- `dist_t_1` : Critical DHW threshold distribution for current timestep, for all species and
            locations
-- `dist_t1` : Critical DHW threshold distribution for next timestep, for all species and
+- `dist_t` : Critical DHW threshold distribution for next timestep, for all species and
               locations
 - `prop_mort` : Cache to store records of bleaching mortality
 
@@ -298,9 +298,7 @@ where \$w\$ are the weights/priors and \$g\$ is the growth rates.
 - `growth_rate` : Growth rates for the given size classes/species
 - `dist_t` : Critical DHW threshold distribution for timestep \$t\$
 - `stdev` : Standard deviations of coral DHW tolerance
-
-# Returns
-Nothing
+- `tmp` : Reused cache for MixtureModels to avoid allocations
 """
 function _shift_distributions!(cover::SubArray, growth_rate::SubArray, dist_t::SubArray, stdev::SubArray)::Nothing
     # Weight distributions based on growth rate and cover
@@ -322,8 +320,8 @@ function _shift_distributions!(cover::SubArray, growth_rate::SubArray, dist_t::S
 end
 
 """
-    adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Matrix{Distribution},
-        dist_t::Matrix{Distribution}, growth_rate::Matrix{Float64}, stdev::Vector{Float64}, h²::Float64)::Nothing
+    adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::SubArray,
+        dist_t::SubArray, growth_rate::SubArray, stdev::SubArray, h²::Float64)::Nothing
 
 Adjust critical DHW thresholds for a given species/size class distribution as mortalities
 affect the distribution over time, and corals mature (moving up size classes).

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -244,8 +244,8 @@ with a depth-adjusted coefficient (from Baird et al., [4]).
    https://doi.org/10.3354/meps12732
 """
 function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
-    depth_coeff::Vector{Float64}, stdev::Vector{Float64}, dist_t_1::Matrix{Distribution},
-    dist_t::Matrix{Distribution}, prop_mort::SubArray{Float64})::Nothing
+    depth_coeff::Vector{Float64}, stdev::Vector{Float64}, dist_t_1::Matrix,
+    dist_t::Matrix, prop_mort::SubArray{Float64})::Nothing
     n_sp_sc, n_locs = size(cover)
 
     # Adjust distributions for all locations, ignoring juveniles
@@ -280,6 +280,8 @@ function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
             cover[sp_sc, loc] = cover[sp_sc, loc] * (1.0 - mort_pop)
         end
     end
+
+    return nothing
 end
 
 """
@@ -335,9 +337,9 @@ affect the distribution over time, and corals mature (moving up size classes).
 - `stdev` : standard deviations of DHW tolerances for each size class
 - `h²` : heritability value
 """
-function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Matrix{Distribution},
-    dist_t::Matrix{Distribution}, growth_rate::Matrix{Float64}, stdev::Vector{Float64}, h²::Float64)::Nothing
-    _, n_sp_sc, n_locs = size(cover)
+function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::SubArray,
+    dist_t::SubArray, growth_rate::SubArray, stdev::SubArray, h²::Float64)::Nothing
+    _, n_sp_sc, _ = size(cover)
 
     step::Int64 = n_groups - 1
     weights::Vector{Float64} = zeros(3)

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -304,7 +304,7 @@ Nothing
 """
 function _shift_distributions!(cover::SubArray, growth_rate::SubArray, dist_t::SubArray, stdev::SubArray)::Nothing
     # Weight distributions based on growth rate and cover
-    for i in 6:-1:3
+    @floop for i in 6:-1:3
         sum(cover[i-1:i]) == 0.0 ? continue : false
         prop_growth = (cover[i-1:i] ./ sum(cover[i-1:i])) .* (growth_rate[i-1:i] ./ sum(growth_rate[i-1:i]))
         x::MixtureModel = MixtureModel([dist_t[i-1], dist_t[i]], prop_growth ./ sum(prop_growth))
@@ -345,7 +345,7 @@ function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Ma
     weights::Vector{Float64} = zeros(3)
 
     # Adjust population distribution
-    for (sc1, loc) in Iterators.product(1:n_groups:n_sp_sc, 1:n_locs)
+    @floop for (sc1, loc) in Iterators.product(1:n_groups:n_sp_sc, 1:n_locs)
         sc4::Int64 = sc1 + 3
         sc6::Int64 = sc1 + step
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -304,10 +304,12 @@ where \$w\$ are the weights/priors and \$g\$ is the growth rates.
 """
 function _shift_distributions!(cover::SubArray, growth_rate::SubArray, dist_t::SubArray, stdev::SubArray)::Nothing
     # Weight distributions based on growth rate and cover
-    @floop for i in 6:-1:3
-        sum(cover[i-1:i]) == 0.0 ? continue : false
-        prop_growth = (cover[i-1:i] ./ sum(cover[i-1:i])) .* (growth_rate[i-1:i] ./ sum(growth_rate[i-1:i]))
-        x::MixtureModel = MixtureModel([dist_t[i-1], dist_t[i]], prop_growth ./ sum(prop_growth))
+    for i in 6:-1:3
+        if sum(cover[i-1:i]) == 0.0
+            continue
+        end
+        prop_growth::Vector{Float64} = @views (cover[i-1:i] ./ sum(cover[i-1:i])) .* (growth_rate[i-1:i] ./ sum(growth_rate[i-1:i]))
+        @views x::MixtureModel = MixtureModel([dist_t[i-1], dist_t[i]], prop_growth ./ sum(prop_growth))
 
         # Use same stdev as target size class to maintain genetic variance
         # pers comm K.B-N (2023-08-09 16:24 AEST)
@@ -342,17 +344,18 @@ function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Su
     _, n_sp_sc, _ = size(cover)
 
     step::Int64 = n_groups - 1
-    weights::Vector{Float64} = zeros(3)
+    weights::MVector{3, Float64} = @MVector(zeros(3))
 
     # Adjust population distribution
-    @floop for (sc1, loc) in Iterators.product(1:n_groups:n_sp_sc, 1:n_locs)
-        sc4::Int64 = sc1 + 3
+    @floop for (sc1, loc) in Iterators.product(1:n_groups:n_sp_sc, axes(cover, 3))
         sc6::Int64 = sc1 + step
 
         # Skip if no cover
         if sum(cover[1, sc1:sc6, loc]) == 0.0
             continue
         end
+
+        sc4::Int64 = sc1 + 3
 
         # Combine distributions using a MixtureModel for all size
         # classes >= 4 (the correct size classes are selected within the
@@ -361,23 +364,23 @@ function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Su
 
         # Reproduction. Size class >= 3 spawn larvae.
         # A new distribution for size class 1 is then determined by taking the
-        # distribution of size classes >= 3 at time t+1 and size class 1 at time t, and
-        # applying the S⋅h² calculation, where:
-        # - $S$ is the distance between the means of the gaussian distributions
-        # - $h$ is heritability (assumed to range from 0.25 to 0.5, nominal value of 0.3)
-        dt_1::Truncated{Normal{Float64},Continuous,Float64,Float64,Float64} = dist_t_1[sc1, loc]
-        if any(cover[2, sc4:sc6, loc] .!= 0.0)
+        # distribution of size classes >= 3 at time t+1 and size class 1 at time t, and 
+        # applying the Breeder's equation (S⋅h²), where:
+        # - $S$ is the distance between the means of the gaussian distributions (selection differential)
+        # - $h²$ is narrow-sense heritability (assumed to range from 0.25 to 0.5, nominal value of 0.3)
+        # - The complement of $h²$ is regarded as the environmental influence
+        if sum(@view(cover[2, sc4:sc6, loc])) > 0.0
             @views weights .= cover[2, sc4:sc6, loc] / sum(cover[2, sc4:sc6, loc])
+            @views d_t::MixtureModel = MixtureModel([dist_t[sc4:sc6, loc]...], weights)
 
-            d_t::MixtureModel = MixtureModel(Truncated{Normal{Float64},Continuous,Float64,Float64,Float64}[dist_t[sc4:sc6, loc]...], weights)
-
-            S::Float64 = mean(d_t) - mean(dt_1)
+            μ_dt_1 = mean(dist_t_1[sc1, loc])
+            S::Float64 = mean(d_t) - μ_dt_1
             if S != 0.0
                 # The new distribution mean for size class 1 is then: prev mean + (S⋅h²)
                 # The standard deviation is assumed to be the same as parents
                 # Note: Nominally, h² := 0.3, but ranges from 0.25 - 0.5
-                μ_t::Float64 = mean(dt_1) + (S * h²)
-                dist_t[sc1, loc] = truncated(Normal(μ_t, stdev[sc1]), minimum(d_t), μ_t + HEAT_UB)
+                μ_t::Float64 = μ_dt_1 + (S * h²)
+                @views dist_t[sc1, loc] = truncated(Normal(μ_t, stdev[sc1]), minimum(d_t), μ_t + HEAT_UB)
             end
         end
     end
@@ -416,6 +419,7 @@ function fecundity_scope!(fec_groups::AbstractArray{T,2}, fec_all::AbstractArray
     for (i, (s, e)) in enumerate(zip(1:ngroups:nclasses, ngroups:ngroups:nclasses+1))
         @views fec_groups[i, :] .= vec(sum(fec_all[s:e, :], dims=1))
     end
+
     return nothing
 end
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -76,7 +76,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
     # Update critical DHW distribution for deployed size classes
     for (i, loc) in enumerate(seed_locs)
         # Previous distributions
-        c_dist_t = @view(c_dist_t1[seed_sc, loc])
+        c_dist_ti = @view(c_dist_t[seed_sc, loc])
 
         # Truncated normal distributions for deployed corals
         # Assume same stdev and bounds as original

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -32,10 +32,9 @@ function distribute_seeded_corals(seed_loc_area::Vector{Float64},
 end
 
 """
-    seed_corals!(cover::Matrix{Float64}, total_location_area::Vector{Float64},
-        leftover_space_m²::Vector{Float64}, seed_locs::BitVector,
-        seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::Vector{Float64},
-        Yseed::SubArray, c_dist_t::Matrix{Distribution})::Nothing
+    seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
+        seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
+        Yseed::SubArray, stdev::V, c_dist_t::Matrix)::Nothing where {V<:Vector{Float64}}
 
 Deploy thermally enhanced corals to indicated locations ("seeding" or "outplanting").
 Increases indicated area covered by the given coral taxa and determines the modified

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -55,7 +55,7 @@ Note: Units for all areas are expected to be identical, and are assumed to be in
 """
 function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
     seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
-    Yseed::SubArray, stdev::V, c_dist_t::Matrix{Distribution})::Nothing where {V<:Vector{Float64}}
+    Yseed::SubArray, stdev::V, c_dist_t::Matrix)::Nothing where {V<:Vector{Float64}}
 
     # Calculate proportion to seed based on current available space
     scaled_seed = distribute_seeded_corals(total_location_area[seed_locs], leftover_space[seed_locs], seeded_area)

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -176,7 +176,12 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
     )
 
     # 36 is the number of species/groups represented
-    coral_dhw_log = zcreate(Float32, tf, 36, n_sites, 2, n_scens; name="coral_dhw_log", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(tf, 36, n_sites, 2, 1), attrs=attrs)
+    local coral_dhw_log
+    if parse(Bool, ENV["ADRIA_DEBUG"]) == true
+        coral_dhw_log = zcreate(Float32, tf, 36, n_sites, 2, n_scens; name="coral_dhw_log", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(tf, 36, n_sites, 2, 1), attrs=attrs)
+    else
+        coral_dhw_log = zcreate(Float32, tf, 36, 1, 2, n_scens; name="coral_dhw_log", fill_value=0.0, fill_as_missing=false, path=log_fn, chunks=(tf, 36, 1, 2, 1), attrs=attrs)
+    end
 
     return ranks, seed_log, fog_log, shade_log, coral_dhw_log
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -536,10 +536,10 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
             d_s::UnitRange{Int64} = 1:length(horizon)
 
             # Put more weight on projected conditions closer to the decision point
-            @views env_horizon = decay[d_s] .* dhw_scen[horizon, :]
+            env_horizon .= decay .* @view(dhw_scen[horizon, :])
             mcda_vars.heat_stress_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
 
-            @views env_horizon = decay[d_s] .* wave_scen[horizon, :]
+            env_horizon .= decay .* @view(wave_scen[horizon, :])
             mcda_vars.dam_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
         end
         if is_guided && (in_seed_years || in_shade_years)
@@ -578,7 +578,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         #    attempts to account for the cooling effect of storms / high wave activity
         # `wave_scen` is normalized to the maximum value found for the given wave scenario
         # so what causes 100% mortality can differ between runs.
-        bleaching_mortality!(Y_pstep, dhw_t .* (1.0 .- @view(wave_scen[tstep, :])), depth_coeff, c_dist_t, c_dist_t1, @view(bleaching_mort[tstep, :, :]))
+        bleaching_mortality!(Y_pstep, dhw_t .* (1.0 .- @view(wave_scen[tstep, :])), depth_coeff, corals.dist_std, c_dist_t_1, c_dist_t, @view(bleaching_mort[tstep, :, :]))
 
         # Apply seeding
         if seed_corals && in_seed_years && has_seed_sites

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -89,7 +89,7 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
         factors=names(scenarios_df)
     )
 
-    parallel = (nrow(param_df) >= 4096) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
+    parallel = (nrow(param_df) >= 256) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin
@@ -104,7 +104,7 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
             #       Julia kernel to crash in multi-processing contexts.
             #       Getting each worker to create its own cache reduces serialization time
             #       (at the cost of increased run time) but resolves the kernel crash issue.
-            @everywhere @eval begin
+            @sync @async @everywhere @eval begin
                 using ADRIA
                 func = (dfx) -> run_scenario(dfx..., domain, data_store)
             end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -478,8 +478,8 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     end
 
     # Set up distributions for natural adaptation/heritability
-    c_dist_t_1 = cache.c_dist_t_1  # coral distribution t-1
-    c_dist_t = cache.c_dist_t  # coral distribution t
+    c_dist_t_1 = copy(cache.c_dist_t_1)  # coral distribution t-1
+    c_dist_t = copy(cache.c_dist_t)  # coral distribution t
 
     # Log of distributions
     dhw_tol_mean_log = cache.dhw_tol_mean_log  # tmp log for mean dhw tolerances

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -536,10 +536,10 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
             d_s::UnitRange{Int64} = 1:length(horizon)
 
             # Put more weight on projected conditions closer to the decision point
-            env_horizon .= decay .* @view(dhw_scen[horizon, :])
+            @views env_horizon = decay[d_s] .* dhw_scen[horizon, :]
             mcda_vars.heat_stress_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
 
-            env_horizon .= decay .* @view(wave_scen[horizon, :])
+            @views env_horizon = decay[d_s] .* wave_scen[horizon, :]
             mcda_vars.dam_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
         end
         if is_guided && (in_seed_years || in_shade_years)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -522,10 +522,10 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
             horizon = tstep:tstep+Int64(param_set("plan_horizon"))
 
             # Put more weight on projected conditions closer to the decision point
-            env_horizon .= decay .* dhw_scen[horizon, :]
+            env_horizon .= decay .* @view(dhw_scen[horizon, :])
             mcda_vars.heat_stress_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
 
-            env_horizon .= decay .* wave_scen[horizon, :]
+            env_horizon .= decay .* @view(wave_scen[horizon, :])
             mcda_vars.dam_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
         end
         if is_guided && (in_seed_years || in_shade_years)
@@ -564,7 +564,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         #    attempts to account for the cooling effect of storms / high wave activity
         # `wave_scen` is normalized to the maximum value found for the given wave scenario
         # so what causes 100% mortality can differ between runs.
-        bleaching_mortality!(Y_pstep, dhw_t .* (1.0 .- wave_scen[tstep, :]), depth_coeff, corals.dist_std, c_dist_t_1, c_dist_t, @view(bleaching_mort[tstep, :, :]))
+        bleaching_mortality!(Y_pstep, dhw_t .* (1.0 .- @view(wave_scen[tstep, :])), depth_coeff, c_dist_t, c_dist_t1, @view(bleaching_mort[tstep, :, :]))
 
         # Apply seeding
         if seed_corals && in_seed_years && has_seed_sites

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -279,6 +279,10 @@ function run_scenario(idx::Int64, param_set::Union{AbstractVector,DataFrameRow},
         data_store.site_ranks[:, :, :, idx] .= tmp_site_ranks
     end
 
+    if (idx % 256) == 0
+        @everywhere GC.gc()
+    end
+
     return nothing
 end
 function run_scenario(idx::Int64, param_set::Union{AbstractVector,DataFrameRow}, domain::Domain, data_store::NamedTuple)::Nothing

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -270,13 +270,6 @@ function run_scenario(idx::Int64, param_set::Union{AbstractVector,DataFrameRow},
         data_store.site_ranks[:, :, :, idx] .= tmp_site_ranks
     end
 
-    # There seems to be an issue when using `pmap` for distributed tasks, where the
-    # garbage collector is not run leading to excessive memory use (Julia v1.9.2).
-    # Force garbage collection if > 95% of total memory is found to be in use.
-    # if (Sys.free_memory() ./ Sys.total_memory()) .< 0.05
-    #     GC.gc()
-    # end
-
     return nothing
 end
 function run_scenario(idx::Int64, param_set::Union{AbstractVector,DataFrameRow}, domain::Domain, data_store::NamedTuple)::Nothing

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -11,22 +11,27 @@ Establish tuple of matrices/vectors for use as reusable data stores to avoid rep
 """
 function setup_cache(domain::Domain)::NamedTuple
 
-    # sim constants
+    # Simulation constants
     n_sites::Int64 = domain.coral_growth.n_sites
     n_species::Int64 = domain.coral_growth.n_species
     n_groups::Int64 = domain.coral_growth.n_groups
+    tf = length(timesteps(domain))
 
-    init_cov = domain.init_coral_cover
     cache = (
-        sf=zeros(n_groups, n_sites),  # stressed fecundity
-        fec_all=zeros(size(init_cov)...),  # all fecundity
+        # sf=zeros(n_groups, n_sites),  # stressed fecundity, commented out as it is disabled
+        fec_all=zeros(n_species, n_sites),  # all fecundity
         fec_scope=zeros(n_groups, n_sites),  # fecundity scope
-        dhw_step=zeros(n_sites),  # DHW each time step
-        cov_tmp=zeros(size(init_cov)...),  # Cover for previous timestep
+        dhw_step=zeros(n_sites),  # DHW for each time step
+        cov_tmp=zeros(n_species, n_sites),  # Cover for previous timestep
         depth_coeff=zeros(n_sites),  # store for depth coefficient
         site_area=Matrix{Float64}(site_area(domain)'),  # site areas
         TP_data=Matrix{Float64}(domain.TP_data),  # transition probabilities
-        waves=zeros(length(timesteps(domain)), n_species, n_sites)
+        wave_scen=zeros(tf, n_sites),  # tmp store for wave scenario
+        wave_damage=zeros(tf, n_species, n_sites),  # damage coefficient for each size class
+        dhw_tol_mean_log = zeros(tf, n_species, n_sites),  # tmp log for mean dhw tolerances
+        dhw_tol_std_log = zeros(tf, n_species, n_sites),  # tmp log for stdev dhw tolerances
+        c_dist_t_1 = fill(truncated(Normal(1.0, 0.25), 0.0, 1.0), n_species, n_sites),  # coral distribution t-1
+        c_dist_t = fill(truncated(Normal(1.0, 0.25), 0.0, 1.0), n_species, n_sites)  # coral distribution t
     )
 
     return cache
@@ -344,7 +349,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     # Caches
     TP_data = cache.TP_data
-    sf = cache.sf
+    # sf = cache.sf  # unused as it is currently deactivated
     fec_all = cache.fec_all
     fec_scope = cache.fec_scope
     dhw_t = cache.dhw_step

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -89,7 +89,7 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
         factors=names(scenarios_df)
     )
 
-    parallel = (nrow(param_df) >= 256) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
+    parallel = (nrow(param_df) >= 2048) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -54,7 +54,7 @@ function _setup_workers()::Nothing
         end
 
         if active_cores > 1
-            addprocs(active_cores; exeflags="--project=$(Base.active_project())")
+            @sync @async addprocs(active_cores; exeflags="--project=$(Base.active_project())")
         end
     end
 
@@ -63,8 +63,8 @@ end
 
 """Remove workers and free up memory."""
 function _remove_workers()::Nothing
-    if nworkers() > 1
-        rmprocs(workers()...)
+    if nworkers() > 1 || nprocs() > 1
+        rmprocs(workers())
     end
 
     return

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -54,7 +54,7 @@ function _setup_workers()::Nothing
         end
 
         if active_cores > 1
-            @sync @async addprocs(active_cores; exeflags="--project=$(Base.active_project())")
+            addprocs(active_cores; exeflags="--project=$(Base.active_project())")
         end
     end
 

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -81,7 +81,7 @@ using ADRIA: distribute_seeded_corals, site_k, seed_corals!
         seed_sc = BitVector([i ∈ [2, 8, 15] for i in 1:36])
 
         # Initial distributions
-        c_dist_t::Matrix{Distribution} = fill(truncated(Normal(1.0, 0.1), 0.0, 2.0), 36, 10)
+        c_dist_t = fill(truncated(Normal(1.0, 0.1), 0.0, 2.0), 36, 10)
         orig_dist = copy(c_dist_t)
 
         dist_std = rand(36)


### PR DESCRIPTION
Closes #413 and re-addresses #405.

Previous approach to parallel runs first initialized the provided domain object with environmental data (via `switch_RCPs!()`).
The `domain` was then sent to workers for each scenario run.

This had two effects:
1. For each run the domain object would be serialized and sent to workers, which unserialized the data on receipt to begin its workload. Due to the size of the domain data, this caused significant overhead
2. Because an explicit copy of the domain is not sent to each worker, I suspect each worker received a reference to the original data structure (although the data associated with the struct would be a copy).

Because of the above, Julia's garbage collector (GC) would recognise the Domain as still in use after a worker had finished a run, so it never cleans up the "copy" of the domain. This leads to ever-increasing amounts of memory to be used. Forcing the GC to run to free up memory (as in #405) only masked the issue.

To resolve both issues, we now send to each worker an uninitialized domain. As this data structure is not loaded with the environmental data, it is much smaller and thus faster to serialize/unserialize, reducing overheads. Each worker then configures the domain with the appropriate environmental data. For clarity, this PR still forces the GC to run (albeit much less than before), but one source of memory leaks has been addressed.

This PR also includes a fix for a zero division error bug, which stems from cases where MCDA returns ranks for `n_sites` but seeding deployments are distributed to < `n_sites`.

It also resolves an issue where an off-by-one error would very rarely arise when determining planning horizons.