### PR TITLE
Fix unnecessarily squashed figure when plotting outcome map for 1 factor

### DIFF
--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -146,7 +146,8 @@ end
 Calculates a "nice" number of rows and columns from a given number of factors to display.
 The number of rows for subplots are calculated based on the number of desired columns.
 
-Note: `n_factors` <= 4 are always displayed with 2 columns.
+Note: `n_factors` == 1 is displayed as a single figure.
+      `n_factors` <= 4 are always displayed with 2 columns.
 
 # Arguments
 - `n_factors` : Number of factors to organize in a grid.


### PR DESCRIPTION
Figure would be unnecessarily squashed when plotting outcome mapping results for a single factor.

```julia
dom = ADRIA.load_domain("... some domain ...")
scens = ADRIA.sample(dom, 1024)
rs = ADRIA.run_scenarios(scens, dom, "45")

s_tac = ADRIA.metrics.scenario_total_cover(rs)
μ_stac_2050 = vec(mean(s_tac(timesteps=2045:2055, scenarios=:), dims=1))

# Factors of interest
foi = ["guided"]

# Find scenarios where metric is above the median
rule = y -> all(y .> 0.5)

# Map input values where to their outcomes
om = ADRIA.sensitivity.outcome_map(rs.inputs, med_stac_2050, rule, foi; S=20, n_boot=100, conf=0.95)
ADRIA.viz.outcome_map(rs, om, foi; axis_opts=Dict(:title => "Test"))
```

Before:

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/53f691b9-87e4-4106-a69f-11f281f8c228)


After:

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/9e5eaece-9a93-4571-8c80-84b382601989)
