### PR TITLE
Fix duplicate x-axis values bug in `viz.outcome_map()`

### DIFF
--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -202,7 +202,7 @@ function ADRIA.viz.rsa!(g::Union{GridLayout,GridPosition}, rs::ResultSet, si::Na
     for r in 1:n_rows
         for c in 1:n_cols
             f_vals = rs.inputs[:, Symbol(factors[curr])]
-            fv_s = quantile(f_vals, b_slices)
+            fv_s = round.(quantile(f_vals, b_slices),digits=2)
             # fv_s = String[(i == 1) || iseven(i) ? @sprintf("%.1f", fv) : "" for (i, fv) in enumerate(quantile(f_vals, b_slices))]
             # xtick_labels = (1:length(bin_slices), fv_s)
 

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -202,7 +202,7 @@ function ADRIA.viz.rsa!(g::Union{GridLayout,GridPosition}, rs::ResultSet, si::Na
     for r in 1:n_rows
         for c in 1:n_cols
             f_vals = rs.inputs[:, Symbol(factors[curr])]
-            fv_s = round.(quantile(f_vals, b_slices),digits=2)
+            fv_s = quantile(f_vals, b_slices)
             # fv_s = String[(i == 1) || iseven(i) ? @sprintf("%.1f", fv) : "" for (i, fv) in enumerate(quantile(f_vals, b_slices))]
             # xtick_labels = (1:length(bin_slices), fv_s)
 
@@ -310,7 +310,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
         for c in 1:n_cols
             f_name = Symbol(factors[curr])
             f_vals = rs.inputs[:, f_name]
-            fv_s = quantile(f_vals, b_slices)
+            fv_s = round.(quantile(f_vals, b_slices), digits=2)
 
             ax::Axis = Axis(
                 g[r, c],

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -302,7 +302,8 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
     end
 
     bin_slices, factor_list, CIs = axiskeys(outcomes)
-    b_slices = parse.(Float64, bin_slices)
+    b_slices = collect(LinRange(0.0, 1.0, length(bin_slices)))
+
     curr::Int64 = 1
     axs = Axis[]
     for r in 1:n_rows

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -302,7 +302,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
     end
 
     bin_slices, factor_list, CIs = axiskeys(outcomes)
-    b_slices = collect(LinRange(0.0, 1.0, length(bin_slices)))
+    b_slices = parse.(Float64, bin_slices)
 
     curr::Int64 = 1
     axs = Axis[]

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -312,7 +312,7 @@ function outcome_map(X::DataFrame, y::AbstractVecOrMat{T}, rule::V, target_facto
 
     p_table = NamedDimsArray(
         zeros(Union{Missing,Float64}, length(steps) - 1, length(target_factors), 3);
-        bins=["$(round(i, digits=2))" for i in steps[2:end]],
+        bins=["$(round(i, digits=5))" for i in steps[2:end]],
         factors=Symbol.(target_factors),
         CI=[:mean, :lower, :upper]
     )

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -312,7 +312,7 @@ function outcome_map(X::DataFrame, y::AbstractVecOrMat{T}, rule::V, target_facto
 
     p_table = NamedDimsArray(
         zeros(Union{Missing,Float64}, length(steps) - 1, length(target_factors), 3);
-        bins=["$(round(i, digits=5))" for i in steps[2:end]],
+        bins=["$i" for i in steps[2:end]],
         factors=Symbol.(target_factors),
         CI=[:mean, :lower, :upper]
     )

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -312,7 +312,7 @@ function outcome_map(X::DataFrame, y::AbstractVecOrMat{T}, rule::V, target_facto
 
     p_table = NamedDimsArray(
         zeros(Union{Missing,Float64}, length(steps) - 1, length(target_factors), 3);
-        bins=["$i" for i in steps[2:end]],
+        bins=string.(steps[2:end]),
         factors=Symbol.(target_factors),
         CI=[:mean, :lower, :upper]
     )


### PR DESCRIPTION
Resolves issue #440.

Previously, plotting factors where the splitting of the factor domain had uneven steps (due to rounding used to define mapping labels possibly), duplicate values would arise when creating the x-axis for outcome mapping plots (see issue). 

Previously plots of factor with uneven splitting would look like this:

![outcome_map_guided_moore_all_time](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/573b2f34-5d70-4d0d-bf1c-5eaa16a3ec86)

with duplicate x-values.
Current plots now look like this:
![outcome_map_guided_moore_alltime](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/df9b6f67-b4f8-4187-b421-4e14ebd53f0e)

without duplicate x-values.