### PR TITLE
More updates to documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(
             "usage/scenario_generation.md",
             "usage/scenario_runs.md",
             "usage/analysis.md",
+            "usage/cookbook.md"
             # "usage/scenario_discovery.md"
         ],
         "dMCDA.md",

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -4,8 +4,8 @@
 
 ```@autodocs
 Modules = [ADRIA.metrics]
-Order   = [:function, :type]
-Private = false
+Order   = [:constant, :function, :type]
+Private = true
 ```
 
 ## Performance indicators

--- a/docs/src/architecture/architecture.md
+++ b/docs/src/architecture/architecture.md
@@ -57,7 +57,7 @@ and so on. The `Criteria` sub-component relates to the preferences for the Multi
 Decision Analysis methods, further detailed in the [MCDA page](TODO). For the ADRIA ecosystem model
 (ADRIAmod), `EnviromentalLayers` relate to the environmental scenarios available for a given
 simulation (a time series of DHW and Wave stress), itself determined on the loading of data
-(see [this page](TODO)).
+(see [Running scenarios](@ref)).
 
 The `Coral` sub-component relates to ADRIAmod, currently representing six coral species:
 

--- a/docs/src/architecture/domain_and_resultsets.md
+++ b/docs/src/architecture/domain_and_resultsets.md
@@ -117,7 +117,7 @@ Example_domain
 
 The directory holding results is also treated as a data package referred to as a `ResultSet`.
 Scenario outcomes are written out to disk as they complete to a directory located in the
-user-defined `Output` directory (see [Getting started](@ref Getting started)).
+user-defined `Output` directory (see [Getting started](@ref)).
 
 The directory name follows the convention of `[Domain Name]__[IDs of RCPs]__[date/time of run]`.
 For example: `Moore_2022-11-17__RCPs45_60__2023-01-01_19_00_00_000`

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -53,7 +53,7 @@ ADRIA.viz.scenario(rs, s_tac)
 See the previous sections [Loading a Domain](@ref), [Generating scenarios](@ref) and
 [Running scenarios](@ref) for more information.
 
-## Metrics Extraction
+## Extracting results
 
 A range of metrics are defined as part of the ADRIA framework. See the [Metrics](@ref)
 page for more details.
@@ -69,7 +69,10 @@ juves = ADRIA.metrics.relative_juveniles(rs)
 ```
 
 We can also look at scenario-level metrics. They aggregate the above metrics across the
-`site` dimension. The result is a 2-dimensional Array of timesteps and scenarios:
+`site` dimension and indicate the _outcomes_ under a given intervention (or non-intervention) option
+and environmental condition.
+
+The result is a 2-dimensional array of timesteps and scenarios:
 
 ```julia
 s_tac = ADRIA.metrics.scenario_total_cover(rs)

--- a/docs/src/usage/domain.md
+++ b/docs/src/usage/domain.md
@@ -4,7 +4,7 @@ ADRIA is designed to work with `Domain` data packages.
 In short, these are pre-packaged data sets that hold all the necessary data to run
 simulations for a given spatial domain.
 
-See [ADRIA Architecture](@ref) for more information.
+See [Architectural overview](@ref) for more information.
 
 A `Domain` may be loaded with the `load_domain` function.
 By convention we assign the `Domain` to `dom`, although this variable can be named anything.

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -28,33 +28,43 @@ function scenario_trajectory(data::AbstractArray; metric=mean)
 end
 
 
-"""
-    scenario_total_cover(rs::ResultSet; kwargs...)
-
-Calculate the mean absolute coral for each scenario for the entire domain.
-"""
 function _scenario_total_cover(X::AbstractArray; kwargs...)
     return dropdims(sum(slice_results(X; kwargs...), dims=:sites), dims=:sites)
 end
 function _scenario_total_cover(rs::ResultSet; kwargs...)
     return dropdims(sum(slice_results(total_absolute_cover(rs); kwargs...), dims=:sites), dims=:sites)
 end
+
+"""
+    scenario_total_cover(rs::ResultSet; kwargs...)
+
+Calculate the mean absolute coral for each scenario for the entire domain.
+"""
 scenario_total_cover = Metric(_scenario_total_cover, (:timesteps, :scenarios), "m²")
 
 
-"""
-    scenario_relative_cover(rs::ResultSet; kwargs...)
-
-Calculate the mean relative coral cover for each scenario for the entire domain.
-"""
 function _scenario_relative_cover(rs::ResultSet; kwargs...)
     target_sites = haskey(kwargs, :sites) ? kwargs[:sites] : (:)
     target_area = sum(((rs.site_max_coral_cover./100.0).*rs.site_area)[target_sites])
 
     return _scenario_total_cover(rs; kwargs...) ./ target_area
 end
+
+"""
+    scenario_relative_cover(rs::ResultSet; kwargs...)
+
+Calculate the mean relative coral cover for each scenario for the entire domain.
+"""
 scenario_relative_cover = Metric(_scenario_relative_cover, (:timesteps, :scenarios))
 
+function _scenario_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
+    @warn "`scenario_juveniles()` is deprecated and will be removed in future versions. Use `scenario_relative_juveniles()` instead."
+    return _scenario_relative_juveniles(data, coral_spec, area; kwargs...)
+end
+function _scenario_juveniles(rs::ResultSet; kwargs...)
+    @warn "`scenario_juveniles()` is deprecated and will be removed in future versions. Use `scenario_relative_juveniles()` instead."
+    return _scenario_relative_juveniles(rs)
+end
 
 """
     scenario_juveniles(data::NamedDimsArray; kwargs...)
@@ -64,22 +74,9 @@ Calculate the cluster-wide relative juvenile population for individual scenarios
 !!! warning DEPRECATED.
     This function is now deprecated. Use `scenario_relative_juveniles()` instead.
 """
-function _scenario_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
-    @warn "`scenario_juveniles()` is deprecated and will be removed in future versions. Use `scenario_relative_juveniles()` instead."
-    return _scenario_relative_juveniles(data, coral_spec, area; kwargs...)
-end
-function _scenario_juveniles(rs::ResultSet; kwargs...)
-    @warn "`scenario_juveniles()` is deprecated and will be removed in future versions. Use `scenario_relative_juveniles()` instead."
-    return _scenario_relative_juveniles(rs)
-end
 scenario_juveniles = Metric(_scenario_juveniles, (:timesteps, :scenarios))
 
 
-"""
-    scenario_relative_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
-
-Calculate the mean relative juvenile population for each scenario for the entire domain.
-"""
 function _scenario_relative_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)::NamedDimsArray
     ajuv = call_metric(absolute_juveniles, data, coral_spec; kwargs...)
     return dropdims(sum(ajuv, dims=:sites), dims=:sites) / sum(area)
@@ -90,15 +87,15 @@ function _scenario_relative_juveniles(rs::ResultSet; kwargs...)::NamedDimsArray
     #       otherwise it will get returned as an AxisKey array for some reason
     return dropdims(sum(absolute_juveniles(rs), dims=:sites), dims=:sites) ./ sum(rs.site_area)
 end
+
+"""
+    scenario_relative_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
+
+Calculate the mean relative juvenile population for each scenario for the entire domain.
+"""
 scenario_relative_juveniles = Metric(_scenario_relative_juveniles, (:timesteps, :scenarios))
 
 
-"""
-    scenario_absolute_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
-    scenario_absolute_juveniles(rs::ResultSet; kwargs...)::AbstractArray
-
-Calculate the mean absolute juvenile population for each scenario for the entire domain.
-"""
 function _scenario_absolute_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
     juv = call_metric(absolute_juveniles, data, coral_spec; kwargs...)
     return dropdims(sum(juv, dims=:sites), dims=:sites) / sum(area)
@@ -107,15 +104,16 @@ function _scenario_absolute_juveniles(rs::ResultSet; kwargs...)::AbstractArray
     # Calculate relative domain-wide cover based on absolute values
     return dropdims(sum(absolute_juveniles(rs), dims=:sites), dims=:sites)
 end
+
+"""
+    scenario_absolute_juveniles(data::NamedDimsArray, coral_spec::DataFrame, area::AbstractVector{<:Real}; kwargs...)
+    scenario_absolute_juveniles(rs::ResultSet; kwargs...)::AbstractArray
+
+Calculate the mean absolute juvenile population for each scenario for the entire domain.
+"""
 scenario_absolute_juveniles = Metric(_scenario_absolute_juveniles, (:timesteps, :scenarios))
 
 
-"""
-    _scenario_juvenile_indicator(data::NamedDimsArray, coral_spec::DataFrame, area::V, k_area::V; kwargs...) where {V<:AbstractVector{<:Real}}
-    _scenario_juvenile_indicator(rs::ResultSet; kwargs...)::AbstractArray
-
-Determine juvenile indicator ∈ [0, 1], where 1 indicates maximum mean juvenile density (51.8) has been achieved.
-"""
 function _scenario_juvenile_indicator(data::NamedDimsArray, coral_spec::DataFrame, area::V, k_area::V; kwargs...) where {V<:AbstractVector{<:Real}}
     juv = call_metric(juvenile_indicator, data, coral_spec, area, k_area; kwargs...)
     return dropdims(mean(juv, dims=:sites), dims=:sites) / sum(area)
@@ -123,15 +121,16 @@ end
 function _scenario_juvenile_indicator(rs::ResultSet; kwargs...)::AbstractArray
     return dropdims(mean(juvenile_indicator(rs), dims=:sites), dims=:sites)
 end
+
+"""
+    scenario_juvenile_indicator(data::NamedDimsArray, coral_spec::DataFrame, area::V, k_area::V; kwargs...) where {V<:AbstractVector{<:Real}}
+    scenario_juvenile_indicator(rs::ResultSet; kwargs...)::AbstractArray
+
+Determine juvenile indicator ∈ [0, 1], where 1 indicates maximum mean juvenile density (51.8) has been achieved.
+"""
 scenario_juvenile_indicator = Metric(_scenario_juvenile_indicator, (:timesteps, :scenarios))
 
 
-"""
-    scenario_asv(sv::NamedDimsArray; kwargs...)
-    scenario_asv(rs::ResultSet; kwargs...)
-
-Calculate the mean absolute shelter volumes for each scenario for the entire domain.
-"""
 function _scenario_asv(sv::NamedDimsArray; kwargs...)
     sv_sliced = slice_results(sv; kwargs...)
     return dropdims(sum(sv_sliced, dims=:sites), dims=:sites)
@@ -139,15 +138,15 @@ end
 function _scenario_asv(rs::ResultSet; kwargs...)
     return _scenario_asv(rs.outcomes[:absolute_shelter_volume]; kwargs...)
 end
+
+"""
+    scenario_asv(sv::NamedDimsArray; kwargs...)
+    scenario_asv(rs::ResultSet; kwargs...)
+
+Calculate the mean absolute shelter volumes for each scenario for the entire domain.
+"""
 scenario_asv = Metric(_scenario_asv, (:timesteps, :scenarios), "m³/m²")
 
-
-"""
-    scenario_rsv(sv::NamedDimsArray; kwargs...)
-    scenario_rsv(rs::ResultSet; kwargs...)
-
-Calculate the mean relative shelter volumes for each scenario for the entire domain.
-"""
 function _scenario_rsv(sv::NamedDimsArray; kwargs...)
     sv_sliced = slice_results(sv; kwargs...)
     return dropdims(mean(sv_sliced, dims=:sites), dims=:sites)
@@ -155,14 +154,16 @@ end
 function _scenario_rsv(rs::ResultSet; kwargs...)
     return _scenario_rsv(rs.outcomes[:relative_shelter_volume]; kwargs...)
 end
+
+"""
+    scenario_rsv(sv::NamedDimsArray; kwargs...)
+    scenario_rsv(rs::ResultSet; kwargs...)
+
+Calculate the mean relative shelter volumes for each scenario for the entire domain.
+"""
 scenario_rsv = Metric(_scenario_rsv, (:timesteps, :scenarios))
 
-"""
-    scenario_evenness(ev::NamedDimsArray; kwargs...)
-    scenario_evenness(rs::ResultSet; kwargs...)
 
-Calculate the mean coral evenness for each scenario for the entire domain.
-"""
 function _scenario_evenness(ev::NamedDimsArray; kwargs...)
     ev_sliced = slice_results(ev; kwargs...)
     return scenario_trajectory(ev_sliced)
@@ -171,4 +172,11 @@ end
 function _scenario_evenness(rs::ResultSet; kwargs...)
     return _scenario_evenness(rs.outcomes[:coral_evenness]; kwargs...)
 end
+
+"""
+    scenario_evenness(ev::NamedDimsArray; kwargs...)
+    scenario_evenness(rs::ResultSet; kwargs...)
+
+Calculate the mean coral evenness for each scenario for the entire domain.
+"""
 scenario_evenness = Metric(_scenario_evenness, (:timesteps, :scenarios))


### PR DESCRIPTION
This PR includes/adds a cookbook page and uses a workaround to include documentation for metrics which use the `Metric` type.
As a bonus, the updated approach to defining metrics makes the docstring available for the built-in Julia help system.

I've noted that documentation for metrics are often incomplete or inconsistently defined. This will be addressed in a later PR.

