### PR TITLE
Adjustments to heritability based on feedback

### DIFF
--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -214,7 +214,7 @@ function coral_spec()::NamedTuple
         ], inner=n_classes)
 
     # Data from Hughes et al., (2018) were based on the 2016 bleaching event.
-    # We some further adaptation (+3.0 DHW) has occurred since then.
+    # We assume some further adaptation (+3.0 DHW) has occurred since then.
     params.dist_mean .+= 3.0
 
     params.dist_std = repeat(Float64[

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -187,9 +187,9 @@ function coral_spec()::NamedTuple
     # Background mortality taken from Bozec et al. 2022 (Supplementary 2, Table S1)
     # Using values for:
     # - juvenile mortality (first two columns)
-    # - < 5cm² (Columns 1 and 2)
-    # - < 250cm² (Columns 3 and 4)
-    # - > 250cm² (Columns 5 and 6)
+    # - < 5cm diameter (Columns 1 and 2)
+    # - < 250cm diameter (Columns 3 and 4)
+    # - > 250cm diameter (Columns 5 and 6)
     # Values for size class 4 are then interpolated by K.A
     mb = Array{Float64,2}([
         0.2 0.2 0.004 0.004 0.002 0.002    # Arborescent Acropora 

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -174,10 +174,9 @@ function coral_spec()::NamedTuple
     # unit is number of larvae per colony
     colony_area_cm2 = colony_mean_area(mean_colony_diameter_m .* 100.0)
     fec = exp.(log.(fec_par_a) .+ fec_par_b .* log.(colony_area_cm2)) ./ 0.1
-    fec[colony_area_cm2.<min_size_full_fec_cm2] .= 0.0
 
-    # Smallest size class do not reproduce
-    fec[:, 1:2] .= 0.0
+    # Size classes below indicated size are not fecund (reproductive)
+    fec[colony_area_cm2.<min_size_full_fec_cm2] .= 0.0
 
     # then convert to number of larvae produced per m2
     fec_m² = fec ./ (colony_mean_area(mean_colony_diameter_m)) # convert from per colony area to per m2
@@ -197,7 +196,7 @@ function coral_spec()::NamedTuple
         0.2 0.2 0.172 0.172 0.088 0.088    # Corymbose Acropora 
         0.2 0.2 0.226 0.226 0.116 0.116    # Corymbose non-Acropora 
         0.2 0.2 0.040 0.026 0.020 0.020    # Small massives and encrusting
-        0.2 0.2 0.040 0.026 0.020 0.020])   # Large massives
+        0.2 0.2 0.040 0.026 0.020 0.020])  # Large massives
     params.mb_rate = mb'[:]
 
     # Natural adaptation / heritability

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -3,7 +3,7 @@ import ModelParameters: Model
 
 
 # Upper bound offset to use when re-creating critical DHW distributions
-const HEAT_UB = 20.0
+const HEAT_UB = 10.0
 
 
 """
@@ -212,10 +212,6 @@ function coral_spec()::NamedTuple
             6.165751937,  # Small massives and encrusting
             7.153507902   # Large massives
         ], inner=n_classes)
-
-    # Data from Hughes et al., (2018) were based on the 2016 bleaching event.
-    # We assume some further adaptation (+3.0 DHW) has occurred since then.
-    params.dist_mean .+= 3.0
 
     params.dist_std = repeat(Float64[
             2.590016677,  # arborescent Acropora

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -213,6 +213,10 @@ function coral_spec()::NamedTuple
             7.153507902   # Large massives
         ], inner=n_classes)
 
+    # Data from Hughes et al., (2018) were based on the 2016 bleaching event.
+    # We some further adaptation (+3.0 DHW) has occurred since then.
+    params.dist_mean .+= 3.0
+
     params.dist_std = repeat(Float64[
             2.590016677,  # arborescent Acropora
             2.904433676,  # tabular Acropora

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -243,8 +243,8 @@ with a depth-adjusted coefficient (from Baird et al., [4]).
    https://doi.org/10.3354/meps12732
 """
 function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
-    depth_coeff::Vector{Float64}, dist_t::Matrix{Distribution},
-    dist_t1::Matrix{Distribution}, prop_mort::SubArray{Float64})::Nothing
+    depth_coeff::Vector{Float64}, dist_t_1::Matrix{Distribution},
+    dist_t::Matrix{Distribution}, prop_mort::SubArray{Float64})::Nothing
     n_sp_sc, n_locs = size(cover)
 
     # Adjust distributions for all locations, ignoring juveniles
@@ -255,7 +255,7 @@ function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
             continue
         end
 
-        affected_pop::Float64 = cdf(dist_t[sp_sc, loc], dhw[loc])
+        affected_pop::Float64 = cdf(dist_t_1[sp_sc, loc], dhw[loc])
         mort_pop::Float64 = 0.0
         if affected_pop > 0.0
             # Calculate depth-adjusted bleaching mortality
@@ -271,9 +271,9 @@ function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
         prop_mort[sp_sc, loc] = mort_pop
         if mort_pop > 0.0
             # Re-create distribution
-            d::Distribution = dist_t[sp_sc, loc]
+            d::Distribution = dist_t_1[sp_sc, loc]
             μ::Float64 = mean(d)
-            dist_t1[sp_sc, loc] = truncated(Normal(μ, std(d)), mort_pop, μ + HEAT_UB)
+            dist_t[sp_sc, loc] = truncated(Normal(μ, std(d)), mort_pop, μ + HEAT_UB)
 
             # Update population
             cover[sp_sc, loc] = cover[sp_sc, loc] * (1.0 - mort_pop)
@@ -373,8 +373,9 @@ end
 
 
 """
-    fecundity_scope!(fec_groups::Array{Float64, 2}, fec_all::Array{Float64, 2}, fec_params::Array{Float64},
-                     Y_pstep::Array{Float64, 2}, k_area::Array{Float64})::Nothing
+    fecundity_scope!(fec_groups::Array{Float64, 2}, fec_all::Array{Float64, 2}, 
+                     fec_params::Array{Float64}, Y_pstep::Array{Float64, 2}, 
+                     k_area::Array{Float64})::Nothing
 
 The scope that different coral groups and size classes have for
 producing larvae without consideration of environment.

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -196,7 +196,7 @@ end
         dist_t1::Matrix{Distribution}, prop_mort::AbstractArray{Float64})::Nothing
 
 Applies bleaching mortality by assuming critical DHW thresholds are normally distributed for
-all non-Juvenile (> 5cm²) size classes. Distributions are informed by learnings from
+all non-Juvenile (> 5cm diameter) size classes. Distributions are informed by learnings from
 Bairos-Novak et al., [1] and (unpublished) data referred to in Hughes et al., [2]. Juvenile
 mortality is assumed to be primarily represented by other factors (i.e., background
 mortality; see Álvarez-Noriega et al., [3]). The proportion of the population which bleached

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -282,10 +282,11 @@ function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
 end
 
 """
-    _merge_distributions!(growth_rate, dists_t)::Nothing
+    _shift_distributions!(growth_rate, dists_t)::Nothing
 
-Combine distributions using a MixtureModel for all size classes above 1.
-Priors for the distributions are based on the assumed growth rates for each size class.
+Combines distributions between size classes > 1 to represent the shifts that occur as each
+size class grows. Priors for the distributions are based on the assumed growth rates for 
+each size class.
 
 i.e., (w_{i+1,1}, w_{i+1,2}) := (g_{i} / sum(g_{i,i+1}), g_{i+1} / sum(g_{i,i+1}))
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -317,12 +317,12 @@ function _shift_distributions!(cover::SubArray, growth_rate::SubArray, dist_t::S
 
         # Use same stdev as target size class to maintain genetic variance
         # pers comm K.B-N (2023-08-09 16:24 AEST)
-        dist_t[i] = truncated(Normal(mean(x), stdev[i]), 0.0, mean(x) + HEAT_UB)
+        dist_t[i] = truncated(Normal(mean(x), stdev[i]), minimum(x), mean(x) + HEAT_UB)
     end
 
-    # # Size class 1 all moves up to size class 2 any way
+    # # Size class 1 all moves up to size class 2 anyway
     μ = mean(dist_t[1])
-    dist_t[2] = truncated(Normal(μ, stdev[2]), 0.0, μ + HEAT_UB)
+    dist_t[2] = truncated(Normal(μ, stdev[2]), minimum(dist_t[1]), μ + HEAT_UB)
 
     return nothing
 end
@@ -385,7 +385,7 @@ function adjust_DHW_distribution!(cover::SubArray, n_groups::Int64, dist_t_1::Ma
                 # The standard deviation is assumed to be the same as parents
                 # Note: Nominally, h² := 0.3, but ranges from 0.25 - 0.5
                 μ_t::Float64 = mean(dt_1) + (S * h²)
-                dist_t[sc1, loc] = truncated(Normal(μ_t, stdev[sc1]), 0.0, μ_t + HEAT_UB)
+                dist_t[sc1, loc] = truncated(Normal(μ_t, stdev[sc1]), minimum(d_t), μ_t + HEAT_UB)
             end
         end
     end

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -75,7 +75,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
 
         # Truncated normal distributions for deployed corals
         # Assume same stdev and bounds as original
-        tn = truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), 0.0, maximum.(c_dist_ti))
+        tn = truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti))
 
         # If seeding an empty location, no need to do any further calculations
         if all(isapprox.(w_taxa[:, i], 1.0))
@@ -87,7 +87,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
         # proportional cover as the priors/weights
         # Priors (weights based on cover for each species)
         tx = MixtureModel[MixtureModel([t, t1], Float64[w, 1.0-w]) for ((t, t1), w) in zip(zip(c_dist_ti, tn), w_taxa[:, i])]
-        c_dist_t[seed_sc, loc] .= truncated.(Normal.(mean.(tx), stdev[seed_sc]), 0.0, maximum.(tx))
+        c_dist_t[seed_sc, loc] .= truncated.(Normal.(mean.(tx), stdev[seed_sc]), minimum.(tx), maximum.(tx))
     end
 
     return nothing

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -15,7 +15,7 @@ const ENV_STATS = "env_stats"
 const MODEL_SPEC = "model_spec"
 
 
-struct ResultSet{S,T1,T2,F,A,B,C,D,G,D1,D2,DF}
+struct ResultSet{S,T1,T2,F,A,B,C,D,G,D1,D2,D3,DF}
     name::S
     RCP::S
     invoke_time::S
@@ -40,6 +40,7 @@ struct ResultSet{S,T1,T2,F,A,B,C,D,G,D1,D2,DF}
     seed_log::B  # Values stored in m^2
     fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
     shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
+    coral_dhw_tol_log::D3
 end
 
 
@@ -65,7 +66,8 @@ function ResultSet(input_set::AbstractArray, env_layer_md::EnvLayer, inputs_used
         NamedDimsArray{Symbol.(Tuple(log_set["rankings"].attrs["structure"]))}(log_set["rankings"]),
         NamedDimsArray{Symbol.(Tuple(log_set["seed"].attrs["structure"]))}(log_set["seed"]),
         NamedDimsArray{Symbol.(Tuple(log_set["fog"].attrs["structure"]))}(log_set["fog"]),
-        NamedDimsArray{Symbol.(Tuple(log_set["shade"].attrs["structure"]))}(log_set["shade"]))
+        NamedDimsArray{Symbol.(Tuple(log_set["shade"].attrs["structure"]))}(log_set["shade"]),
+        NamedDimsArray{Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))}(log_set["coral_dhw_log"]))
 end
 
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -587,7 +587,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_loc_area, 0.0, 1.0)
 
         if tstep <= tf
-            adjust_DHW_distribution!(Y_cover, n_groups, c_dist_t_1, c_dist_t, tstep,
+            adjust_DHW_distribution!(@view(Y_cover[tstep-1:tstep, :, :]), n_groups, c_dist_t_1, c_dist_t,
                 p.r, param_set("heritability"))
 
             dhw_tol_log[tstep, :, :] .= c_dist_t

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -158,8 +158,8 @@ function run_scenarios(param_df::DataFrame, domain::Domain, RCP::Vector{String};
 end
 
 """
-    run_scenario(idx::Int64, param_set::Union{AbstractVector, DataFrameRow}, domain::Domain, data_store::NamedTuple, cache::NamedTuple)::NamedTuple
-    run_scenario(idx::Int64, param_set::Union{AbstractVector, DataFrameRow}, domain::Domain, data_store::NamedTuple)::NamedTuple
+    run_scenario(idx::Int64, param_set::Union{AbstractVector, DataFrameRow}, domain::Domain, data_store::NamedTuple, cache::NamedTuple)::Nothing
+    run_scenario(idx::Int64, param_set::Union{AbstractVector, DataFrameRow}, domain::Domain, data_store::NamedTuple)::Nothing
     run_scenario(param_set::Union{AbstractVector, DataFrameRow}, domain::Domain, cache::NamedTuple)::NamedTuple
     run_scenario(param_set::NamedTuple, domain::Domain)::NamedTuple
 
@@ -597,7 +597,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     # Could collate critical DHW threshold log for corals to reduce disk space...
     # dhw_tol_mean = dropdims(mean(mean.(dhw_tol_log), dims=3), dims=3)
     # dhw_tol_mean_std = dropdims(mean(std.(dhw_tol_log), dims=3), dims=3)
-    # collated_dhw_tol_log = NamedDimsArray(cat(dhw_tol_mean, dhw_tol_mean_std, dims=3), 
+    # collated_dhw_tol_log = NamedDimsArray(cat(dhw_tol_mean, dhw_tol_mean_std, dims=3),
     #     timesteps=1:tf, species=corals.coral_id, stat=[:mean, :stdev])
     dhw_tol_mean_log = mean.(dhw_tol_log)
     dhw_tol_mean_std_log = std.(dhw_tol_log)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -591,6 +591,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
                 p.r, param_set("heritability"))
 
             dhw_tol_log[tstep, :, :] .= c_dist_t
+            c_dist_t_1 .= c_dist_t
         end
     end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -588,7 +588,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
         if tstep <= tf
             adjust_DHW_distribution!(Y_cover, n_groups, c_dist_t_1, c_dist_t, tstep,
-                param_set("heritability"))
+                p.r, param_set("heritability"))
 
             dhw_tol_log[tstep, :, :] .= c_dist_t
         end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -589,7 +589,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
         if tstep <= tf
             adjust_DHW_distribution!(@view(Y_cover[tstep-1:tstep, :, :]), n_groups, c_dist_t_1, c_dist_t,
-                p.r, param_set("heritability"))
+                p.r, corals.dist_std, param_set("heritability"))
 
             dhw_tol_log[tstep, :, :] .= c_dist_t
             c_dist_t_1 .= c_dist_t

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -82,16 +82,18 @@ using ADRIA: distribute_seeded_corals, site_k, seed_corals!
 
         # Initial distributions
         c_dist_t::Matrix{Distribution} = fill(truncated(Normal(1.0, 0.1), 0.0, 2.0), 36, 10)
+        orig_dist = copy(c_dist_t)
 
+        dist_std = rand(36)
         seed_corals!(Y_pstep, total_location_area, leftover_space_m², seed_locs, seeded_area, seed_sc,
-            a_adapt, @view(Yseed[1, :, :]), c_dist_t)
+            a_adapt, @view(Yseed[1, :, :]), dist_std, c_dist_t)
 
         # Ensure correct priors/weightings for each location
         for loc in seed_locs
             for (i, sc) in enumerate(findall(seed_sc))
                 prior1 = Yseed[1, i, loc] ./ Y_pstep[sc, loc]
                 expected = [prior1, 1.0 - prior1]
-                @test c_dist_t[sc, loc].prior.p == expected || "Expected $(expected) but got $(c_dist_t[sc, loc].prior.p) | SC: $sc ; Location: $loc"
+                @test mean(c_dist_t[sc, loc]) > mean(orig_dist[sc, loc]) || "Expected mean of distribution to shift | SC: $sc ; Location: $loc"
             end
         end
     end


### PR DESCRIPTION
Adjusting representation of natural adaptation and heritability based on feedback and discussion (thanks to @ecolology), principally:

Minimum bound of truncated distribution for each size class is the minimum of the Mixture distribution, such that over time corals are less likely to die from low DHW events. This makes the (truncated) normal distribution behave somewhat more like a log-normal distribution.

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/c540e1f6-d9d7-40a5-bc39-110d78e8a3ce)

**Note: the CDF above is prior to any adjustments based on depth. Actual mortality may be significantly less**

Standard deviation is now fixed to the original value used for a given size class. Standard deviations does still change over time (we see an increase) due to the Mixture and truncation approach, indicating a greater variability in DHW sensitivity over time.

The +20 from mean rule used as a hypothetical upper bound of the DHW tolerance distribution is adjusted to be +10 from mean.

Corrected size classes that are deemed to be reproductive (fecund): size classes 4 - 6, not 3 - 6

Renamed variables for conceptual alignment: the prototype was based on $t$ to $t+1$, where as ADRIAmod works on $t-1$ to $t$

