### PR TITLE
Adjust PAWN function to support 1D matrix for convenience

### DIFF
--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -154,7 +154,7 @@ end
 function pawn(X::NamedDimsArray, y::Union{NamedDimsArray,AbstractVector{<:Real}}; S::Int64=10)::NamedDimsArray
     return pawn(X, y, axiskeys(X, 2); S=S)
 end
-function pawn(X::Union{DataFrame,AbstractMatrix{<:Real}}, y::AbstractMatrix{<:Real}; S::Int64=10)::NamedDimsArray
+function pawn(X::Union{DataFrame,NamedDimsArray}, y::AbstractMatrix{<:Real}; S::Int64=10)::NamedDimsArray
     N, D = size(y)
     if N > 1 && D > 1
         msg::String = string(

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -81,17 +81,17 @@ ADRIA.sensitivity.pawn(rs, μ_tac)
 
 # Extended help
 Pianosi and Wagener have made public their review responding to a critique of their method
-by Puy et al., (2020). A key criticism by Puy et al. was that the PAWN method is sensitive to its
-tuning parameters and thus may produce biased results. The tuning parameters referred to are
-the number of samples (\$N\$) and the number of conditioning points - \$n\$ in Puy et al., but
-denoted as \$S\$ here.
+by Puy et al., (2020). A key criticism by Puy et al. was that the PAWN method is sensitive
+to its tuning parameters and thus may produce biased results. The tuning parameters referred
+to are the number of samples (\$N\$) and the number of conditioning points - \$n\$ in Puy et
+al., but denoted as \$S\$ here.
 
-Puy et al., found that the ratio of \$N\$ (number of samples) to \$S\$ has to be sufficiently high
-(\$N/S > 80\$) to avoid biased results. Pianosi and Wagener point  out this requirement is not
-particularly difficult to meet. Using the recommended value (\$S := 10\$), a sample of 1024 runs
-(small for purposes of Global Sensitivity Analysis) meets this requirement (\$1024/10 = 102.4\$).
-Additionally, lower values of \$N/S\$ is more an indication of faulty experimental design moreso
-than any deficiency of the PAWN method.
+Puy et al., found that the ratio of \$N\$ (number of samples) to \$S\$ has to be
+sufficiently high (\$N/S > 80\$) to avoid biased results. Pianosi and Wagener point out this
+requirement is not particularly difficult to meet. Using the recommended value
+(\$S := 10\$), a sample of 1024 runs (small for purposes of Global Sensitivity Analysis)
+meets this requirement (\$1024/10 = 102.4\$). Additionally, lower values of \$N/S\$ is more
+an indication of faulty experimental design moreso than any deficiency of the PAWN method.
 """
 function pawn(
     X::AbstractMatrix{<:Real},
@@ -151,10 +151,18 @@ end
 function pawn(X::DataFrame, y::AbstractVector{<:Real}; S::Int64=10)::NamedDimsArray
     return pawn(Matrix(X), y, names(X); S=S)
 end
-function pawn(X::NamedDimsArray, y::Union{NamedDimsArray,AbstractVector{<:Real}}; S::Int64=10)::NamedDimsArray
+function pawn(
+    X::NamedDimsArray,
+    y::Union{NamedDimsArray,AbstractVector{<:Real}};
+    S::Int64=10
+)::NamedDimsArray
     return pawn(X, y, axiskeys(X, 2); S=S)
 end
-function pawn(X::Union{DataFrame,NamedDimsArray}, y::AbstractMatrix{<:Real}; S::Int64=10)::NamedDimsArray
+function pawn(
+    X::Union{DataFrame,NamedDimsArray},
+    y::AbstractMatrix{<:Real};
+    S::Int64=10
+)::NamedDimsArray
     N, D = size(y)
     if N > 1 && D > 1
         msg::String = string(
@@ -168,7 +176,11 @@ function pawn(X::Union{DataFrame,NamedDimsArray}, y::AbstractMatrix{<:Real}; S::
     # (N x 1 or 1 x D) and so ensures a vector is passed along
     return pawn(X, vec(y); S=S)
 end
-function pawn(rs::ResultSet, y::Union{NamedDimsArray,AbstractVector{<:Real}}; S::Int64=10)::NamedDimsArray
+function pawn(
+    rs::ResultSet,
+    y::Union{NamedDimsArray,AbstractVector{<:Real}};
+    S::Int64=10
+)::NamedDimsArray
     return pawn(rs.inputs, y; S=S)
 end
 

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -93,7 +93,12 @@ particularly difficult to meet. Using the recommended value (\$S := 10\$), a sam
 Additionally, lower values of \$N/S\$ is more an indication of faulty experimental design moreso
 than any deficiency of the PAWN method.
 """
-function pawn(X::AbstractMatrix{<:Real}, y::AbstractVector{<:Real}, factor_names::Vector{String}; S::Int64=10)::NamedDimsArray
+function pawn(
+    X::AbstractMatrix{<:Real},
+    y::AbstractVector{<:Real},
+    factor_names::Vector{String};
+    S::Int64=10
+)::NamedDimsArray
     N, D = size(X)
     step = 1 / S
     seq = 0.0:step:1.0
@@ -127,13 +132,21 @@ function pawn(X::AbstractMatrix{<:Real}, y::AbstractVector{<:Real}, factor_names
             p_mean = mean(p_ind)
             p_sdv = std(p_ind)
             p_cv = p_sdv ./ p_mean
-            results[d_i, :] .= (minimum(p_ind), p_mean, median(p_ind), maximum(p_ind), p_sdv, p_cv)
+            results[d_i, :] .= (
+                minimum(p_ind),
+                p_mean,
+                median(p_ind),
+                maximum(p_ind),
+                p_sdv,
+                p_cv
+            )
         end
     end
 
     replace!(results, NaN => 0.0, Inf => 0.0)
 
-    return NamedDimsArray(results; factors=Symbol.(factor_names), Si=[:min, :mean, :median, :max, :std, :cv])
+    col_names = [:min, :mean, :median, :max, :std, :cv]
+    return NamedDimsArray(results; factors=Symbol.(factor_names), Si=col_names)
 end
 function pawn(X::DataFrame, y::AbstractVector{<:Real}; S::Int64=10)::NamedDimsArray
     return pawn(Matrix(X), y, names(X); S=S)
@@ -144,7 +157,11 @@ end
 function pawn(X::Union{DataFrame,AbstractMatrix{<:Real}}, y::AbstractMatrix{<:Real}; S::Int64=10)::NamedDimsArray
     N, D = size(y)
     if N > 1 && D > 1
-        throw(ArgumentError("The current implementation of PAWN can only assess a single quantity of interest at a time."))
+        msg::String = string(
+            "The current implementation of PAWN can only assess a single quantity",
+            " of interest at a time."
+        )
+        throw(ArgumentError(msg))
     end
 
     # The wrapped call to `vec()` handles cases where matrix-like data type is passed in

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -29,16 +29,18 @@ end
 
 Calculates the PAWN sensitivity index.
 
-The PAWN method (by Pianosi and Wagener) is a moment-independent approach to Global Sensitivity Analysis.
-Outputs are characterized by their Cumulative Distribution Function (CDF), quantifying the variation in
-the output distribution after conditioning an input over "slices" (\$S\$) - the conditioning intervals.
-If both distributions coincide at all slices (i.e., the distributions are similar or identical), then
-the factor is deemed non-influential.
+The PAWN method (by Pianosi and Wagener) is a moment-independent approach to Global
+Sensitivity Analysis. Outputs are characterized by their Cumulative Distribution Function
+(CDF), quantifying the variation in the output distribution after conditioning an input over
+"slices" (\$S\$) - the conditioning intervals. If both distributions coincide at all slices
+(i.e., the distributions are similar or identical), then the factor is deemed
+non-influential.
 
-This implementation applies the Kolmogorov-Smirnov test as the distance measure and returns summary
-statistics (min, mean, median, max, std, and cv) over the slices.
+This implementation applies the Kolmogorov-Smirnov test as the distance measure and returns
+summary statistics (min, mean, median, max, std, and cv) over the slices.
 
 # Arguments
+- `rs` : ResultSet
 - `X` : Model inputs
 - `y` : Model outputs
 - `factor_names` : Names of each factor represented by columns in `X`

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -102,7 +102,16 @@ end
 function pawn(X::NamedDimsArray, y::T; S::Int64=10)::NamedDimsArray where {T<:Union{NamedDimsArray,AbstractVector{<:Real}}}
     return pawn(X, y, axiskeys(X, 2); S=S)
 end
-function pawn(rs::ResultSet, y::T; S::Int64=10)::NamedDimsArray where {T<:Union{NamedDimsArray,AbstractVector{<:Real}}}
+function pawn(X::Union{DataFrame,AbstractMatrix{<:Real}}, y::AbstractMatrix{<:Real}; S::Int64=10)::NamedDimsArray
+    if size(y, 2) > 1
+        throw(ValueError("The current implementation of PAWN can only assess a single quantity of interest at a time."))
+    end
+
+    # The wrapped call to vec(collect()) handles cases where a NamedDimsArray or adjoint matrix
+    # type is passed in
+    return pawn(X, vec(collect(y)); S=S)
+end
+function pawn(rs::ResultSet, y::Union{NamedDimsArray,AbstractVector{<:Real}}; S::Int64=10)::NamedDimsArray
     return pawn(rs.inputs, y; S=S)
 end
 


### PR DESCRIPTION
Say a user was assessing the mean of some scenario outcome

```julia
μ_tac = mean(ADRIA.metrics.scenario_total_cover(rs), dims=:timesteps)
ADRIA.sensitivity.pawn(rs, μ_tac)
```

Previously, this would fail with an error as `μ_tac` would be a matrix (i.e., $1 \times N$) rather than a vector which the method expects.

The change also supports transposed matrices:

```julia
μ_tac = mean(ADRIA.metrics.scenario_total_cover(rs), dims=:timesteps)'  # note the transpose!
ADRIA.sensitivity.pawn(rs, μ_tac)
```

The above `μ_tac` would be an $N \times 1$ matrix (again, instead of a vector).

The PR supports implicit conversion to vector simply for convenience.

Originally, the user was expected to convert to vector explicitly prior to use:

```julia
μ_tac = vec(mean(ADRIA.metrics.scenario_total_cover(rs), dims=:timesteps))
```

which is a little tedious to remember to do every time.

This PR also expands and updates the docstring to detail all methods and provide additional contextual information of the method.