### PR TITLE
Adds a series of aggregation functions for location selection ranks

### DIFF
--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -146,9 +146,8 @@ using ADRIA:
 using DataFrames
 using Statistics, StatsBase
 
-@info "Loading data package"
-here = @__DIR__
-dom = ADRIA.load_domain(joinpath(here, "Moore_2023-08-17"), "45")
+# Load data package
+dom = ADRIA.load_domain("path to Domain files", "RCP")
 scens = ADRIA.sample_site_selection(dom, 8) # Get scenario dataframe.
 
 area_to_seed = 962.11  # Area of seeded corals in m^2.
@@ -156,14 +155,13 @@ area_to_seed = 962.11  # Area of seeded corals in m^2.
 # Initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites)).
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
-@info "Run site selection"
 # Use run_site_selection to get ranks
 ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
 
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
 
-@info "Calculate rank aggregations"
+# Calculate rank aggregations
 # Get location selection freqencies for set of standalone location selections.
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
@@ -202,6 +200,5 @@ unguided_freq = location_selection_frequencies(
 inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
 inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1]; dims=[:scenarios])
-
 
 ```

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -117,7 +117,7 @@ rs = ADRIA.run_scenarios(dom, p_df, "45")
 
 ```julia
 using ADRIA
-using ADRIA: rank_locations
+using ADRIA: run_site_selection
 
 @info "Loading data package"
 here = @__DIR__
@@ -130,8 +130,8 @@ area_to_seed = 962.11  # Area of seeded corals in m^2.
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
 @info "Run site selection"
-# Use rank_locations to get ranks
-ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
+# Use run_site_selection to get ranks
+ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
 ```
 
 ## Intervention location selection - summary functions
@@ -139,57 +139,49 @@ ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
 ```julia
 using ADRIA
 using ADRIA:
-    rank_locations,
+    run_site_selection,
     ranks_to_frequencies,
+    ranks_to_location_order,
     location_selection_frequencies,
     summed_inverse_rank
 using DataFrames
 using Statistics, StatsBase
 
-# Load data package
-dom = ADRIA.load_domain("path to Domain files", "RCP")
-scens = ADRIA.sample_site_selection(dom, 8) # Get site selection scenario dataframe.
+@info "Loading data package"
+here = @__DIR__
+dom = ADRIA.load_domain(joinpath(here, "Moore_2023-08-17"), "45")
+scens = ADRIA.sample_site_selection(dom, 8) # Get scenario dataframe.
 
 area_to_seed = 962.11  # Area of seeded corals in m^2.
 
 # Initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites)).
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
-# Use rank_locations to get ranks
-ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
-
+@info "Run site selection"
+# Use run_site_selection to get ranks
+ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
 
-# Calculate rank aggregations
+@info "Calculate rank aggregations"
 # Get location selection freqencies for set of standalone location selections.
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
 # Measure of magnitude and frequency of high rank.
 inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 
-# Use aggregation function within rank_locations to get direct output.
+# Use aggregation function within run_site_selection to get direct output.
 # To get rank frequencies:
-rank_frequencies_seed = rank_locations(
+rank_frequencies_seed = run_site_selection(
     dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
-)
-rank_frequencies_seed = rank_locations(
-    dom, scens, sum_cover, area_to_seed, location_selection_frequencies, 1
-)
-rank_frequencies_seed = rank_locations(
-    dom, scens, sum_cover, area_to_seed, summed_inverse_rank, 1
 )
 
 # Example using ADRIA runs
-scens = ADRIA.sample(dom, 2^5) # Get scenario dataframe.
+scens = ADRIA.sample(dom, 8) # Get scenario dataframe.
 rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
 
 # Get frequencies with which each site is selected for each rank for set of runs.
-rank_freq = ranks_to_frequencies(rs.ranks[intervention=1]) # with timesteps not aggregated
-rank_freq = ranks_to_frequencies(
-    rs.ranks[intervention=1];
-    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
-) # with timesteps aggregated
+rank_freq = ranks_to_frequencies(rs.ranks[intervention=1])
 
 # Get selection frequencies for set of runs.
 selection_freq = location_selection_frequencies(rs.ranks[intervention=1])

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -141,7 +141,6 @@ using ADRIA
 using ADRIA:
     run_site_selection,
     ranks_to_frequencies,
-    ranks_to_location_order,
     location_selection_frequencies,
     summed_inverse_rank
 using DataFrames
@@ -160,6 +159,7 @@ sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 @info "Run site selection"
 # Use run_site_selection to get ranks
 ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
+
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
 
@@ -175,9 +175,15 @@ inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 rank_frequencies_seed = run_site_selection(
     dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
 )
+rank_frequencies_seed = run_site_selection(
+    dom, scens, sum_cover, area_to_seed, location_selection_frequencies, 1
+)
+rank_frequencies_seed = run_site_selection(
+    dom, scens, sum_cover, area_to_seed, summed_inverse_rank, 1
+)
 
 # Example using ADRIA runs
-scens = ADRIA.sample(dom, 8) # Get scenario dataframe.
+scens = ADRIA.sample(dom, 2^5) # Get scenario dataframe.
 rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
 
 # Get frequencies with which each site is selected for each rank for set of runs.
@@ -196,5 +202,6 @@ unguided_freq = location_selection_frequencies(
 inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
 inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1]; dims=[:scenarios])
+
 
 ```

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -166,7 +166,7 @@ rank_freq = ranks_to_frequencies(ranks[intervention=1])
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = selection_score(ranks[intervention=1])
+sel_score = selection_score(ranks[intervention=1])
 
 # Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
@@ -201,8 +201,8 @@ unguided_freq = location_selection_frequencies(
 
 # Get summed inverse rank for set of runs.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = selection_score(rs.ranks[intervention=1])
+sel_score = selection_score(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
-inv_summ_rank = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])
+sel_score = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])
 
 ```

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -117,7 +117,7 @@ rs = ADRIA.run_scenarios(dom, p_df, "45")
 
 ```julia
 using ADRIA
-using ADRIA: run_site_selection
+using ADRIA: rank_locations
 
 @info "Loading data package"
 here = @__DIR__
@@ -130,8 +130,8 @@ area_to_seed = 962.11  # Area of seeded corals in m^2.
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
 @info "Run site selection"
-# Use run_site_selection to get ranks
-ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
+# Use rank_locations to get ranks
+ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
 ```
 
 ## Intervention location selection - summary functions
@@ -139,7 +139,7 @@ ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
 ```julia
 using ADRIA
 using ADRIA:
-    run_site_selection,
+    rank_locations,
     ranks_to_frequencies,
     location_selection_frequencies,
     summed_inverse_rank
@@ -155,8 +155,8 @@ area_to_seed = 962.11  # Area of seeded corals in m^2.
 # Initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites)).
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
-# Use run_site_selection to get ranks
-ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
+# Use rank_locations to get ranks
+ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
 
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
@@ -168,15 +168,15 @@ location_selection_frequency = location_selection_frequencies(ranks[intervention
 # Measure of magnitude and frequency of high rank.
 inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 
-# Use aggregation function within run_site_selection to get direct output.
+# Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
 )
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, location_selection_frequencies, 1
 )
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, summed_inverse_rank, 1
 )
 

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -148,7 +148,7 @@ using Statistics, StatsBase
 
 # Load data package
 dom = ADRIA.load_domain("path to Domain files", "RCP")
-scens = ADRIA.sample_site_selection(dom, 8) # Get scenario dataframe.
+scens = ADRIA.sample_site_selection(dom, 8) # Get site selection scenario dataframe.
 
 area_to_seed = 962.11  # Area of seeded corals in m^2.
 

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -166,7 +166,7 @@ rank_freq = ranks_to_frequencies(ranks[intervention=1])
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
+inv_summ_rank = selection_score(ranks[intervention=1])
 
 # Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
@@ -201,8 +201,8 @@ unguided_freq = location_selection_frequencies(
 
 # Get summed inverse rank for set of runs.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1])
+inv_summ_rank = selection_score(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
-inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1]; dims=[:scenarios])
+inv_summ_rank = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])
 
 ```

--- a/docs/src/usage/cookbook.md
+++ b/docs/src/usage/cookbook.md
@@ -185,7 +185,11 @@ scens = ADRIA.sample(dom, 2^5) # Get scenario dataframe.
 rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
 
 # Get frequencies with which each site is selected for each rank for set of runs.
-rank_freq = ranks_to_frequencies(rs.ranks[intervention=1])
+rank_freq = ranks_to_frequencies(rs.ranks[intervention=1]) # with timesteps not aggregated
+rank_freq = ranks_to_frequencies(
+    rs.ranks[intervention=1];
+    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
+) # with timesteps aggregated
 
 # Get selection frequencies for set of runs.
 selection_freq = location_selection_frequencies(rs.ranks[intervention=1])

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -29,7 +29,7 @@ rank_freq = ranks_to_frequencies(ranks[intervention=1])
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = selection_score(ranks[intervention=1])
+sel_score = selection_score(ranks[intervention=1])
 
 # Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
@@ -64,6 +64,6 @@ unguided_freq = location_selection_frequencies(
 
 # Get summed inverse rank for set of runs.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = selection_score(rs.ranks[intervention=1])
+sel_score = selection_score(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
-inv_summ_rank = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])
+sel_score = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -1,6 +1,6 @@
 using ADRIA
 using ADRIA:
-    run_site_selection,
+    rank_locations,
     ranks_to_frequencies,
     location_selection_frequencies,
     summed_inverse_rank
@@ -18,8 +18,8 @@ area_to_seed = 962.11  # Area of seeded corals in m^2.
 sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
 @info "Run site selection"
-# Use run_site_selection to get ranks
-ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
+# Use rank_locations  to get ranks
+ranks = rank_locations(dom, scens, sum_cover, area_to_seed)
 
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
@@ -31,15 +31,15 @@ location_selection_frequency = location_selection_frequencies(ranks[intervention
 # Measure of magnitude and frequency of high rank.
 inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 
-# Use aggregation function within run_site_selection to get direct output.
+# Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
 )
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, location_selection_frequencies, 1
 )
-rank_frequencies_seed = run_site_selection(
+rank_frequencies_seed = rank_locations(
     dom, scens, sum_cover, area_to_seed, summed_inverse_rank, 1
 )
 

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -48,7 +48,11 @@ scens = ADRIA.sample(dom, 2^5) # Get scenario dataframe.
 rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
 
 # Get frequencies with which each site is selected for each rank for set of runs.
-rank_freq = ranks_to_frequencies(rs.ranks[intervention=1])
+rank_freq = ranks_to_frequencies(rs.ranks[intervention=1]) # with timesteps not aggregated
+rank_freq = ranks_to_frequencies(
+    rs.ranks[intervention=1];
+    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
+) # with timesteps aggregated
 
 # Get selection frequencies for set of runs.
 selection_freq = location_selection_frequencies(rs.ranks[intervention=1])

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -29,7 +29,7 @@ rank_freq = ranks_to_frequencies(ranks[intervention=1])
 location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
 # Get summed inverse rank for set of standalone location selections.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
+inv_summ_rank = selection_score(ranks[intervention=1])
 
 # Use aggregation function within rank_locations to get direct output.
 # To get rank frequencies:
@@ -64,6 +64,6 @@ unguided_freq = location_selection_frequencies(
 
 # Get summed inverse rank for set of runs.
 # Measure of magnitude and frequency of high rank.
-inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1])
+inv_summ_rank = selection_score(rs.ranks[intervention=1])
 # Get summed inverse rank over time.
-inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1]; dims=[:scenarios])
+inv_summ_rank = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -1,5 +1,10 @@
 using ADRIA
-using ADRIA: run_site_selection, ranks_to_frequencies, ranks_to_frequencies_ts, ranks_to_location_order, location_selection_frequencies
+using ADRIA:
+    run_site_selection,
+    ranks_to_frequencies,
+    ranks_to_location_order,
+    location_selection_frequencies,
+    summed_inverse_rank
 using DataFrames
 using Statistics, StatsBase
 
@@ -8,30 +13,47 @@ here = @__DIR__
 dom = ADRIA.load_domain(joinpath(here, "Moore_2023-08-17"), "45")
 scens = ADRIA.sample_site_selection(dom, 8) # Get scenario dataframe.
 
-scens = ADRIA.sample_site_selection(dom, 8) # Get scenario dataframe.
-
 area_to_seed = 962.11  # Area of seeded corals in m^2.
 
 # Initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites)).
-sum_cover = repeat(sum(dom.init_coral_cover, dims=1), size(scens, 1))
+sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 
 @info "Run site selection"
 # Use run_site_selection to get ranks
 ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
-# Use an aggregation function to get location selection frequency.
+# Get frequencies with which each site is selected for each rank for set of stand alone location selections.
+rank_freq = ranks_to_frequencies(ranks[intervention=1])
 
 @info "Calculate rank aggregations"
-location_selection_frequency = location_selection_frequencies(ranks, "seed")
+# Get location selection freqencies for set of standalone location selections.
+location_selection_frequency = location_selection_frequencies(ranks[intervention=1])
+# Get summed inverse rank for set of standalone location selections.
+# Measure of magnitude and frequency of high rank.
+inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 
 # Use aggregation function within run_site_selection to get direct output.
 # To get rank frequencies:
-rank_frequencies_seed = run_site_selection(dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, "seed")
-# To get location rank order as site ids:
-location_order_seed = run_site_selection(dom, scens, sum_cover, area_to_seed, ranks_to_location_order, "seed")
+rank_frequencies_seed = run_site_selection(
+    dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
+)
 
 # Example using ADRIA runs
 scens = ADRIA.sample(dom, 8) # Get scenario dataframe.
-rs = ADRIA.run_scenarios(scens, dom, "45") # Run scenarios.
-rank_freq = ranks_to_frequencies(rs, "seed") # Get rank frequencies.
-rank_freq_ts = ranks_to_frequencies_ts(rs, "seed") # Get rank frequencies over time.
-selection_freq = location_selection_frequencies(rs, "seed") # Get rank frequencies over time.
+rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
+
+# Get frequencies with which each site is selected for each rank for set of runs.
+rank_freq = ranks_to_frequencies(rs.ranks[intervention=1])
+
+# Get selection frequencies for set of runs.
+selection_freq = location_selection_frequencies(rs.ranks[intervention=1])
+
+# Get selection frequencies over time for unguided runs only.
+unguided_freq = location_selection_frequencies(
+    rs.seed_log[scenarios=findall(scens.guided .== 1)]
+)
+
+# Get summed inverse rank for set of runs.
+# Measure of magnitude and frequency of high rank.
+inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1])
+# Get summed inverse rank over time.
+inv_summ_rank = summed_inverse_rank(rs.ranks[intervention=1]; dims=[:scenarios])

--- a/examples/site_selection.jl
+++ b/examples/site_selection.jl
@@ -2,7 +2,6 @@ using ADRIA
 using ADRIA:
     run_site_selection,
     ranks_to_frequencies,
-    ranks_to_location_order,
     location_selection_frequencies,
     summed_inverse_rank
 using DataFrames
@@ -21,6 +20,7 @@ sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))
 @info "Run site selection"
 # Use run_site_selection to get ranks
 ranks = run_site_selection(dom, scens, sum_cover, area_to_seed)
+
 # Get frequencies with which each site is selected for each rank for set of stand alone location selections.
 rank_freq = ranks_to_frequencies(ranks[intervention=1])
 
@@ -36,9 +36,15 @@ inv_summ_rank = summed_inverse_rank(ranks[intervention=1])
 rank_frequencies_seed = run_site_selection(
     dom, scens, sum_cover, area_to_seed, ranks_to_frequencies, 1
 )
+rank_frequencies_seed = run_site_selection(
+    dom, scens, sum_cover, area_to_seed, location_selection_frequencies, 1
+)
+rank_frequencies_seed = run_site_selection(
+    dom, scens, sum_cover, area_to_seed, summed_inverse_rank, 1
+)
 
 # Example using ADRIA runs
-scens = ADRIA.sample(dom, 8) # Get scenario dataframe.
+scens = ADRIA.sample(dom, 2^5) # Get scenario dataframe.
 rs = ADRIA.run_scenarios(dom, scens, "45") # Run scenarios.
 
 # Get frequencies with which each site is selected for each rank for set of runs.

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -24,7 +24,7 @@ ADRIA.viz.scenarios(rs.inputs, s_tac[:, scens.SRM .< 1.0])
 ```
 
 # Arguments
-- `scenarios` : DataFrame with ResultSet inputs
+- `scenarios` : Scenario specification
 - `outcomes` : Results of scenario metric
 - `opts` : Aviz options
     - `by_RCP` : color by RCP otherwise color by scenario type. Defaults to false.

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -75,13 +75,14 @@ end
 Constuctors for DMCDA variables.
 """
 function DMCDA_vars(
-    domain::Domain,
+    domain::Domain, 
     criteria::NamedDimsArray,
-    site_ids::AbstractArray,
-    sum_cover::AbstractArray,
+    site_ids::AbstractArray, 
+    sum_cover::AbstractArray, 
     area_to_seed::Float64,
     waves::AbstractArray, 
-    dhws::AbstractArray)::DMCDA_vars
+    dhws::AbstractArray
+)::DMCDA_vars
 
     # Site Data
     site_d = domain.site_data
@@ -127,7 +128,8 @@ function DMCDA_vars(
     criteria::NamedDimsArray,
     site_ids::AbstractArray,
     sum_cover::AbstractArray,
-    area_to_seed::Float64)::DMCDA_vars
+    area_to_seed::Float64
+)::DMCDA_vars
     num_sites = n_locations(domain)
     return DMCDA_vars(domain, criteria, site_ids, sum_cover, area_to_seed, zeros(num_sites, 1), zeros(num_sites, 1))
 end
@@ -138,7 +140,8 @@ function DMCDA_vars(
     sum_cover::AbstractArray,
     area_to_seed::Float64, 
     waves::AbstractArray, 
-    dhw::AbstractArray)::DMCDA_vars
+    dhw::AbstractArray
+)::DMCDA_vars
 
     criteria_vec::NamedDimsArray = NamedDimsArray(collect(criteria), rows=names(criteria))
     return DMCDA_vars(domain, criteria_vec, site_ids, sum_cover, area_to_seed, waves, dhw)
@@ -148,7 +151,8 @@ function DMCDA_vars(
     criteria::DataFrameRow,
     site_ids::AbstractArray,
     sum_cover::AbstractArray,
-    area_to_seed::Float64)::DMCDA_vars
+    area_to_seed::Float64
+)::DMCDA_vars
 
     criteria_vec::NamedDimsArray = NamedDimsArray(collect(criteria), rows=names(criteria))
     return DMCDA_vars(domain, criteria_vec, site_ids, sum_cover, area_to_seed)
@@ -178,7 +182,9 @@ end
 
 Align a vector of site rankings to match the indicated order in `s_order`.
 """
-function align_rankings!(rankings::Array, s_order::Matrix, col::Int64)::Nothing
+function align_rankings!(rankings::Array, 
+    s_order::Matrix, 
+    col::Int64)::Nothing
     # Fill target ranking column
     for (i, site_id) in enumerate(s_order[:, 1])
         rankings[rankings[:, 1].==site_id, col] .= i
@@ -267,8 +273,9 @@ function retrieve_ranks(
     return retrieve_ranks(site_ids, results.scores, maximize)
 end
 function retrieve_ranks(
-    site_ids::Vector{Float64}, scores::Vector, maximize::Bool
-)::Matrix{Union{Float64,Int64}}
+    site_ids::Vector,
+    scores::Vector,
+    maximize::Bool)::Matrix{Union{Float64,Int64}}
     s_order::Vector{Int64} = sortperm(scores, rev=maximize)
     return Union{Float64,Int64}[Int64.(site_ids[s_order]) scores[s_order]]
 end
@@ -315,7 +322,8 @@ function create_decision_matrix(
     site_depth::T, 
     predec::Matrix{Float64}, 
     zones_criteria::T, 
-    risk_tol::Float64)where {T<:Vector{Float64}}
+    risk_tol::Float64
+) where {T<:Vector{Float64}}
     A = zeros(length(site_ids), 9)
     A[:, 1] .= site_ids  # Column of site ids
    
@@ -404,7 +412,8 @@ function create_seed_matrix(
     wt_heat::T, 
     wt_predec_seed::T, 
     wt_predec_zones_seed::T, 
-    wt_lo_cover::T)where {T<:Float64}
+    wt_lo_cover::T
+) where {T<:Float64}
     # Define seeding decision matrix, based on copy of A
     SE = copy(A)
 
@@ -738,7 +747,8 @@ function unguided_site_selection(
     shade_years,
     n_site_int,
     available_space, 
-    depth)
+    depth
+)
     # Unguided deployment, seed/shade corals anywhere so long as available_space > 0.0
     # Only sites that have available space are considered, otherwise a zero-division error may occur later on.
 

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -322,7 +322,7 @@ function create_decision_matrix(
     predec::Matrix{Float64},
     zones_criteria::T,
     risk_tol::Float64
-)::Matrix{Union{Float64,Int64}} where {T<:Vector{Float64}}
+)::Tuple{Matrix{Float64}, BitVector} where {T<:Vector{Float64}}
     A = zeros(length(site_ids), 9)
     A[:, 1] .= site_ids  # Column of site ids
 
@@ -412,7 +412,7 @@ function create_seed_matrix(
     wt_predec_seed::T,
     wt_predec_zones_seed::T,
     wt_lo_cover::T
-)::Matrix{Union{Float64,Int64}} where {T<:Float64}
+)::Tuple{Matrix{Float64}, Vector{Float64}} where {T<:Float64}
     # Define seeding decision matrix, based on copy of A
     SE = copy(A)
 
@@ -474,7 +474,7 @@ function create_shade_matrix(A::Matrix{Float64},
     wt_heat::T,
     wt_predec_shade::T,
     wt_predec_zones_shade::T,
-    wt_hi_cover)::Matrix{Union{Float64,Int64}} where {T<:Float64}
+    wt_hi_cover)::Tuple{Matrix{Float64}, Vector{Float64}} where {T<:Float64}
     # Set up decision matrix to be same size as A
     SH = copy(A)
 
@@ -526,8 +526,9 @@ function guided_site_selection(
     out_conn::Vector{Float64},
     strong_pred::Vector{Int64};
     methods_mcda=methods_mcda
-)::Tuple where {T<:Int64,IA<:AbstractArray{<:Int64},IB<:AbstractArray{<:Int64},B<:Bool}
-
+)::Tuple{Vector{T}, Vector{T}, Matrix{T}} where {
+    T<:Int64,IA<:AbstractArray{<:Int64},IB<:AbstractArray{<:Int64},B<:Bool
+}
     use_dist::Int64 = d_vars.use_dist
     min_dist::Float64 = d_vars.min_dist
     site_ids = copy(d_vars.site_ids)

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -273,9 +273,10 @@ function retrieve_ranks(
     return retrieve_ranks(site_ids, results.scores, maximize)
 end
 function retrieve_ranks(
-    site_ids::Vector,
+    site_ids::Vector{Float64},
     scores::Vector,
-    maximize::Bool)::Matrix{Union{Float64,Int64}}
+    maximize::Bool
+)::Matrix{Union{Float64,Int64}}
     s_order::Vector{Int64} = sortperm(scores, rev=maximize)
     return Union{Float64,Int64}[Int64.(site_ids[s_order]) scores[s_order]]
 end

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -75,12 +75,12 @@ end
 Constuctors for DMCDA variables.
 """
 function DMCDA_vars(
-    domain::Domain, 
+    domain::Domain,
     criteria::NamedDimsArray,
     site_ids::AbstractArray,
     sum_cover::AbstractArray,
     area_to_seed::Float64,
-    waves::AbstractArray, 
+    waves::AbstractArray,
     dhws::AbstractArray
 )::DMCDA_vars
 
@@ -138,8 +138,8 @@ function DMCDA_vars(
     criteria::DataFrameRow,
     site_ids::AbstractArray,
     sum_cover::AbstractArray,
-    area_to_seed::Float64, 
-    waves::AbstractArray, 
+    area_to_seed::Float64,
+    waves::AbstractArray,
     dhw::AbstractArray
 )::DMCDA_vars
 
@@ -210,7 +210,7 @@ function rank_sites!(
     weights::Vector{Float64},
     rankings::Matrix{Int64},
     n_site_int::Int64,
-    mcda_func::Union{Function,Type{<:MCDMMethod}}, 
+    mcda_func::Union{Function,Type{<:MCDMMethod}},
     rank_col)::Tuple{Vector{Int64},Matrix{Union{Float64,Int64}}}
     # Filter out all non-preferred sites
     selector = vec(.!all(S[:, 2:end] .== 0, dims=1))
@@ -231,9 +231,9 @@ function rank_sites!(
 end
 
 """
-    retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Function)
-    retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Type{<:MCDMMethod})
-    retrieve_ranks(site_ids::Vector, scores::Vector, maximize::Bool)
+    retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Function)::Matrix{Union{Float64,Int64}}
+    retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Type{<:MCDMMethod})::Matrix{Union{Float64,Int64}}
+    retrieve_ranks(site_ids::Vector, scores::Vector, maximize::Bool)::Matrix{Union{Float64,Int64}}
 
 Get location ranks using mcda technique specified in mcda_func, weights and a decision matrix S.
 
@@ -252,7 +252,7 @@ function retrieve_ranks(
     S::Matrix{Float64},
     site_ids::Vector{Float64},
     weights::Vector{Float64},
-    mcda_func::Function)
+    mcda_func::Function)::Matrix{Union{Float64,Int64}}
     S = mcda_normalize(S) .* weights'
     scores = mcda_func(S)
 
@@ -263,7 +263,7 @@ function retrieve_ranks(
     site_ids::Vector{Float64},
     weights::Vector{Float64},
     mcda_func::Type{<:MCDMMethod},
-)
+)::Matrix{Union{Float64,Int64}}
     fns = fill(maximum, length(weights))
     results = mcdm(MCDMSetting(S, weights, fns), mcda_func())
     maximize = results.bestIndex == argmax(results.scores)
@@ -315,17 +315,17 @@ function create_decision_matrix(
     out_conn::T,
     sum_cover::Union{NamedDimsArray,T},
     max_cover::T,
-    area::T, 
-    wave_stress::T, 
-    heat_stress::T, 
-    site_depth::T, 
-    predec::Matrix{Float64}, 
-    zones_criteria::T, 
+    area::T,
+    wave_stress::T,
+    heat_stress::T,
+    site_depth::T,
+    predec::Matrix{Float64},
+    zones_criteria::T,
     risk_tol::Float64
-) where {T<:Vector{Float64}}
+)::Matrix{Union{Float64,Int64}} where {T<:Vector{Float64}}
     A = zeros(length(site_ids), 9)
     A[:, 1] .= site_ids  # Column of site ids
-   
+
     # node connectivity centrality, need to instead work out strongest predecessors to priority sites
     A[:, 2] .= maximum(in_conn) != 0.0 ? in_conn / maximum(in_conn) : 0.0
     A[:, 3] .= maximum(out_conn) != 0.0 ? out_conn / maximum(out_conn) : 0.0
@@ -407,12 +407,12 @@ function create_seed_matrix(
     min_area::T,
     wt_in_conn_seed::T,
     wt_out_conn_seed::T,
-    wt_waves::T, 
-    wt_heat::T, 
-    wt_predec_seed::T, 
-    wt_predec_zones_seed::T, 
+    wt_waves::T,
+    wt_heat::T,
+    wt_predec_seed::T,
+    wt_predec_zones_seed::T,
     wt_lo_cover::T
-) where {T<:Float64}
+)::Matrix{Union{Float64,Int64}} where {T<:Float64}
     # Define seeding decision matrix, based on copy of A
     SE = copy(A)
 
@@ -468,13 +468,13 @@ Tuple (SH, wsh)
     5. high cover (weights importance of sites with high cover of coral to shade)
 """
 function create_shade_matrix(A::Matrix{Float64},
-    max_area::Vector{Float64}, 
-    wt_conn_shade::T, 
-    wt_waves::T, 
-    wt_heat::T, 
-    wt_predec_shade::T, 
-    wt_predec_zones_shade::T, 
-    wt_hi_cover)where {T<:Float64}
+    max_area::Vector{Float64},
+    wt_conn_shade::T,
+    wt_waves::T,
+    wt_heat::T,
+    wt_predec_shade::T,
+    wt_predec_zones_shade::T,
+    wt_hi_cover)::Matrix{Union{Float64,Int64}} where {T<:Float64}
     # Set up decision matrix to be same size as A
     SH = copy(A)
 
@@ -519,7 +519,7 @@ function guided_site_selection(
     alg_ind::T,
     log_seed::B,
     log_shade::B,
-    prefseedsites::IA, 
+    prefseedsites::IA,
     prefshadesites::IB,
     rankingsin::Matrix{T},
     in_conn::Vector{Float64},
@@ -650,7 +650,7 @@ function guided_site_selection(
 end
 
 """
-    distance_sorting(pref_sites::AbstractArray{Int}, site_order::AbstractVector, dist::Matrix{Float64}, dist_thresh::Float64)::AbstractArray{Int}
+    distance_sorting( pref_sites::AbstractArray{Int}, s_order::Matrix{Union{Float64,Int64}}, dist::Matrix{Float64}, min_dist::Float64, rankings::Matrix{Int64}, rank_col::Int64)::Tuple{Vector{Union{Float64,Int64}},Matrix{Int64}}
 
 Find selected sites with distances between each other < median distance-dist_thresh*(median distance).
 Replaces these sites with sites in the top ranks if the distance between these sites is greater.
@@ -664,7 +664,10 @@ Replaces these sites with sites in the top ranks if the distance between these s
 # Returns
 - `prefsites` : new set of selected sites for seeding or shading.
 """
-function distance_sorting(pref_sites::AbstractArray{Int}, s_order::Matrix{Union{Float64,Int64}}, dist::Matrix{Float64},
+function distance_sorting(
+    pref_sites::AbstractArray{Int},
+    s_order::Matrix{Union{Float64,Int64}},
+    dist::Matrix{Float64},
     min_dist::Float64,
     rankings::Matrix{Int64},
     rank_col::Int64,
@@ -732,22 +735,26 @@ Randomly select seed/shade site locations for the given year, constraining to si
 Here, `max_cover` represents the max. carrying capacity for each site (the `k` value).
 
 # Arguments
-- `prefseedsites` : Previously selected sites
+- `pref_seed_locs` : Previously selected seeding locations
+- `pref_shade_locs` : Previously selected shading locations
 - `seed_years` : bool, indicating whether to seed this year or not
 - `shade_years` : bool, indicating whether to shade this year or not
 - `n_site_int` : int, number of sites to intervene on
 - `available_space` : vector/matrix : space available at each site (`k` value)
 - `depth` : vector of site ids found to be within desired depth range
+
+# Returns
+Tuple, of vectors indicating preferred seeding and shading locations by location index
 """
 function unguided_site_selection(
-    prefseedsites,
-    prefshadesites,
+    pref_seed_locs,
+    pref_shade_locs,
     seed_years,
     shade_years,
     n_site_int,
-    available_space, 
+    available_space,
     depth
-)
+)::Tuple
     # Unguided deployment, seed/shade corals anywhere so long as available_space > 0.0
     # Only sites that have available space are considered, otherwise a zero-division error may occur later on.
 
@@ -757,14 +764,14 @@ function unguided_site_selection(
     s_n_site_int = num_sites < n_site_int ? num_sites : n_site_int
 
     if seed_years
-        prefseedsites = zeros(Int64, n_site_int)
-        prefseedsites[1:s_n_site_int] .= StatsBase.sample(candidate_sites, s_n_site_int; replace=false)
+        pref_seed_locs = zeros(Int64, n_site_int)
+        pref_seed_locs[1:s_n_site_int] .= StatsBase.sample(candidate_sites, s_n_site_int; replace=false)
     end
 
     if shade_years
-        prefshadesites = zeros(Int64, n_site_int)
-        prefshadesites[1:s_n_site_int] .= StatsBase.sample(candidate_sites, s_n_site_int; replace=false)
+        pref_shade_locs = zeros(Int64, n_site_int)
+        pref_shade_locs[1:s_n_site_int] .= StatsBase.sample(candidate_sites, s_n_site_int; replace=false)
     end
 
-    return prefseedsites[prefseedsites.>0], prefshadesites[prefshadesites.>0]
+    return pref_seed_locs[pref_seed_locs.>0], pref_shade_locs[pref_shade_locs.>0]
 end

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -77,8 +77,8 @@ Constuctors for DMCDA variables.
 function DMCDA_vars(
     domain::Domain, 
     criteria::NamedDimsArray,
-    site_ids::AbstractArray, 
-    sum_cover::AbstractArray, 
+    site_ids::AbstractArray,
+    sum_cover::AbstractArray,
     area_to_seed::Float64,
     waves::AbstractArray, 
     dhws::AbstractArray
@@ -182,9 +182,7 @@ end
 
 Align a vector of site rankings to match the indicated order in `s_order`.
 """
-function align_rankings!(rankings::Array, 
-    s_order::Matrix, 
-    col::Int64)::Nothing
+function align_rankings!(rankings::Array, s_order::Matrix, col::Int64)::Nothing
     # Fill target ranking column
     for (i, site_id) in enumerate(s_order[:, 1])
         rankings[rankings[:, 1].==site_id, col] .= i

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -233,9 +233,8 @@ Counts for location selection at each location in the domain.
 function location_selection_frequencies(
     ranks::NamedDimsArray;
     n_loc_int::Int64=5,
-    agg_func=nothing,
 )
-    ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_loc_int, agg_func=agg_func)
+    ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_loc_int)
     loc_count = sum(ranks_frequencies[ranks=1:n_loc_int], dims=2)[ranks=1]
 
     return loc_count

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -256,6 +256,9 @@ function location_selection_frequencies(
     return loc_count
 end
 
+"""Drop single dimensions."""
+_drop_single(x::AbstractMatrix) = dropdims(x, dims=(findall(size(x) .== 1)...,))
+
 """
     selection_score(ranks::NamedDimsArray{D,T,3,A}; dims::Vector{Symbol}=[:scenarios, :timesteps]) where {D,T,A}
     selection_score(ranks::NamedDimsArray{D,T,2,A}) where {D,T,A}
@@ -277,13 +280,13 @@ function selection_score(
     ranks::NamedDimsArray{D,T,3,A};
     dims::Vector{Symbol}=[:scenarios, :timesteps],
 ) where {D,T,A}
-    return selection_score(ranks, dims)
+    return _drop_single(selection_score(ranks, dims))
 end
 function selection_score(
     ranks::NamedDimsArray{D,T,2,A};
     dims::Vector{Symbol}=[:scenarios],
 ) where {D,T,A}
-    return selection_score(ranks, dims)
+    return _drop_single(selection_score(ranks, dims))
 end
 function selection_score(
     ranks::NamedDimsArray,

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -260,30 +260,21 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 
 """
 function summed_inverse_rank(
+    ranks::NamedDimsArray{D,T,3,A};
+    dims::Union{Symbol,Vector{Symbol}}=[:scenarios, :timsteps],
+) where {D,T,A}
+    return summed_inverse_rank(ranks, dims)
+end
+function summed_inverse_rank(
+    ranks::NamedDimsArray{D,T,2,A};
+) where {D,T,A}
+    return summed_inverse_rank(ranks, dims)
+end
+function summed_inverse_rank(
     ranks::NamedDimsArray,
-    iv_type::String;
-    dims::Symbol=:scenarios,
-    agg_func::Function=x -> x,
-)
-    selected_ranks = _get_iv_type(ranks, iv_type)
-    return summed_inverse_rank(selected_ranks; dims=dims,agg_func=agg_func)
-
-end
-function summed_inverse_rank(
-    rs::ResultSet, iv_type::String; dims::Symbol=:scenarios, agg_func::Function=x -> x
-)
-    selected_ranks = _get_iv_type(rs.ranks, iv_type)
-    return summed_inverse_rank(selected_ranks; dims=dims,agg_func=agg_func)
-
-end
-function summed_inverse_rank(
-    ranks::NamedDimsArray; dims::Symbol=:scenarios, agg_func::Function=x -> x
+    dims::Union{Symbol,Vector{Symbol}},
 )
     n_ranks = maximum(ranks)
-    inv_ranks = agg_func(dropdims(sum(n_ranks .- ranks,dims=dims),dims=dims))
-    return inv_ranks
+    inv_ranks = dropdims(sum(n_ranks .- ranks; dims=dims); dims=dims)
+    return inv_ranks ./ n_ranks
 end
-
-
-"""
-    _get_iv_type(ranks, iv_type)

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -153,7 +153,8 @@ function ranks_to_location_order(ranks::NamedDimsArray)
     end
     return location_orders
 end
-function ranks_to_location_order(ranks::NamedDimsArray, iv_type::String)
+function ranks_to_location_order(ranks::NamedDimsArray, 
+    iv_type::String)
     ranks_set = _get_iv_type(ranks, iv_type)
     return ranks_to_location_order(ranks_set)
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -230,7 +230,7 @@ set of scenarios.
 
 # Arguments
 - `ranks` : Rankings of locations `rank_locations()`
-- `n_loc_int` : number of locations which are intervened at for each intervention decision
+- `n_loc_int` : number of locations intervened at, for each decision point
 - `iv_log` : Intervention logs
 - `dims` : dimensions to sum selection frequencies over
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -177,7 +177,7 @@ function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
 end
 function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,3,A};
-    n_ranks=length(ranks.sites),
+    n_ranks::Int64=length(ranks.sites),
     agg_func=nothing,
 ) where {D,T,A}
     if !isnothing(agg_func)
@@ -188,7 +188,7 @@ function ranks_to_frequencies(
 end
 function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,2,A};
-    n_ranks=length(ranks.sites),
+    n_ranks::Int64=length(ranks.sites),
     agg_func=nothing,
 ) where {D,T,A}
     if !isnothing(agg_func)

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -287,34 +287,3 @@ end
 
 """
     _get_iv_type(ranks, iv_type)
-
-Get ranks for intervention based on name.
-    
-# Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
-- `iv_type` : indicates intervention log to use ("seed", "shade" or "fog").
-
-# Returns
-- Ranks for specified iv_type.
-"""
-function _get_iv_type(ranks::NamedDimsArray, iv_type::String)
-    iv_dict = Dict([("seed", 1), ("shade", 2)])
-    return ranks[intervention=iv_dict[iv_type]]
-end
-
-"""
-    _get_scen_ids(ranks)
-
-Get ranks for intervention based on name.
-    
-# Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
-
-# Returns
-- Ids for full scenario set in ranks.
-"""
-function _get_scen_ids(ranks::NamedDimsArray)
-    return collect(ranks.scenarios)
-end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -120,7 +120,7 @@ function run_site_selection(domain::Domain,
     sum_cover::NamedDimsArray, 
     area_to_seed::Float64, 
     aggregation_function::Function, 
-    iv_type::String;
+    iv_type::Union{String,Int64};
     target_seed_sites=nothing, 
     target_shade_sites=nothing)
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -270,6 +270,6 @@ function selection_score(
     dims::Vector{Symbol},
 )
     lowest_rank = maximum(ranks)
-    inv_ranks = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
-    return inv_ranks ./ (lowest_rank * prod([size(ranks, d) for d in dims]))
+    selection_score = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
+    return selection_score ./ (lowest_rank * prod([size(ranks, d) for d in dims]))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -271,5 +271,5 @@ function selection_score(
 )
     lowest_rank = maximum(ranks)
     selection_score = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
-    return selection_score ./ (lowest_rank * prod([size(ranks, d) for d in dims]))
+    return selection_score ./ ((lowest_rank - 1) * prod([size(ranks, d) for d in dims]))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -221,7 +221,7 @@ function ranks_to_frequencies(
 end
 
 """
-    location_selection_frequencies(ranks::NamedDimsArray; n_loc_int::Int64=5)
+    location_selection_frequencies(ranks::NamedDimsArray; n_iv_locs::Int64=5)
     location_selection_frequencies(iv_log::NamedDimsArray{D,T,4,A}; dims::Union{Symbol,Vector{Symbol}}=:coral_id) where {D,T,A}
 
 Determines the count of times each location was selected for a specific intervention over a
@@ -229,7 +229,7 @@ set of scenarios.
 
 # Arguments
 - `ranks` : Rankings of locations `rank_locations()`
-- `n_loc_int` : number of locations intervened at, for each decision point
+- `n_iv_locs` : number of locations intervened at, for each decision point
 - `iv_log` : Intervention logs
 - `dims` : dimensions to sum selection frequencies over
 
@@ -238,10 +238,10 @@ Number of times each location was selected for an intervention.
 """
 function location_selection_frequencies(
     ranks::NamedDimsArray;
-    n_loc_int::Int64=5,
+    n_iv_locs::Int64=5,
 )::NamedDimsArray
-    ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_loc_int)
-    loc_count = sum(ranks_frequencies[ranks=1:n_loc_int], dims=2)[ranks=1]
+    ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_iv_locs)
+    loc_count = sum(ranks_frequencies[ranks=1:n_iv_locs], dims=2)[ranks=1]
 
     return loc_count
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -338,7 +338,7 @@ Get ranks for intervention based on name.
 # Returns
 - Ranks for specified iv_type.
 """
-function _get_iv_type(ranks, iv_type)
+function _get_iv_type(ranks::NamedDimsArray, iv_type::String)
     iv_dict = Dict([("seed", 1), ("shade", 2)])
     return ranks[intervention=iv_dict[iv_type]]
 end
@@ -355,6 +355,6 @@ Get ranks for intervention based on name.
 # Returns
 - Ids for full scenario set in ranks.
 """
-function _get_scen_ids(ranks)
+function _get_scen_ids(ranks::NamedDimsArray)
     return collect(ranks.scenarios)
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -146,7 +146,6 @@ function rank_locations(
         target_seed_sites=target_seed_sites,
         target_shade_sites=target_shade_sites,
     )
-
     local iv_id
     try
         iv_id = axiskeys(ranks, :intervention)[iv_type]

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -180,8 +180,8 @@ function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
     freq_dims = [n for n in dn if n != :scenarios]
     dn_subset = vcat(freq_dims, [:ranks])
     freq_elements = vcat(
-        [1:length(axiskeys(ranks, n)) for n in dn if n != :scenarios],
-        [1:length(axiskeys(ranks, :sites))],
+        [1:size(ranks, n) for n in dn if n != :scenarios],
+        [1:size(ranks, :sites)],
     )
     mn = ([size(ranks, k) for k in freq_dims]..., size(ranks, :sites))
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -2,7 +2,7 @@ using NamedDims, AxisKeys
 
 
 """
-    _site_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)
+    _location_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)
 
 Perform site selection using a chosen aggregation method, domain, initial cover, criteria weightings and thresholds.
 
@@ -15,7 +15,8 @@ Perform site selection using a chosen aggregation method, domain, initial cover,
 `ranks` : n_reps * sites * 3 (last dimension indicates: site_id, seeding rank, shading rank)
     containing ranks for single scenario.
 """
-function _site_selection(domain::Domain, 
+function _location_selection(
+    domain::Domain,
     mcda_vars::DMCDA_vars, 
     guided::Int64)
     
@@ -41,12 +42,12 @@ function _site_selection(domain::Domain,
 end
 
 """
-    run_site_selection(domain::Domain, scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64;
+    rank_locations(domain::Domain, scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64;
         target_seed_sites=nothing, target_shade_sites=nothing)
-    run_site_selection(domain::Domain,scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64, aggregation_function::Function, 
+    rank_locations(domain::Domain,scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64, aggregation_function::Function, 
         iv_type::Union{String,Int64};target_seed_sites=nothing, target_shade_sites=nothing)
 
-Perform site selection for a given domain for multiple scenarios defined in a dataframe.
+Get location rankings for a given domain for multiple scenarios defined in a dataframe.
 
 # Arguments
 - `domain` : ADRIA Domain type, indicating geographical domain to perform site selection over.
@@ -61,7 +62,8 @@ Perform site selection for a given domain for multiple scenarios defined in a da
 -`ranks_store` : number of scenarios * sites * 3 (last dimension indicates: site_id, seed rank, shade rank)
     containing ranks for each scenario run.
 """
-function run_site_selection(domain::Domain, 
+function rank_locations(
+    domain::Domain,
     scenarios::DataFrame, 
     sum_cover::NamedDimsArray, 
     area_to_seed::Float64;
@@ -105,7 +107,7 @@ function run_site_selection(domain::Domain,
             vec((mean(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios)) .+ std(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios))) .* 0.5),
             )
 
-        ranks_store(; scenarios=scen_idx, sites=considered_sites) .= _site_selection(
+        ranks_store(; scenarios=scen_idx, sites=considered_sites) .= _location_selection(
             domain, mcda_vars_temp, scen.guided
         )
     end
@@ -115,7 +117,8 @@ function run_site_selection(domain::Domain,
     return ranks_store
 
 end
-function run_site_selection(domain::Domain, 
+function rank_locations(
+    domain::Domain,
     scenarios::DataFrame, 
     sum_cover::NamedDimsArray, 
     area_to_seed::Float64, 
@@ -124,7 +127,8 @@ function run_site_selection(domain::Domain,
     target_seed_sites=nothing, 
     target_shade_sites=nothing)
 
-    ranks = run_site_selection(domain, 
+    ranks = rank_locations(
+        domain,
         scenarios, 
         sum_cover, 
         area_to_seed; 
@@ -142,11 +146,11 @@ end
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,3,A};n_ranks=length(ranks.sites),agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),) where {D,T,A}
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,2,A};n_ranks=length(ranks.sites),agg_func=nothing) where {D,T,A}
 
-Post-processing for location ranks output of `run_location_selection()`. Gives the frequency 
+Post-processing for location ranks output of `rank_locations()`. Gives the frequency 
 with which each location was selected at each rank across the location selection scenarios.
 
 # Arguments
-- `ranks` : Rankings of locations `run_location_selection()`.
+- `ranks` : Rankings of locations `rank_locations()`.
 - `n_ranks` : number of rankings (defualt is number of locations).
 - `agg_func` : Aggregation function to appy after frequencies are calculated.
 
@@ -198,7 +202,7 @@ Post-process intervention logs. Calculates the frequencies with which locations 
 for a selection of scenarios (e.g. selected robust scenarios).
 
 # Arguments
-- `ranks` : Rankings of locations `run_location_selection()`.
+- `ranks` : Rankings of locations `rank_locations()`.
 - `n_loc_int` : number of locations which are intervened at for each intervention decision.
 - `dims` : dimensions to sum selection frequencies over.
 
@@ -235,7 +239,7 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
     (default no transformation).
 
 # Arguments
-- `ranks` : Rankings of locations `run_location_selection()`.
+- `ranks` : Rankings of locations `rank_locations()`.
 - `dims` : Dimensions to sum over.
 
 # Returns 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -249,7 +249,8 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 - `dims` : Dimensions to sum over.
 
 # Returns 
-Inverse rankings (i.e. the greater the number the higher ranked the site).
+Inverse rankings (i.e. for ranks the lowest value is the highest rank, 
+in the inverse ranks the greater the number the higher ranked the location).
 """
 function summed_inverse_rank(
     ranks::NamedDimsArray{D,T,3,A};
@@ -267,7 +268,7 @@ function summed_inverse_rank(
     ranks::NamedDimsArray,
     dims::Vector{Symbol},
 )
-    max_ranks = maximum(ranks)
-    inv_ranks = dropdims(sum(max_ranks .- ranks; dims=dims); dims=dims[1])
-    return inv_ranks ./ (max_ranks * prod([size(ranks, d) for d in dims]))
+    lowest_rank = maximum(ranks)
+    inv_ranks = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
+    return inv_ranks ./ (lowest_rank * prod([size(ranks, d) for d in dims]))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -34,7 +34,7 @@ function _location_selection(
     in_conn, out_conn, strong_pred = connectivity_strength(domain.TP_data .* site_k_area(domain), Array(mcda_vars.sum_cover))
 
     # Perform location selection for seeding and shading.
-    seed_true, shade_true = [true, true]
+    seed_true, shade_true = true, true
 
     (_, _, ranks) = guided_site_selection(mcda_vars, guided, seed_true, shade_true, prefseedsites, prefshadesites, rankingsin, in_conn[site_ids], out_conn[site_ids], strong_pred[site_ids])
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -245,7 +245,7 @@ function location_selection_frequencies(
     dims::Union{Symbol,Vector{Symbol}}=:coral_id,
 ) where {D,T,A}
     loc_count = dropdims(
-        sum(dropdims(sum(inv_log; dims=dim); dims=dims) .> 0; dims=:scenarios);
+        sum(dropdims(sum(inv_log; dims=dims); dims=dims) .> 0; dims=:scenarios);
         dims=:scenarios,
     )
     return loc_count

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -148,6 +148,8 @@ end
 
 Post-processing for location ranks output of `rank_locations()`. Gives the frequency 
 with which each location was selected at each rank across the location selection scenarios.
+Note : default output for 3D input case includes the timestep dimension. To aggregate over time use,
+`agg_func = x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps)`.
 
 # Arguments
 - `ranks` : Rankings of locations `rank_locations()`.

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -188,7 +188,7 @@ function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
     rank_frequencies = NamedDimsArray(zeros(mn...); zip(dn_subset, freq_elements)...)
 
     for rank in 1:n_ranks
-        rank_frequencies[ranks=Int64(rank)] .= vec(sum(ranks .== rank; dims=:scenarios))
+        rank_frequencies[ranks=Int64(rank)] .= sum(ranks .== rank; dims=:scenarios)[scenarios=1]
     end
 
     return rank_frequencies

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -105,6 +105,8 @@ function run_site_selection(domain::Domain,
     
         ranks_store(scenarios=scen_idx, sites=domain.site_ids[considered_sites]) .= _site_selection(domain, mcda_vars_temp, scen.guided)
     end
+    # Set filtered locations as n_locs+1 for consistency with time dependent ranks
+    ranks_store[ranks_store.==0.0] .= length(domain.site_ids)+1
 
     return ranks_store
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -120,7 +120,7 @@ function run_site_selection(domain::Domain,
     sum_cover::NamedDimsArray, 
     area_to_seed::Float64, 
     aggregation_function::Function, 
-    iv_type::String;
+    iv_type::Int64;
     target_seed_sites=nothing, 
     target_shade_sites=nothing)
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -5,12 +5,12 @@ using NamedDims, AxisKeys
     _location_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)::Matrix
 
 Select locations for a given domain and criteria/weightings/thresholds, using a chosen
-aggregation method.
+MCDA method.
 
 # Arguments
 - `domain` : The geospatial domain to assess
 - `mcda_vars` : Parameters for MCDA
-- `guided` : ID of aggregation algorithm to apply
+- `guided` : ID of MCDA algorithm to apply
 
 # Returns
 Matrix[n_sites ⋅ 2], where columns hold seeding and shading ranks for each location.
@@ -60,10 +60,10 @@ Return location ranks for a given domain and scenarios.
 # Arguments
 - `domain` : The geospatial domain locations were selected from
 - `scenarios` : Scenario specification
-- `sum_cover` : Matrix[n_scenarios ⋅ n_sites] containing the total coral cover for each
+- `sum_cover` : Matrix[n_scenarios ⋅ n_sites] containing the total coral cover at each
     location, for each scenario
 - `area_to_seed` : Area of coral to be seeded at each time step in km²
-- `agg_func` : Aggregation function to apply, e.g `ranks_to_frequencies`,
+- `agg_func` : Aggregation function to apply, e.g `ranks_to_frequencies` or
     `ranks_to_location_order`
 - `iv_type` : ID of intervention (1 = seeding, 2 = fogging)
 - `target_seed_sites` : list of candidate locations for seeding (indices)
@@ -166,9 +166,8 @@ end
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,3,A}; n_ranks=length(ranks.sites), agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),) where {D,T,A}
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,2,A}; n_ranks=length(ranks.sites), agg_func=nothing) where {D,T,A}
 
-Post-process location ranks as given by `rank_locations()`.
-
 Returns the frequency with which each location was ranked across scenarios.
+Uses the results from `rank_locations()`.
 
 Note: By default, ranks are aggregated over time where `ranks` is a 3-dimensional array.
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -11,9 +11,6 @@ Perform site selection using a chosen aggregation method, domain, initial cover,
 - `mcda_vars` : Contains relevant parameters for performing guided location selection.
 - `guided` : Integer indicating aggegation algorithm to use for guided location selection.
 
-# Returns
-- `ranks` : n_reps * sites * 3 (last dimension indicates: site_id, seeding rank, shading rank)
-    containing ranks for single scenario.
 """
 function _site_selection(domain::Domain, 
     mcda_vars::DMCDA_vars, 
@@ -57,9 +54,6 @@ Perform site selection for a given domain for multiple scenarios defined in a da
 - `target_seed_sites` : list of candidate locations for seeding (indices)
 - `target_shade_sites` : list of candidate location to shade (indices)
 
-# Returns
-- `ranks_store` : number of scenarios * sites * 3 (last dimension indicates: site_id, seed rank, shade rank)
-    containing ranks for each scenario run.
 """
 function run_site_selection(domain::Domain, 
     scenarios::DataFrame, 
@@ -144,8 +138,6 @@ of location preference for each scenario as location ids.
     `run_location_selection()`.
 - `iv_type` : String indicating the intervention type to perform aggregation on.
 
-# Returns
-- Location order after ranking as string IDs for each scenario.
 """
 function ranks_to_location_order(ranks::NamedDimsArray)
 
@@ -175,8 +167,6 @@ with which each location was selected at each rank across the location selection
 - `rs` : ADRIA result set.
 - `iv_type` : String indicating the intervention type to perform aggregation on.
 
-# Returns
-- Frequency with which each location was selected for each rank.
 """
 function ranks_to_frequencies(
     ranks::NamedDimsArray,
@@ -251,8 +241,6 @@ for a selection of scenarios (e.g. selected robust scenarios).
 - `iv_type` : indicates intervention log to use ("seed", "shade" or "fog").
 - `n_loc_int` : number of locations which are intervened at for each intervention decision.
 
-# Returns 
-- Counts for location selection at each location in the domain.
 """
 function location_selection_frequencies(
     ranks::NamedDimsArray,
@@ -299,8 +287,6 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 - `dims` : Dimensions to sum over.
 - `agg_func` : function to transform result.
 
-# Returns 
-- Inverse rankings (i.e. the greater the number the higher ranked the site).
 """
 function summed_inverse_rank(
     ranks::NamedDimsArray,

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -142,7 +142,7 @@ end
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,3,A};n_ranks=length(ranks.sites),agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),) where {D,T,A}
     ranks_to_frequencies(ranks::NamedDimsArray{D,T,2,A};n_ranks=length(ranks.sites),agg_func=nothing) where {D,T,A}
 
-Post-processing function for location ranks output of `run_location_selection()`. Gives the frequency 
+Post-processing for location ranks output of `run_location_selection()`. Gives the frequency 
 with which each location was selected at each rank across the location selection scenarios.
 
 # Arguments
@@ -195,7 +195,7 @@ end
     location_selection_frequencies(ranks::NamedDimsArray;n_loc_int::Int64=5)
     location_selection_frequencies(inv_log::NamedDimsArray{D,T,4,A};dims::Union{Symbol,Vector{Symbol}}=:coral_id) where {D,T,A}
 
-Post-processing function for intervention logs. Calculates the frequencies with which locations were selected for a particular intervention,
+Post-process intervention logs. Calculates the frequencies with which locations were selected for a particular intervention,
 for a selection of scenarios (e.g. selected robust scenarios).
 
 # Arguments

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -265,7 +265,7 @@ function summed_inverse_rank(
     ranks::NamedDimsArray,
     dims::Vector{Symbol},
 )
-    n_ranks = maximum(ranks)
-    inv_ranks = dropdims(sum(n_ranks .- ranks; dims=dims); dims=dims[1])
-    return inv_ranks ./ (n_ranks * prod([size(ranks, d) for d in dims]))
+    max_ranks = maximum(ranks)
+    inv_ranks = dropdims(sum(max_ranks .- ranks; dims=dims); dims=dims[1])
+    return inv_ranks ./ (max_ranks * prod([size(ranks, d) for d in dims]))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -178,9 +178,13 @@ end
 function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,3,A};
     n_ranks=length(ranks.sites),
-    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
+    agg_func=nothing,
 ) where {D,T,A}
-    return agg_func(ranks_to_frequencies(ranks, n_ranks))
+    if !isnothing(agg_func)
+        return agg_func(ranks_to_frequencies(ranks, n_ranks))
+    end
+
+    return ranks_to_frequencies(ranks, n_ranks)
 end
 function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,2,A};

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -196,7 +196,7 @@ end
 function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,3,A};
     n_ranks=length(ranks.sites),
-    agg_func=x -> sum(x; dims=(:timesteps, :scenarios)),
+    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
 ) where {D,T,A}
     return agg_func(ranks_to_frequencies(ranks, n_ranks))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -122,8 +122,8 @@ function run_site_selection(domain::Domain,
         scenarios, 
         sum_cover, 
         area_to_seed; 
-        target_seed_sites=nothing,
-        target_shade_sites=nothing)
+        target_seed_sites=target_seed_sites,
+        target_shade_sites=target_shade_sites)
     return aggregation_function(ranks, iv_type)
 
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -317,10 +317,8 @@ end
 function summed_inverse_rank(ranks::NamedDimsArray; 
     dims::Symbol=:scenarios,
     agg_func::Function=x->x)
-
-    n_locs = size(ranks,1)
-    inv_ranks = agg_func(sum(ranks .- n_locs,dims=dims))
-    inv_ranks[inv_ranks.<0.0] .= 0.0
+    n_ranks = maximum(ranks)
+    inv_ranks = agg_func(dropdims(sum(n_ranks .- ranks,dims=dims),dims=dims))
     return inv_ranks
 end
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -149,10 +149,7 @@ function ranks_to_location_order(ranks::NamedDimsArray)
     end
     return location_orders
 end
-function ranks_to_location_order(ranks::NamedDimsArray, iv_type::String)
-    ranks_set = _get_iv_type(ranks, iv_type)
-    return ranks_to_location_order(ranks_set)
-end
+
 
 """
     ranks_to_frequencies(ranks::NamedDimsArray, iv_type::String; n_ranks=length(ranks.sites))

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -246,20 +246,21 @@ Inverse rankings (i.e. the greater the number the higher ranked the site).
 """
 function summed_inverse_rank(
     ranks::NamedDimsArray{D,T,3,A};
-    dims::Union{Symbol,Vector{Symbol}}=[:scenarios, :timsteps],
+    dims::Vector{Symbol}=[:scenarios, :timesteps],
 ) where {D,T,A}
     return summed_inverse_rank(ranks, dims)
 end
 function summed_inverse_rank(
     ranks::NamedDimsArray{D,T,2,A};
+    dims::Vector{Symbol}=[:scenarios],
 ) where {D,T,A}
     return summed_inverse_rank(ranks, dims)
 end
 function summed_inverse_rank(
     ranks::NamedDimsArray,
-    dims::Union{Symbol,Vector{Symbol}},
+    dims::Vector{Symbol},
 )
     n_ranks = maximum(ranks)
-    inv_ranks = dropdims(sum(n_ranks .- ranks; dims=dims); dims=dims)
-    return inv_ranks ./ n_ranks
+    inv_ranks = dropdims(sum(n_ranks .- ranks; dims=dims); dims=dims[1])
+    return inv_ranks ./ (n_ranks * prod([size(ranks, d) for d in dims]))
 end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -236,10 +236,10 @@ function location_selection_frequencies(
 end
 
 """
-    summed_inverse_rank(ranks::NamedDimsArray{D,T,3,A};dims::Union{Symbol,Vector{Symbol}}=[:scenarios, :timsteps],
+    selection_score(ranks::NamedDimsArray{D,T,3,A};dims::Union{Symbol,Vector{Symbol}}=[:scenarios, :timsteps],
             ) where {D,T,A}
-    summed_inverse_rank(ranks::NamedDimsArray{D,T,2,A};) where {D,T,A}
-    summed_inverse_rank(ranks::NamedDimsArray,dims::Union{Symbol,Vector{Symbol}},)
+    selection_score(ranks::NamedDimsArray{D,T,2,A};) where {D,T,A}
+    selection_score(ranks::NamedDimsArray,dims::Union{Symbol,Vector{Symbol}},)
 
 Calculates (number of sites) .- ranks summed over the dimension dims and transformed using agg_func 
     (default no transformation).
@@ -249,22 +249,23 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 - `dims` : Dimensions to sum over.
 
 # Returns 
-Inverse rankings (i.e. for ranks the lowest value is the highest rank, 
-in the inverse ranks the greater the number the higher ranked the location).
+Selection score (i.e. for ranks the lowest value is the highest rank, 
+in the selection score the greater the number the higher ranked and more 
+frequently selected the location).
 """
-function summed_inverse_rank(
+function selection_score(
     ranks::NamedDimsArray{D,T,3,A};
     dims::Vector{Symbol}=[:scenarios, :timesteps],
 ) where {D,T,A}
-    return summed_inverse_rank(ranks, dims)
+    return selection_score(ranks, dims)
 end
-function summed_inverse_rank(
+function selection_score(
     ranks::NamedDimsArray{D,T,2,A};
     dims::Vector{Symbol}=[:scenarios],
 ) where {D,T,A}
-    return summed_inverse_rank(ranks, dims)
+    return selection_score(ranks, dims)
 end
-function summed_inverse_rank(
+function selection_score(
     ranks::NamedDimsArray,
     dims::Vector{Symbol},
 )

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -11,6 +11,9 @@ Perform site selection using a chosen aggregation method, domain, initial cover,
 - `mcda_vars` : Contains relevant parameters for performing guided location selection.
 - `guided` : Integer indicating aggegation algorithm to use for guided location selection.
 
+# Returns
+`ranks` : n_reps * sites * 3 (last dimension indicates: site_id, seeding rank, shading rank)
+    containing ranks for single scenario.
 """
 function _site_selection(domain::Domain, 
     mcda_vars::DMCDA_vars, 
@@ -54,6 +57,9 @@ Perform site selection for a given domain for multiple scenarios defined in a da
 - `target_seed_sites` : list of candidate locations for seeding (indices)
 - `target_shade_sites` : list of candidate location to shade (indices)
 
+# Returns
+-`ranks_store` : number of scenarios * sites * 3 (last dimension indicates: site_id, seed rank, shade rank)
+    containing ranks for each scenario run.
 """
 function run_site_selection(domain::Domain, 
     scenarios::DataFrame, 
@@ -138,6 +144,8 @@ of location preference for each scenario as location ids.
     `run_location_selection()`.
 - `iv_type` : String indicating the intervention type to perform aggregation on.
 
+# Returns
+Location order after ranking as string IDs for each scenario.
 """
 function ranks_to_location_order(ranks::NamedDimsArray)
 
@@ -164,6 +172,8 @@ with which each location was selected at each rank across the location selection
 - `rs` : ADRIA result set.
 - `iv_type` : String indicating the intervention type to perform aggregation on.
 
+# Returns
+Frequency with which each location was selected for each rank.
 """
 function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
     dn = NamedDims.dimnames(ranks)
@@ -217,6 +227,8 @@ for a selection of scenarios (e.g. selected robust scenarios).
 - `iv_type` : indicates intervention log to use ("seed", "shade" or "fog").
 - `n_loc_int` : number of locations which are intervened at for each intervention decision.
 
+# Returns 
+Counts for location selection at each location in the domain.
 """
 function location_selection_frequencies(
     ranks::NamedDimsArray;
@@ -255,6 +267,8 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 - `dims` : Dimensions to sum over.
 - `agg_func` : function to transform result.
 
+# Returns 
+Inverse rankings (i.e. the greater the number the higher ranked the site).
 """
 function summed_inverse_rank(
     ranks::NamedDimsArray{D,T,3,A};

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -155,8 +155,7 @@ function ranks_to_location_order(ranks::NamedDimsArray)
     end
     return location_orders
 end
-function ranks_to_location_order(ranks::NamedDimsArray, 
-    iv_type::String)
+function ranks_to_location_order(ranks::NamedDimsArray, iv_type::String)
     ranks_set = _get_iv_type(ranks, iv_type)
     return ranks_to_location_order(ranks_set)
 end
@@ -177,27 +176,27 @@ with which each location was selected at each rank across the location selection
 # Returns
 - Frequency with which each location was selected for each rank.
 """
-function ranks_to_frequencies(ranks::NamedDimsArray, 
-    rank_frequencies::NamedDimsArray; 
-    n_ranks::Int64=length(ranks.sites))
+function ranks_to_frequencies(
+    ranks::NamedDimsArray,
+    rank_frequencies::NamedDimsArray;
+    n_ranks::Int64=length(ranks.sites),
+)
 
     for rank in range(1, n_ranks, n_ranks)
         rank_frequencies[ranks=Int64(rank)] .= sum(ranks .== rank, dims=:scenarios)[scenarios=1]
     end
     return rank_frequencies
 end
-function ranks_to_frequencies(ranks::NamedDimsArray, 
-    iv_type::String; 
-    n_ranks::Int64=length(ranks.sites))
-
+function ranks_to_frequencies(
+    ranks::NamedDimsArray, iv_type::String; n_ranks::Int64=length(ranks.sites)
+)
     selected_ranks = _get_iv_type(ranks, iv_type)
     rank_frequencies = NamedDimsArray(zeros(length(ranks.sites), length(ranks.sites)), sites=ranks.sites, ranks=1:length(ranks.sites))
     return ranks_to_frequencies(selected_ranks, rank_frequencies; n_ranks=n_ranks)
 end
-function ranks_to_frequencies(rs::ResultSet, 
-    iv_type::String; 
-    n_ranks=length(rs.ranks.sites))
-
+function ranks_to_frequencies(
+    rs::ResultSet, iv_type::String; n_ranks=length(rs.ranks.sites)
+)
     return sum(ranks_to_frequencies_ts(rs, iv_type; n_ranks=n_ranks), dims=:timesteps)[timesteps=1]
 end
 
@@ -218,23 +217,19 @@ with which each location was selected at each rank across the location selection
 # Returns 
 - Frequency with which each location was selected for each rank over time.
 """
-function ranks_to_frequencies_ts(ranks::NamedDimsArray; 
-    n_ranks::Int64=length(ranks.sites))
-
+function ranks_to_frequencies_ts(ranks::NamedDimsArray; n_ranks::Int64=length(ranks.sites))
     rank_frequencies = NamedDimsArray(zeros(length(ranks.timesteps), length(ranks.sites), length(ranks.sites)), timesteps=ranks.timesteps, sites=ranks.sites, ranks=1:length(ranks.sites))
     return ranks_to_frequencies(ranks, rank_frequencies; n_ranks=n_ranks)
 end
-function ranks_to_frequencies_ts(ranks::NamedDimsArray, 
-    iv_type::String; 
-    n_ranks=length(ranks.sites))
-
+function ranks_to_frequencies_ts(
+    ranks::NamedDimsArray, iv_type::String; n_ranks=length(ranks.sites)
+)
     selected_ranks = _get_iv_type(ranks, iv_type)
     return ranks_to_frequencies_ts(selected_ranks; n_ranks=n_ranks)
 end
-function ranks_to_frequencies_ts(rs::ResultSet, 
-    iv_type::String; 
-    n_ranks=length(rs.ranks.sites))
-
+function ranks_to_frequencies_ts(
+    rs::ResultSet, iv_type::String; n_ranks=length(rs.ranks.sites)
+)
     selected_ranks = _get_iv_type(rs.ranks, iv_type)
     return ranks_to_frequencies_ts(selected_ranks; n_ranks=n_ranks)
 end
@@ -257,21 +252,23 @@ for a selection of scenarios (e.g. selected robust scenarios).
 # Returns 
 - Counts for location selection at each location in the domain.
 """
-function location_selection_frequencies(ranks::NamedDimsArray, 
-    iv_type::String; 
-    n_loc_int::Int64=5, 
-    ind_metrics::Vector{Int64}=_get_scen_ids(ranks))
-
+function location_selection_frequencies(
+    ranks::NamedDimsArray,
+    iv_type::String;
+    n_loc_int::Int64=5,
+    ind_metrics::Vector{Int64}=_get_scen_ids(ranks),
+)
     ranks_frequencies = ranks_to_frequencies(ranks[scenarios=ind_metrics], iv_type; n_ranks=n_loc_int)
     loc_count = sum(ranks_frequencies[ranks=1:n_loc_int], dims=2)[ranks=1]
 
     return loc_count
 end
-function location_selection_frequencies(rs::ResultSet, 
-    iv_type::String; 
-    n_loc_int::Int64=5, 
-    ind_metrics::Vector{Int64}=_get_scen_ids(rs.ranks))
-
+function location_selection_frequencies(
+    rs::ResultSet,
+    iv_type::String;
+    n_loc_int::Int64=5,
+    ind_metrics::Vector{Int64}=_get_scen_ids(rs.ranks),
+)
     selected_ranks = _get_iv_type(rs.ranks[scenarios=ind_metrics], iv_type)
     ranks_frequencies = ranks_to_frequencies_ts(selected_ranks; n_ranks=n_loc_int)
     loc_count = dropdims(sum(ranks_frequencies[ranks=1:n_loc_int], dims=[1, 3]), dims=3)[timesteps=1]
@@ -298,27 +295,26 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
 # Returns 
 - Inverse rankings (i.e. the greater the number the higher ranked the site).
 """
-function summed_inverse_rank(ranks::NamedDimsArray, 
-    iv_type::String; 
-    dims::Symbol=:scenarios, 
-    agg_func::Function=x->x)
-
+function summed_inverse_rank(
+    ranks::NamedDimsArray,
+    iv_type::String;
+    dims::Symbol=:scenarios,
+    agg_func::Function=x -> x,
+)
     selected_ranks = _get_iv_type(ranks, iv_type)
     return summed_inverse_rank(selected_ranks; dims=dims,agg_func=agg_func)
 
 end
-function summed_inverse_rank(rs::ResultSet, 
-    iv_type::String; 
-    dims::Symbol=:scenarios, 
-    agg_func::Function=x->x)
-
+function summed_inverse_rank(
+    rs::ResultSet, iv_type::String; dims::Symbol=:scenarios, agg_func::Function=x -> x
+)
     selected_ranks = _get_iv_type(rs.ranks, iv_type)
     return summed_inverse_rank(selected_ranks; dims=dims,agg_func=agg_func)
 
 end
-function summed_inverse_rank(ranks::NamedDimsArray; 
-    dims::Symbol=:scenarios,
-    agg_func::Function=x->x)
+function summed_inverse_rank(
+    ranks::NamedDimsArray; dims::Symbol=:scenarios, agg_func::Function=x -> x
+)
     n_ranks = maximum(ranks)
     inv_ranks = agg_func(dropdims(sum(n_ranks .- ranks,dims=dims),dims=dims))
     return inv_ranks

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -120,7 +120,7 @@ function run_site_selection(domain::Domain,
     sum_cover::NamedDimsArray, 
     area_to_seed::Float64, 
     aggregation_function::Function, 
-    iv_type::Union{String,Int64};
+    iv_type::String;
     target_seed_sites=nothing, 
     target_shade_sites=nothing)
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -127,33 +127,11 @@ function run_site_selection(domain::Domain,
         sum_cover, 
         area_to_seed; 
         target_seed_sites=target_seed_sites,
-        target_shade_sites=target_shade_sites)
-    return aggregation_function(ranks, iv_type)
+        target_shade_sites=target_shade_sites,
+    )
 
-end
+    return aggregation_function(ranks(; intervention=iv_type))
 
-"""
-    ranks_to_location_order(ranks::NamedDimsArray)
-
-Post-processing function for location ranks output of `run_location_selection()`. Gives the order 
-of location preference for each scenario as location ids.
-
-# Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
-
-# Returns
-Location order after ranking as string IDs for each scenario.
-"""
-function ranks_to_location_order(ranks::NamedDimsArray)
-
-    n_scens = length(ranks.scenarios)
-    location_orders = NamedDimsArray(repeat([""], length(ranks.scenarios), length(ranks.sites)), scenarios=ranks.scenarios, ranks=1:length(ranks.sites))
-
-    for scen in 1:n_scens
-        location_orders[scenarios=scen, ranks=1:sum(ranks[scenarios=scen] .!= 0.0)] .= sort(Int.(ranks[scenarios=scen][ranks[scenarios=scen].!=0.0])).sites
-    end
-    return location_orders
 end
 
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -93,7 +93,6 @@ function run_site_selection(domain::Domain,
         target_site_ids = collect(1:length(domain.site_ids))
     end
 
-    n_sites = length(domain.site_ids)
     for (scen_idx, scen) in enumerate(eachrow(scenarios))
         depth_criteria = (domain.site_data.depth_med .<= (scen.depth_min .+ scen.depth_offset)) .& (domain.site_data.depth_med .>= scen.depth_min)
         depth_priority = findall(depth_criteria)

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -1,3 +1,5 @@
+using NamedDims, AxisKeys
+
 
 """
     _site_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -146,8 +146,7 @@ Post-processing for location ranks output of `run_location_selection()`. Gives t
 with which each location was selected at each rank across the location selection scenarios.
 
 # Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
+- `ranks` : Rankings of locations `run_location_selection()`.
 - `n_ranks` : number of rankings (defualt is number of locations).
 - `agg_func` : Aggregation function to appy after frequencies are calculated.
 
@@ -199,8 +198,7 @@ Post-process intervention logs. Calculates the frequencies with which locations 
 for a selection of scenarios (e.g. selected robust scenarios).
 
 # Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
+- `ranks` : Rankings of locations `run_location_selection()`.
 - `n_loc_int` : number of locations which are intervened at for each intervention decision.
 - `dims` : dimensions to sum selection frequencies over.
 
@@ -237,8 +235,7 @@ Calculates (number of sites) .- ranks summed over the dimension dims and transfo
     (default no transformation).
 
 # Arguments
-- `ranks` : Contains location ranks for each scenario of location selection, as created by 
-    `run_location_selection()`.
+- `ranks` : Rankings of locations `run_location_selection()`.
 - `dims` : Dimensions to sum over.
 
 # Returns 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -179,7 +179,7 @@ Note: By default, ranks are aggregated over time where `ranks` is a 3-dimensiona
 # Returns
 Frequency with which each location was selected for each rank.
 """
-function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
+function ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)::NamedDimsArray
     dn = NamedDims.dimnames(ranks)
     freq_dims = [n for n in dn if n != :scenarios]
     dn_subset = vcat(freq_dims, [:ranks])
@@ -201,7 +201,7 @@ function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,3,A};
     n_ranks::Int64=length(ranks.sites),
     agg_func=nothing,
-) where {D,T,A}
+)::NamedDimsArray where {D,T,A}
     if !isnothing(agg_func)
         return agg_func(ranks_to_frequencies(ranks, n_ranks))
     end
@@ -212,7 +212,7 @@ function ranks_to_frequencies(
     ranks::NamedDimsArray{D,T,2,A};
     n_ranks::Int64=length(ranks.sites),
     agg_func=nothing,
-) where {D,T,A}
+)::NamedDimsArray where {D,T,A}
     if !isnothing(agg_func)
         return agg_func(ranks_to_frequencies(ranks, n_ranks))
     end
@@ -239,7 +239,7 @@ Number of times each location was selected for an intervention.
 function location_selection_frequencies(
     ranks::NamedDimsArray;
     n_loc_int::Int64=5,
-)
+)::NamedDimsArray
     ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_loc_int)
     loc_count = sum(ranks_frequencies[ranks=1:n_loc_int], dims=2)[ranks=1]
 
@@ -248,7 +248,7 @@ end
 function location_selection_frequencies(
     iv_log::NamedDimsArray{D,T,4,A};
     dims::Union{Symbol,Vector{Symbol}}=:coral_id,
-) where {D,T,A}
+)::NamedDimsArray where {D,T,A}
     loc_count = dropdims(
         sum(dropdims(sum(iv_log; dims=dims); dims=dims) .> 0; dims=:scenarios);
         dims=:scenarios,
@@ -279,19 +279,19 @@ Selection score
 function selection_score(
     ranks::NamedDimsArray{D,T,3,A};
     dims::Vector{Symbol}=[:scenarios, :timesteps],
-) where {D,T,A}
+)::NamedDimsArray where {D,T,A}
     return _drop_single(selection_score(ranks, dims))
 end
 function selection_score(
     ranks::NamedDimsArray{D,T,2,A};
     dims::Vector{Symbol}=[:scenarios],
-) where {D,T,A}
-    return _drop_single(selection_score(ranks, dims))
+)::NamedDimsArray where {D,T,A}
+    return selection_score(ranks, dims)
 end
 function selection_score(
     ranks::NamedDimsArray,
     dims::Vector{Symbol},
-)
+)::NamedDimsArray
     lowest_rank = maximum(ranks) # 1 is best rank, n_sites + 1 is worst rank
     selection_score = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
     return selection_score ./ ((lowest_rank - 1) * prod([size(ranks, d) for d in dims]))

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -265,15 +265,20 @@ function location_selection_frequencies(
 end
 function location_selection_frequencies(
     rs::ResultSet,
-    iv_type::String;
-    n_loc_int::Int64=5,
-    ind_metrics::Vector{Int64}=_get_scen_ids(rs.ranks),
+    iv_type::String,
 )
-    selected_ranks = _get_iv_type(rs.ranks[scenarios=ind_metrics], iv_type)
-    ranks_frequencies = ranks_to_frequencies_ts(selected_ranks; n_ranks=n_loc_int)
-    loc_count = dropdims(sum(ranks_frequencies[ranks=1:n_loc_int], dims=[1, 3]), dims=3)[timesteps=1]
-
+    log = getfield(rs, Symbol(string(iv_type, "_log")))
+    return location_selection_frequencies(log)
+end
+function location_selection_frequencies(inv_log::NamedDimsArray)
+    loc_count = dropdims(
+        sum(dropdims(sum(inv_log; dims=:coral_id); dims=:coral_id) .> 0; dims=:scenarios);
+        dims=:scenarios,
+    )
     return loc_count
+end
+function location_selection_frequencies(inv_log::NamedDimsArray, scen_ids::Vector{Int46})
+    return location_selection_frequencies(inv_log[scenarios=scen_ids])
 end
 
 """

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -70,7 +70,7 @@ function run_site_selection(domain::Domain,
 
     ranks_store = NamedDimsArray(
         zeros(length(domain.site_ids), 2, nrow(scenarios)),
-        sites=domain.site_ids,
+        sites=1:length(domain.site_ids),
         intervention=1:2,
         scenarios=1:nrow(scenarios),
     )
@@ -104,8 +104,10 @@ function run_site_selection(domain::Domain,
             vec((mean(wave_scens[:, :, target_wave_scens], dims=(:timesteps, :scenarios)) .+ std(wave_scens[:, :, target_wave_scens], dims=(:timesteps, :scenarios))) .* 0.5),
             vec((mean(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios)) .+ std(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios))) .* 0.5),
             )
-    
-        ranks_store(scenarios=scen_idx, sites=domain.site_ids[considered_sites]) .= _site_selection(domain, mcda_vars_temp, scen.guided)
+
+        ranks_store(; scenarios=scen_idx, sites=considered_sites) .= _site_selection(
+            domain, mcda_vars_temp, scen.guided
+        )
     end
     # Set filtered locations as n_locs+1 for consistency with time dependent ranks
     ranks_store[ranks_store.==0.0] .= length(domain.site_ids)+1

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -2,24 +2,20 @@ using NamedDims, AxisKeys
 
 
 """
-    _location_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)
+    _location_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)::Matrix
 
-Perform site selection using a chosen aggregation method, domain, initial cover, criteria weightings and thresholds.
+Select locations for a given domain and criteria/weightings/thresholds, using a chosen
+aggregation method.
 
 # Arguments
-- `domain` : ADRIA Domain type, indicating geographical domain to perform site selection over.
-- `mcda_vars` : Contains relevant parameters for performing guided location selection.
-- `guided` : Integer indicating aggegation algorithm to use for guided location selection.
+- `domain` : The geospatial domain to assess
+- `mcda_vars` : Parameters for MCDA
+- `guided` : ID of aggregation algorithm to apply
 
 # Returns
-`ranks` : n_reps * sites * 3 (last dimension indicates: site_id, seeding rank, shading rank)
-    containing ranks for single scenario.
+Matrix[n_sites ⋅ 2], where columns hold seeding and shading ranks for each location.
 """
-function _location_selection(
-    domain::Domain,
-    mcda_vars::DMCDA_vars, 
-    guided::Int64)
-    
+function _location_selection(domain::Domain, mcda_vars::DMCDA_vars, guided::Int64)::Matrix
     site_ids = mcda_vars.site_ids
     n_sites = length(site_ids)
 
@@ -31,49 +27,65 @@ function _location_selection(
 
     # Determine connectivity strength
     # Account for cases where no coral cover
-    in_conn, out_conn, strong_pred = connectivity_strength(domain.TP_data .* site_k_area(domain), Array(mcda_vars.sum_cover))
+    in_conn, out_conn, strong_pred = connectivity_strength(
+        domain.TP_data .* site_k_area(domain), collect(mcda_vars.sum_cover)
+    )
 
     # Perform location selection for seeding and shading.
     seed_true, shade_true = true, true
 
-    (_, _, ranks) = guided_site_selection(mcda_vars, guided, seed_true, shade_true, prefseedsites, prefshadesites, rankingsin, in_conn[site_ids], out_conn[site_ids], strong_pred[site_ids])
+    (_, _, ranks) = guided_site_selection(
+        mcda_vars,
+        guided,
+        seed_true,
+        shade_true,
+        prefseedsites,
+        prefshadesites,
+        rankingsin,
+        in_conn[site_ids],
+        out_conn[site_ids],
+        strong_pred[site_ids]
+    )
 
     return ranks[:, 2:3]
 end
 
 """
-    rank_locations(domain::Domain, scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64;
-        target_seed_sites=nothing, target_shade_sites=nothing)
-    rank_locations(domain::Domain,scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64, aggregation_function::Function, 
-        iv_type::Union{String,Int64};target_seed_sites=nothing, target_shade_sites=nothing)
+    rank_locations(domain::Domain, scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64; target_seed_sites=nothing, target_shade_sites=nothing)::NamedDimsArray
+    rank_locations(domain::Domain,scenarios::DataFrame, sum_cover::NamedDimsArray, area_to_seed::Float64, agg_func::Function,
+        iv_type::Union{String,Int64}; target_seed_sites=nothing, target_shade_sites=nothing)::AbstractArray
 
-Get location rankings for a given domain for multiple scenarios defined in a dataframe.
+Return location ranks for a given domain and scenarios.
 
 # Arguments
-- `domain` : ADRIA Domain type, indicating geographical domain to perform site selection over.
-- `scenarios` : DataFrame of criteria weightings and thresholds for each scenario.
-- `sum_cover` : array of size (number of scenarios * number of sites) containing the summed coral cover for each site selection scenario.
-- `area_to_seed` : area of coral to be seeded at each time step in km^2
-- `aggregation_function` : function which aggregates ranks output into preferred form, e.g `ranks_to_frequencies`, `ranks_to_location_order`.
+- `domain` : The geospatial domain locations were selected from
+- `scenarios` : Scenario specification
+- `sum_cover` : Matrix[n_scenarios ⋅ n_sites] containing the total coral cover for each
+    location, for each scenario
+- `area_to_seed` : Area of coral to be seeded at each time step in km²
+- `agg_func` : Aggregation function to apply, e.g `ranks_to_frequencies`,
+    `ranks_to_location_order`
+- `iv_type` : ID of intervention (1 = seeding, 2 = fogging)
 - `target_seed_sites` : list of candidate locations for seeding (indices)
 - `target_shade_sites` : list of candidate location to shade (indices)
 
 # Returns
--`ranks_store` : number of scenarios * sites * 3 (last dimension indicates: site_id, seed rank, shade rank)
-    containing ranks for each scenario run.
+Array[n_locations ⋅ 2 ⋅ n_scenarios], where columns hold seeding and shading ranks.
 """
 function rank_locations(
     domain::Domain,
-    scenarios::DataFrame, 
-    sum_cover::NamedDimsArray, 
+    scenarios::DataFrame,
+    sum_cover::NamedDimsArray,
     area_to_seed::Float64;
-    target_seed_sites=nothing, 
-    target_shade_sites=nothing)
+    target_seed_sites=nothing,
+    target_shade_sites=nothing
+)::NamedDimsArray
+    n_locs = n_locations(domain)
 
     ranks_store = NamedDimsArray(
-        zeros(length(domain.site_ids), 2, nrow(scenarios)),
-        sites=1:length(domain.site_ids),
-        intervention=1:2,
+        zeros(n_locs, 2, nrow(scenarios)),
+        sites=1:n_locs,
+        intervention=["seed", "shade"],
         scenarios=1:nrow(scenarios),
     )
 
@@ -102,7 +114,7 @@ function rank_locations(
         depth_priority = findall(depth_criteria)
 
         considered_sites = target_site_ids[findall(in(depth_priority), target_site_ids)]
-        mcda_vars_temp = DMCDA_vars(domain, scen, considered_sites,  sum_cover[scen_idx, :], area_to_seed, 
+        mcda_vars_temp = DMCDA_vars(domain, scen, considered_sites,  sum_cover[scen_idx, :], area_to_seed,
             vec((mean(wave_scens[:, :, target_wave_scens], dims=(:timesteps, :scenarios)) .+ std(wave_scens[:, :, target_wave_scens], dims=(:timesteps, :scenarios))) .* 0.5),
             vec((mean(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios)) .+ std(dhw_scens[:, :, target_dhw_scens], dims=(:timesteps, :scenarios))) .* 0.5),
             )
@@ -115,45 +127,55 @@ function rank_locations(
     ranks_store[ranks_store.==0.0] .= length(domain.site_ids)+1
 
     return ranks_store
-
 end
 function rank_locations(
     domain::Domain,
-    scenarios::DataFrame, 
-    sum_cover::NamedDimsArray, 
-    area_to_seed::Float64, 
-    aggregation_function::Function, 
-    iv_type::Int64;
-    target_seed_sites=nothing, 
-    target_shade_sites=nothing)
-
+    scenarios::DataFrame,
+    sum_cover::NamedDimsArray,
+    area_to_seed::Float64,
+    agg_func::Function,
+    iv_type::Union{Int64, Symbol, String};
+    target_seed_sites=nothing,
+    target_shade_sites=nothing
+)::AbstractArray
     ranks = rank_locations(
         domain,
-        scenarios, 
-        sum_cover, 
-        area_to_seed; 
+        scenarios,
+        sum_cover,
+        area_to_seed;
         target_seed_sites=target_seed_sites,
         target_shade_sites=target_shade_sites,
     )
 
-    return aggregation_function(ranks(; intervention=iv_type))
+    local iv_id
+    try
+        iv_id = axiskeys(ranks, :intervention)[iv_type]
+    catch err
+        if !(err isa ArgumentError)
+            rethrow(err)
+        end
 
+        iv_id = iv_type
+    end
+
+    return agg_func(ranks(intervention=iv_id))
 end
 
 
 """
-    ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)ranks_to_frequencies(rs::ResultSet, iv_type::String; n_ranks=length(ranks.sites))
-    ranks_to_frequencies(ranks::NamedDimsArray{D,T,3,A};n_ranks=length(ranks.sites),agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),) where {D,T,A}
-    ranks_to_frequencies(ranks::NamedDimsArray{D,T,2,A};n_ranks=length(ranks.sites),agg_func=nothing) where {D,T,A}
+    ranks_to_frequencies(ranks::NamedDimsArray, n_ranks::Int64)
+    ranks_to_frequencies(ranks::NamedDimsArray{D,T,3,A}; n_ranks=length(ranks.sites), agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),) where {D,T,A}
+    ranks_to_frequencies(ranks::NamedDimsArray{D,T,2,A}; n_ranks=length(ranks.sites), agg_func=nothing) where {D,T,A}
 
-Post-processing for location ranks output of `rank_locations()`. Gives the frequency 
-with which each location was selected at each rank across the location selection scenarios.
-Note : default output for 3D input case includes the timestep dimension. To aggregate over time use,
-`agg_func = x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps)`.
+Post-process location ranks as given by `rank_locations()`.
+
+Returns the frequency with which each location was ranked across scenarios.
+
+Note: By default, ranks are aggregated over time where `ranks` is a 3-dimensional array.
 
 # Arguments
-- `ranks` : Rankings of locations `rank_locations()`.
-- `n_ranks` : number of rankings (defualt is number of locations).
+- `ranks` : Location ranks from `rank_locations()`
+- `n_ranks` : Number of rankings (default is number of locations).
 - `agg_func` : Aggregation function to appy after frequencies are calculated.
 
 # Returns
@@ -201,19 +223,20 @@ function ranks_to_frequencies(
 end
 
 """
-    location_selection_frequencies(ranks::NamedDimsArray;n_loc_int::Int64=5)
-    location_selection_frequencies(inv_log::NamedDimsArray{D,T,4,A};dims::Union{Symbol,Vector{Symbol}}=:coral_id) where {D,T,A}
+    location_selection_frequencies(ranks::NamedDimsArray; n_loc_int::Int64=5)
+    location_selection_frequencies(iv_log::NamedDimsArray{D,T,4,A}; dims::Union{Symbol,Vector{Symbol}}=:coral_id) where {D,T,A}
 
-Post-process intervention logs. Calculates the frequencies with which locations were selected for a particular intervention,
-for a selection of scenarios (e.g. selected robust scenarios).
+Determines the count of times each location was selected for a specific intervention over a
+set of scenarios.
 
 # Arguments
-- `ranks` : Rankings of locations `rank_locations()`.
-- `n_loc_int` : number of locations which are intervened at for each intervention decision.
-- `dims` : dimensions to sum selection frequencies over.
+- `ranks` : Rankings of locations `rank_locations()`
+- `n_loc_int` : number of locations which are intervened at for each intervention decision
+- `iv_log` : Intervention logs
+- `dims` : dimensions to sum selection frequencies over
 
-# Returns 
-Counts for location selection at each location in the domain.
+# Returns
+Number of times each location was selected for an intervention.
 """
 function location_selection_frequencies(
     ranks::NamedDimsArray;
@@ -225,33 +248,32 @@ function location_selection_frequencies(
     return loc_count
 end
 function location_selection_frequencies(
-    inv_log::NamedDimsArray{D,T,4,A};
+    iv_log::NamedDimsArray{D,T,4,A};
     dims::Union{Symbol,Vector{Symbol}}=:coral_id,
 ) where {D,T,A}
     loc_count = dropdims(
-        sum(dropdims(sum(inv_log; dims=dims); dims=dims) .> 0; dims=:scenarios);
+        sum(dropdims(sum(iv_log; dims=dims); dims=dims) .> 0; dims=:scenarios);
         dims=:scenarios,
     )
     return loc_count
 end
 
 """
-    selection_score(ranks::NamedDimsArray{D,T,3,A};dims::Union{Symbol,Vector{Symbol}}=[:scenarios, :timsteps],
-            ) where {D,T,A}
-    selection_score(ranks::NamedDimsArray{D,T,2,A};) where {D,T,A}
-    selection_score(ranks::NamedDimsArray,dims::Union{Symbol,Vector{Symbol}},)
+    selection_score(ranks::NamedDimsArray{D,T,3,A}; dims::Vector{Symbol}=[:scenarios, :timesteps]) where {D,T,A}
+    selection_score(ranks::NamedDimsArray{D,T,2,A}) where {D,T,A}
+    selection_score(ranks::NamedDimsArray, dims::Vector{Symbol})
 
-Calculates (number of sites) .- ranks summed over the dimension dims and transformed using agg_func 
-    (default no transformation).
+Calculates score ∈ [0, 1], where 1 is the highest score possible, indicative of the relative
+desirability of each location.
+
+The score reflects the location ranking and frequency of attaining a high rank.
 
 # Arguments
-- `ranks` : Rankings of locations `rank_locations()`.
-- `dims` : Dimensions to sum over.
+- `ranks` : Rankings of locations from `rank_locations()`
+- `dims` : Dimensions to sum over
 
-# Returns 
-Selection score (i.e. for ranks the lowest value is the highest rank, 
-in the selection score the greater the number the higher ranked and more 
-frequently selected the location).
+# Returns
+Selection score
 """
 function selection_score(
     ranks::NamedDimsArray{D,T,3,A};
@@ -269,7 +291,7 @@ function selection_score(
     ranks::NamedDimsArray,
     dims::Vector{Symbol},
 )
-    lowest_rank = maximum(ranks)
+    lowest_rank = maximum(ranks) # 1 is best rank, n_sites + 1 is worst rank
     selection_score = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
     return selection_score ./ ((lowest_rank - 1) * prod([size(ranks, d) for d in dims]))
 end

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -25,7 +25,7 @@ end
 """Set a model parameter value directly."""
 function set(p::Param, val::Union{Int64,Float64})
     if hasproperty(p, :ptype)
-        if _check_discrete(p.ptype) && !isinteger(val)
+        if _check_discrete.(p.ptype) && !isinteger(val)
             val = map_to_discrete(val, p.bounds[2])
         end
     end

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -173,7 +173,9 @@ function connectivity_strength(TP_base::AbstractMatrix{Float64})::NamedTuple
 
     return (in_conn=C1, out_conn=C2, strongest_predecessor=strong_pred)
 end
-function connectivity_strength(area_weighted_TP::AbstractMatrix{Float64}, cover::AbstractArray)::NamedTuple
+function connectivity_strength(
+    area_weighted_TP::NamedDimsArray, cover::Union{Vector{Float32},Vector{Float64}}
+)::NamedTuple
 
     # Accounts for cases where there is no coral cover
     tp = (area_weighted_TP .* cover)

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -174,9 +174,8 @@ function connectivity_strength(TP_base::AbstractMatrix{Float64})::NamedTuple
     return (in_conn=C1, out_conn=C2, strongest_predecessor=strong_pred)
 end
 function connectivity_strength(
-    area_weighted_TP::NamedDimsArray, cover::Union{Vector{Float32},Vector{Float64}}
+    area_weighted_TP::NamedDimsArray, cover::Vector{<:Union{Float32, Float64}}
 )::NamedTuple
-
     # Accounts for cases where there is no coral cover
     tp = (area_weighted_TP .* cover)
     tp .= tp ./ maximum(tp)

--- a/test/mcda.jl
+++ b/test/mcda.jl
@@ -41,7 +41,6 @@ using ADRIA: mcda_normalize, create_decision_matrix, create_seed_matrix, create_
         zones_criteria,
         risk_tol,
     )
-
     @test !any(isnan.(A)) || "NaNs found in decision matrix"
     @test !any(isinf.(A)) || "Infs found in decision matrix"
 
@@ -93,8 +92,9 @@ end
     SE, wse = create_seed_matrix(A, min_area, wtconseedin, wtconseedout, wt_waves, wt_heat, wt_predec_seed, wt_zones_seed, wt_lo_cover)
 
     @test (sum(filtered)) == size(A, 1) || "Site where heat stress > risk_tol not filtered out"
-    @test size(SE, 1) == n_sites - 2 ||
-        "Sites where space available < min_area not filtered out"
+    @test size(SE, 1) == size(A, 1) - 2 || "Sites where space available<min_area not filtered out"
+    @test A[3, 8] == 0.0 || "Site with k<coral cover should be set to space = 0"
+
 end
 
 @testset "MCDA shade matrix creation" begin
@@ -139,9 +139,7 @@ end
 
     SH, wsh = create_shade_matrix(A, area_max_cover[filtered], wt_conn_shade, wt_waves, wt_heat, wt_predec_shade, wt_zones_shade, wt_hi_cover)
 
-    @test maximum(SH[:, 8]) ==
-          (maximum(area_max_cover[convert(Vector{Int64}, A[:, 1])] .- A[:, 8])) ||
-        "Largest site with most coral area should have highest score"
+    @test maximum(SH[:, 8]) == (maximum(area_max_cover[convert(Vector{Int64}, A[:, 1])] .- A[:, 8])) || "Largest site with most coral area should have highest score"
 end
 
 @testset "MCDA normalisation" begin

--- a/test/mcda.jl
+++ b/test/mcda.jl
@@ -92,8 +92,8 @@ end
     SE, wse = create_seed_matrix(A, min_area, wtconseedin, wtconseedout, wt_waves, wt_heat, wt_predec_seed, wt_zones_seed, wt_lo_cover)
 
     @test (sum(filtered)) == size(A, 1) || "Site where heat stress > risk_tol not filtered out"
-    @test size(SE, 1) == size(A, 1) - 2 || "Sites where space available<min_area not filtered out"
-    @test A[3, 8] == 0.0 || "Site with k<coral cover should be set to space = 0"
+    @test size(SE, 1) == n_sites - 2 ||
+        "Sites where space available < min_area not filtered out"
 
 end
 

--- a/test/mcda.jl
+++ b/test/mcda.jl
@@ -41,6 +41,7 @@ using ADRIA: mcda_normalize, create_decision_matrix, create_seed_matrix, create_
         zones_criteria,
         risk_tol,
     )
+
     @test !any(isnan.(A)) || "NaNs found in decision matrix"
     @test !any(isinf.(A)) || "Infs found in decision matrix"
 
@@ -94,7 +95,6 @@ end
     @test (sum(filtered)) == size(A, 1) || "Site where heat stress > risk_tol not filtered out"
     @test size(SE, 1) == n_sites - 2 ||
         "Sites where space available < min_area not filtered out"
-
 end
 
 @testset "MCDA shade matrix creation" begin
@@ -139,7 +139,9 @@ end
 
     SH, wsh = create_shade_matrix(A, area_max_cover[filtered], wt_conn_shade, wt_waves, wt_heat, wt_predec_shade, wt_zones_shade, wt_hi_cover)
 
-    @test maximum(SH[:, 8]) == (maximum(area_max_cover[convert(Vector{Int64}, A[:, 1])] .- A[:, 8])) || "Largest site with most coral area should have highest score"
+    @test maximum(SH[:, 8]) ==
+          (maximum(area_max_cover[convert(Vector{Int64}, A[:, 1])] .- A[:, 8])) ||
+        "Largest site with most coral area should have highest score"
 end
 
 @testset "MCDA normalisation" begin

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -61,7 +61,7 @@ end
     area_to_seed = 662.11  # area of seeded corals in m^2
 
     sum_cover = repeat(sum(dom.init_coral_cover, dims=1), size(scens, 1))
-    ranks = ADRIA.run_site_selection(dom, criteria_df, sum_cover, area_to_seed)
+    ranks = ADRIA.rank_locations(dom, criteria_df, sum_cover, area_to_seed)
 
     @test length(ranks.scenarios) == sum(criteria_df.guided .> 0) || "Specified number of scenarios was not carried out."
     @test length(ranks.sites) == length(dom.site_ids) || "Ranks storage is not correct size for this domain."


### PR DESCRIPTION
Addresses issue #324
- adds 3 aggregation functions for ranks outputs
- ranks can be taken in as result set for ADRIA runs outputs or as ranks NamedDimsArray from run_site_selection()
- 3 functions for calculating location selection frequencies 
- location_selection_frequencies() counts frequency with which sites are actually selected (ranks 1-5)
- ranks_to_frequencies() counts frequencies with which each site is selected for each rank.
- ranks_to_frequencies_ts() calculates the same but for each time step.
- ranks_to_location_order() gives the ranking order as location names for each scenario (no time dependent version).
- Other changes fix bugs in run_site_selection() due to upstream changes.
