### PR TITLE
Address very slow extraction of relative cover values

### DIFF
--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -157,10 +157,11 @@ function _relative_cover(X::AbstractArray{U}, total_area::Vector{T}, k_area::Vec
 end
 function _relative_cover(rs::ResultSet)::AbstractArray
     k_area = (site_k_area(rs) .* site_area(rs))'
-    tac = rs.outcomes[:total_absolute_cover]
-    rc = tac ./ k_area
+    rc = copy(rs.outcomes[:total_absolute_cover])
+    non_zero_locs = findall(k_area' .> 0.0)
+    rc[:, non_zero_locs, :] ./= k_area[non_zero_locs]'
 
-    return replace(rc, NaN => 0.0, Inf => 0.0)
+    return rc
 end
 relative_cover = Metric(_relative_cover, (:timesteps, :sites, :scenarios))
 


### PR DESCRIPTION
Previous approach was to naively calculate the relative  (to $k$) area for all locations using the disk-based Zarr data. This change loads all data into memory and only calculates relative cover for non-zero locations.

The caveat re performance is that much larger spatial areas may take a bit longer to initially load.
