### PR TITLE
Changes to improve performance of PAWN sensitivity analysis

### DIFF
--- a/ext/AvizExt/analysis.jl
+++ b/ext/AvizExt/analysis.jl
@@ -2,8 +2,8 @@ using ADRIA.analysis: col_normalize
 using ADRIA.sensitivity
 
 
-function relative_sensitivities(X, y; S=10, stat=:median)::Vector{Float64}
-    return col_normalize(sensitivity.pawn(X, Array(y); S=S)(Si=stat))
+function relative_sensitivities(X, y::AbstractArray{<:Real}; S=10, stat=:median)::Vector{Float64}
+    return col_normalize(sensitivity.pawn(X, y; S=S)(Si=stat))
 end
 
 """

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -2,7 +2,7 @@ module sensitivity
 
 using Logging
 using DataFrames, NamedDims, AxisKeys
-using Distributions, HypothesisTests, Bootstrap, StaticArrays
+using Distributions, HypothesisTests, Bootstrap, StaticArrays, FLoops
 
 using ADRIA: ResultSet
 using ADRIA.analysis: col_normalize
@@ -59,23 +59,24 @@ function pawn(X::T1, y::T2, factor_names::Vector{String}; S::Int64=10)::NamedDim
     step = 1 / S
     seq = 0.0:step:1.0
 
-    X_di = @MVector zeros(N)
+    # Preallocate result structures
     X_q = @MVector zeros(S + 1)
     pawn_t = @MArray zeros(S, D)
     results = @MArray zeros(D, 6)
+
     # Hide warnings from HypothesisTests
     with_logger(NullLogger()) do
-        for d_i in 1:D
-            X_di .= X[:, d_i]
+        @floop for d_i in 1:D
+            X_di = @view(X[:, d_i])
             X_q .= quantile(X_di, seq)
 
-            Y_sel = y[X_q[1].<=X_di.<=X_q[2]]
+            Y_sel = @view(y[X_q[1].<=X_di.<=X_q[2]])
             if length(Y_sel) > 0
                 pawn_t[1, d_i] = ks_statistic(ApproximateTwoSampleKSTest(Y_sel, y))
             end
 
             for s in 2:S
-                Y_sel = y[X_q[s].<X_di.<=X_q[s+1]]
+                Y_sel = @view(y[X_q[s].<X_di.<=X_q[s+1]])
                 if length(Y_sel) == 0
                     continue  # no available samples
                 end
@@ -83,7 +84,7 @@ function pawn(X::T1, y::T2, factor_names::Vector{String}; S::Int64=10)::NamedDim
                 pawn_t[s, d_i] = ks_statistic(ApproximateTwoSampleKSTest(Y_sel, y))
             end
 
-            p_ind = pawn_t[:, d_i]
+            p_ind = @view(pawn_t[:, d_i])
             p_mean = mean(p_ind)
             p_sdv = std(p_ind)
             p_cv = p_sdv ./ p_mean

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -96,9 +96,6 @@ function pawn(X::T1, y::T2, factor_names::Vector{String}; S::Int64=10)::NamedDim
 
     return NamedDimsArray(results; factors=Symbol.(factor_names), Si=[:min, :mean, :median, :max, :std, :cv])
 end
-function pawn(X::Vector{<:Real}, y::NamedDimsArray, factor_names::Vector{String}; S::Int64=10)::NamedDimsArray
-    return pawn(reshape(X, :, 1), y, factor_names; S=S)
-end
 function pawn(X::DataFrame, y::AbstractVector; S::Int64=10)::NamedDimsArray
     return pawn(Matrix(X), y, names(X); S=S)
 end


### PR DESCRIPTION
Use views to reduce memory allocations / data copying

Use `@floop` to calculate $S$ for each factor using threads

Example (spacing added for readability):

```julia
julia> @time begin
           n = 8192 * 8
           X = rand(n, 3)
           @info "Size of X:" size(X)
           results = NamedDimsArray(X[:, 3], scenarios=1:n)
           ADRIA.sensitivity.pawn(X, results, ["dummy1", "dummy2", "real1"])
       end

┌ Info: Size of X:
└   size(X) = (65536, 3)

  0.153640 seconds (1.06 k allocations: 89.405 MiB, 22.54% gc time)

2-dimensional NamedDimsArray(KeyedArray(...)) with keys:
↓   factors ∈ 3-element Vector{Symbol}
→   Si ∈ 6-element Vector{Symbol}
And data, 3×6 StaticArraysCore.MMatrix{3, 6, Float64, 18} with indices SOneTo(3)×SOneTo(6):
             (:min)     (:mean)    (:median)  (:max)     (:std)     (:cv)
  (:dummy1)   0.52819    0.696462   0.726732   0.898241   0.143296   0.205748
  (:dummy2)   0.443938   0.914592   0.906355   1.24633    0.230881   0.252442
  (:real1)   38.5918    54.0307    54.0302    69.4697    11.5068     0.212968
```