### PR TITLE
Incorporate settler DHW tolerances

### DIFF
--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -234,9 +234,6 @@ function retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, m
     return retrieve_ranks(site_ids, results.scores, maximize)
 end
 function retrieve_ranks(site_ids::Vector, scores::Vector, maximize::Bool)::Matrix{Union{Float64,Int64}}
-    # s_order = Union{Float64,Int64}[Int64.(site_ids) scores]
-    # s_order .= sortslices(s_order, dims=1, by=x -> x[2], rev=maximize)
-    # return s_order
     s_order::Vector{Int64} = sortperm(scores, rev=maximize)
     return Union{Float64,Int64}[Int64.(site_ids[s_order]) scores[s_order]]
 end

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -212,15 +212,15 @@ Get location ranks using mcda technique specified in mcda_func, weights and a de
 # Arguments
 - `S` : decision matrix containing criteria values for each location (n locations)*(m criteria)
 - `site_ids` : array of site ids still remaining after filtering.
-- `weights` : importance weights for each criteria. 
+- `weights` : importance weights for each criteria.
 - `mcda_func` : function/JMcDM DataType to use for mcda, specified as an element from methods_mcda.
 - `scores` : set of scores derived from applying an mcda ranking method.
-- `maximize` : Boolean indicating whether a mcda method is maximizing score (true), or minimizing (false). 
+- `maximize` : Boolean indicating whether a mcda method is maximizing score (true), or minimizing (false).
 
 # Returns
 - `s_order` : [site_ids, criteria values, ranks]
 """
-function retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, mcda_func::Function)
+function retrieve_ranks(S::Matrix{Float64}, site_ids::Vector{Float64}, weights::Vector{Float64}, mcda_func::Function)
     S = mcda_normalize(S) .* weights'
     scores = mcda_func(S)
 
@@ -233,11 +233,12 @@ function retrieve_ranks(S::Matrix, site_ids::Vector, weights::Vector{Float64}, m
 
     return retrieve_ranks(site_ids, results.scores, maximize)
 end
-function retrieve_ranks(site_ids::Vector, scores::Vector, maximize::Bool)
-    s_order = Union{Float64,Int64}[Int64.(site_ids) scores]
-    s_order .= sortslices(s_order, dims=1, by=x -> x[2], rev=maximize)
-
-    return s_order
+function retrieve_ranks(site_ids::Vector, scores::Vector, maximize::Bool)::Matrix{Union{Float64,Int64}}
+    # s_order = Union{Float64,Int64}[Int64.(site_ids) scores]
+    # s_order .= sortslices(s_order, dims=1, by=x -> x[2], rev=maximize)
+    # return s_order
+    s_order::Vector{Int64} = sortperm(scores, rev=maximize)
+    return Union{Float64,Int64}[Int64.(site_ids[s_order]) scores[s_order]]
 end
 
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -303,7 +303,7 @@ where \$w\$ are the weights/priors and \$g\$ is the growth rates.
 """
 function _shift_distributions!(cover::SubArray{F}, growth_rate::SubArray{F}, dist_t::SubArray{<:Truncated}, stdev::SubArray{F})::Nothing where {F<:Float64}
     # Weight distributions based on growth rate and cover
-    for i in 6:-1:3
+    @floop for i in 6:-1:3
         sum(cover[i-1:i]) == 0.0 ? continue : false
         prop_growth = @views (cover[i-1:i] ./ sum(cover[i-1:i])) .* (growth_rate[i-1:i] ./ sum(growth_rate[i-1:i]))
         x::MixtureModel = MixtureModel(dist_t[i-1:i], prop_growth ./ sum(prop_growth))
@@ -313,7 +313,7 @@ function _shift_distributions!(cover::SubArray{F}, growth_rate::SubArray{F}, dis
         dist_t[i] = truncated(Normal(mean(x), stdev[i]), minimum(x), mean(x) + HEAT_UB)
     end
 
-    # # Size class 1 all moves up to size class 2 anyway
+    # Size class 1 all moves up to size class 2 anyway
     μ = mean(dist_t[1])
     dist_t[2] = truncated(Normal(μ, stdev[2]), minimum(dist_t[1]), μ + HEAT_UB)
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -349,9 +349,8 @@ function adjust_DHW_distribution!(cover::SubArray{F}, n_groups::Int64, dist_t::M
                 continue
             end
 
-            # Combine distributions using a MixtureModel for all size
-            # classes >= 4 (the correct size classes are selected within the
-            # function).
+            # Combine distributions using a MixtureModel for all non-juvenile size
+            # classes (we pass in all relevant size classes for the species group here).
             @views _shift_distributions!(cover[1, sc1:sc6, loc], growth_rate[sc1:sc6], dist_t[sc1:sc6, loc], stdev[sc1:sc6])
         end
     end

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -66,12 +66,12 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
 
     # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
     # Note: It is entirely possible for a location to be ranked in the top N, but
-    #       with no deployments (for a given species). A location with 0 cover 
-    #       and no deployments will therefore be NaN due to zero division. 
+    #       with no deployments (for a given species). A location with 0 cover
+    #       and no deployments will therefore be NaN due to zero division.
     #       These are replaced with 1.0 so that the distribution for unseeded
     #       corals are used.
     w_taxa::Matrix{Float64} = scaled_seed ./ cover[seed_sc, seed_locs]
-    replace!(w_taxa, NaN=>1.0)
+    replace!(w_taxa, NaN => 1.0)
 
     # Update critical DHW distribution for deployed size classes
     for (i, loc) in enumerate(seed_locs)
@@ -80,7 +80,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
 
         # Truncated normal distributions for deployed corals
         # Assume same stdev and bounds as original
-        tn = truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti))
+        tn::Vector{Truncated} = truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti))
 
         # If seeding an empty location, no need to do any further calculations
         if all(isapprox.(w_taxa[:, i], 1.0))
@@ -91,7 +91,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
         # Create new distributions by mixing previous and current distributions using
         # proportional cover as the priors/weights
         # Priors (weights based on cover for each species)
-        tx = MixtureModel[MixtureModel([t, t1], Float64[w, 1.0-w]) for ((t, t1), w) in zip(zip(c_dist_ti, tn), w_taxa[:, i])]
+        tx::Vector{MixtureModel} = MixtureModel[MixtureModel([t, t1], Float64[w, 1.0-w]) for ((t, t1), w) in zip(zip(c_dist_ti, tn), w_taxa[:, i])]
         c_dist_t[seed_sc, loc] .= truncated.(Normal.(mean.(tx), stdev[seed_sc]), minimum.(tx), maximum.(tx))
     end
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -55,7 +55,7 @@ Note: Units for all areas are expected to be identical, and are assumed to be in
 """
 function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
     seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
-    Yseed::SubArray, stdev::V, c_dist_t::Matrix)::Nothing where {V<:Vector{Float64}}
+    Yseed::SubArray, stdev::V, c_dist_t::Matrix{<:Truncated})::Nothing where {V<:Vector{Float64}}
 
     # Calculate proportion to seed based on current available space
     scaled_seed = distribute_seeded_corals(total_location_area[seed_locs], leftover_space[seed_locs], seeded_area)

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -25,7 +25,6 @@ function setup_cache(domain::Domain)::NamedTuple
         cov_tmp=zeros(n_species, n_sites),  # Cover for previous timestep
         depth_coeff=zeros(n_sites),  # store for depth coefficient
         site_area=Matrix{Float64}(site_area(domain)'),  # site areas
-        TP_data=Matrix{Float64}(domain.TP_data),  # transition probabilities
         wave_scen=zeros(tf, n_sites),  # tmp store for wave scenario
         wave_damage=zeros(tf, n_species, n_sites),  # damage coefficient for each size class
         dhw_tol_mean_log = zeros(tf, n_species, n_sites),  # tmp log for mean dhw tolerances

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -516,7 +516,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     # basal_area_per_settler is the area in m^2 of a size class one coral
     basal_area_per_settler = colony_mean_area(corals.mean_colony_diameter_m[corals.class_id.==1])
-    @inbounds for tstep::Int64 in 2:tf
+    for tstep::Int64 in 2:tf
         p_step::Int64 = tstep - 1
         Y_pstep .= Y_cover[p_step, :, :]
 
@@ -531,6 +531,54 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         # Gets used in ODE
         p.rec .= settler_cover(fec_scope, TP_data, leftover_space_prop,
             sim_params.max_settler_density, sim_params.max_larval_density, basal_area_per_settler)
+
+        # Adjust DHW tolerances incorporating recruited coral
+        for sink_loc in findall(site_k_area(domain) .> 0)
+            larvae_contribution = TP_data[TP_data[:, sink_loc].>0.0, sink_loc]
+            if length(larvae_contribution) == 0.0
+                # Skip if no recruitment occurred
+                continue
+            end
+
+            w = larvae_contribution ./ sum(larvae_contribution)
+            for (sp, sc1) in enumerate(1:6:36)
+                if p.rec[sp, sink_loc] == 0.0
+                    continue
+                end
+
+                sc1_6 = sc1:sc1+5
+
+                # Identify source locations
+                source_locs = TP_data[:, sink_loc] .> 0.0
+
+                # Get distributions of reproductive size classes at source locations
+                reproductive_sc = fec_params_per_m²[sc1_6] .> 0.0
+                source_dists = vec(c_dist_t_1[sc1_6, source_locs][reproductive_sc, :])
+
+                # Determine weights based on contribution to recruitment.
+                # This weights the recruited corals by the size classes and source locations
+                # which contributed to recruitment.
+                expanded_w = repeat(w, inner=count(reproductive_sc))
+                expanded_w /= sum(expanded_w)
+
+                # Obtain the recruited and original distributions for the sink location.
+                recruited = MixtureModel(source_dists, expanded_w)
+                orig = c_dist_t_1[sc1, sink_loc]
+
+                # Combine distributions altogether to determine new distribution for size class 1
+                # for the CURRENT timestep
+                @views total_w = p.rec[sp, sink_loc] ./ (p.rec[sp, sink_loc] + Y_pstep[sp, sink_loc])
+                d = MixtureModel([orig, recruited], [1.0 - total_w, total_w])
+
+                # Breeder's equation
+                S = mean(d) - mean(c_dist_t_1[sc1, sink_loc])
+                h² = param_set("heritability")
+                μ_t::Float64 = mean(d) + (S * h²)
+
+                # New DHW tolerance distribution for size class 1, for NEXT timestep
+                c_dist_t[sc1, sink_loc] = truncated(Normal(μ_t, corals.dist_std[sc1]), minimum(d), μ_t + HEAT_UB)
+            end
+        end
 
         in_shade_years = (shade_start_year <= tstep) && (tstep <= (shade_start_year + shade_years - 1))
         in_seed_years = (seed_start_year <= tstep) && (tstep <= (seed_start_year + seed_years - 1))
@@ -624,7 +672,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_loc_area, 0.0, 1.0)
 
         if tstep <= tf
-            adjust_DHW_distribution!(@view(Y_cover[tstep-1:tstep, :, :]), n_groups, @view(c_dist_t_1[:,:]), @view(c_dist_t[:,:]),
+            adjust_DHW_distribution!(@view(Y_cover[tstep-1:tstep, :, :]), n_groups, @view(c_dist_t_1[:, :]), @view(c_dist_t[:, :]),
                 @view(p.r[:]), @view(corals.dist_std[:]), param_set("heritability"))
 
             if in_debug_mode


### PR DESCRIPTION
Previous implementation assumed localised coral reproduction when incorporating DHW tolerances. This was simply for convenience, to have a prototype working.

This PR incorporates coral larvae from other (source) locations that settle on to a given (sink) location.

The role of connectivity between locations are then better represented as locations with a higher thermal tolerance can contribute larvae to locations with less thermal tolerance (and vice versa).