### PR TITLE
Fix clustering map visualisation

### DIFF
--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -82,7 +82,7 @@ Figure
 """
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
-    data::AbstractArray,
+    data::AbstractArray{<:Real},
     clusters::Vector{Int64};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -70,7 +70,7 @@ Visualize clustered time series for each site and map.
 
 # Arguments
 - `rs` : ResultSet
-- `data` : Matrix of scenario data for each location
+- `data` : Vector of summary statistics data for each location
 - `clusters` : Vector of numbers corresponding to clusters
 - `opts` : Options specific to this plotting method
     - `highlight` : Vector of colors indicating cluster membership for each location.
@@ -97,7 +97,7 @@ end
 function ADRIA.viz.map!(
     g::Union{GridLayout,GridPosition},
     rs::Union{Domain,ResultSet},
-    data::AbstractArray,
+    data::AbstractVector{<:Real},
     clusters::Vector{Int64};
     opts::Dict=Dict(),
     axis_opts::Dict=Dict()

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -80,10 +80,14 @@ Visualize clustered time series for each site and map.
 # Returns
 Figure
 """
-function ADRIA.viz.map(rs::Union{Domain,ResultSet}, data::AbstractArray,
-    clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict())
-
+function ADRIA.viz.map(
+    rs::Union{Domain,ResultSet},
+    data::AbstractArray,
+    clusters::Vector{Int64};
+    opts::Dict=Dict(),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
     ADRIA.viz.map!(g, rs, data, clusters; opts=opts, axis_opts=axis_opts)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,3 +1,5 @@
+using JuliennedArrays
+
 """
     ts_cluster(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
     ts_cluster!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
@@ -88,21 +90,21 @@ function ADRIA.viz.map(rs::Union{Domain,ResultSet}, data::AbstractArray,
 
     return f
 end
-function ADRIA.viz.map!(g::Union{GridLayout,GridPosition},
-    rs::Union{Domain,ResultSet}, data::AbstractArray, clusters::Vector{Int64};
-    opts::Dict=Dict(), axis_opts::Dict=Dict())
-
-    # Vector of summary statistics (default is mean) computed over timesteps
-    opts[:summary] = get(opts, :summary, mean)
-    data_stats = collect(ADRIA.metrics.per_loc(opts[:summary], data))
-
+function ADRIA.viz.map!(
+    g::Union{GridLayout,GridPosition},
+    rs::Union{Domain,ResultSet},
+    data::AbstractArray,
+    clusters::Vector{Int64};
+    opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
     cluster_colors = _clusters_colors(clusters)
-    legend_params = _cluster_legend_params(clusters, cluster_colors, data_stats)
+    legend_params = _cluster_legend_params(clusters, cluster_colors, data)
 
     opts[:highlight] = get(opts, :highlight, cluster_colors)
     opts[:legend_params] = get(opts, :legend_params, legend_params)
 
-    ADRIA.viz.map!(g, rs, data_stats; opts=opts, axis_opts=axis_opts)
+    ADRIA.viz.map!(g, rs, data; opts=opts, axis_opts=axis_opts)
 
     return g
 end

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -163,7 +163,7 @@ end
 function ADRIA.viz.map!(
     g::Union{GridLayout,GridPosition},
     rs::Union{Domain,ResultSet},
-    y::AbstractVector;
+    y::AbstractVector{<:Real};
     opts::Dict=Dict(),
     axis_opts::Dict=Dict()
 )

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -152,10 +152,10 @@ function ADRIA.viz.map(rs::Union{Domain,ResultSet}; opts::Dict=Dict(), fig_opts:
     return f
 end
 function ADRIA.viz.map!(g::Union{GridLayout,GridPosition}, rs::Union{Domain,ResultSet},
-    y::Vector; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    y::AbstractVector; opts::Dict=Dict(), axis_opts::Dict=Dict())
 
     geodata = get_geojson_copy(rs)
-    data = Observable(y)
+    data = Observable(collect(y))
 
     highlight = get(opts, :highlight, nothing)
     c_label = get(opts, :colorbar_label, "")

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -132,8 +132,13 @@ Plot spatial choropleth of outcomes.
 # Returns
 GridPosition
 """
-function ADRIA.viz.map(rs::Union{Domain,ResultSet}, y::NamedDimsArray; opts::Dict=Dict(),
-    fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+function ADRIA.viz.map(
+    rs::Union{Domain,ResultSet},
+    y::NamedDimsArray;
+    opts::Dict=Dict(),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
@@ -141,8 +146,12 @@ function ADRIA.viz.map(rs::Union{Domain,ResultSet}, y::NamedDimsArray; opts::Dic
 
     return f
 end
-function ADRIA.viz.map(rs::Union{Domain,ResultSet}; opts::Dict=Dict(), fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict())
+function ADRIA.viz.map(
+    rs::Union{Domain,ResultSet};
+    opts::Dict=Dict(),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
@@ -151,9 +160,13 @@ function ADRIA.viz.map(rs::Union{Domain,ResultSet}; opts::Dict=Dict(), fig_opts:
 
     return f
 end
-function ADRIA.viz.map!(g::Union{GridLayout,GridPosition}, rs::Union{Domain,ResultSet},
-    y::AbstractVector; opts::Dict=Dict(), axis_opts::Dict=Dict())
-
+function ADRIA.viz.map!(
+    g::Union{GridLayout,GridPosition},
+    rs::Union{Domain,ResultSet},
+    y::AbstractVector;
+    opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
     geodata = get_geojson_copy(rs)
     data = Observable(collect(y))
 


### PR DESCRIPTION
`ADRIA.viz.map` has a call to `per_loc` that is raising an error because it doesn't have a `:scenarios` dimension. This is fixed by computing the summary statistics for this particular case inside `map` function.