### PR TITLE
Fix print_rules condition

### DIFF
--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -87,7 +87,7 @@ compact form.
 - `rules` : Vector of Rule objects
 """
 function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})
-    condition(rule) = [c == :L ? "$(c[1]) < $(c[3])" : "$(c[1]) ≥ $(c[3])" for c in rule.condition]
+    condition(rule) = [c[2] == :L ? "$(c[1]) < $(c[3])" : "$(c[1]) ≥ $(c[3])" for c in rule.condition]
     consequent(rule) = " then $(rule.consequent[1]) else $(rule.consequent[2])\n"
     rule_string(rule) = "if " * join(condition(rule), " & ") * consequent(rule)
     print(join([rule_string(rule) for rule in rules]))

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -86,11 +86,13 @@ compact form.
 # Arguments
 - `rules` : Vector of Rule objects
 """
-function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})
+function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothing
     condition(rule) = [c[2] == :L ? "$(c[1]) < $(c[3])" : "$(c[1]) ≥ $(c[3])" for c in rule.condition]
     consequent(rule) = " then $(rule.consequent[1]) else $(rule.consequent[2])\n"
     rule_string(rule) = "if " * join(condition(rule), " & ") * consequent(rule)
     print(join([rule_string(rule) for rule in rules]))
+
+    return nothing
 end
 
 


### PR DESCRIPTION
Instead of checking if a clause second element was :L or :R, it was checking the whole clause. which was always false. That was causing the prints to always use the "greater than or equal" for all clauses.
