### PR TITLE
Update Reef Tourism Index regression coefficient (temporary solution)

### DIFF
--- a/src/metrics/performance.jl
+++ b/src/metrics/performance.jl
@@ -41,19 +41,19 @@ Gini's Mean Difference.
 The absolute mean of all pairwise distances between elements in a given set.
 
 # References
-1. La Haye, R., & Zizler, P. (2019). 
-   The Gini mean difference and variance. 
-   METRON, 77(1), 43-52. 
+1. La Haye, R., & Zizler, P. (2019).
+   The Gini mean difference and variance.
+   METRON, 77(1), 43-52.
    https://doi.org/10.1007/s40300-019-00149-2
 
-2. Yitzhaki, S. (2003). 
+2. Yitzhaki, S. (2003).
    Gini's Mean difference: A superior measure of variability for non-normal
-     distributions. 
+     distributions.
    Metron - International Journal of Statistics, LXI(2), 285-316.
    https://ideas.repec.org/a/mtn/ancoec/030208.html
 
 3. Kashif, M., Aslam, M., Al-Marshadi, A. H., & Jun, C.-H. (2016).
-   Capability Indices for Non-Normal Distribution Using Gini's Mean Difference as Measure of Variability. 
+   Capability Indices for Non-Normal Distribution Using Gini's Mean Difference as Measure of Variability.
    IEEE Access, 4, 7322-7330.
    https://doi.org/10.1109/ACCESS.2016.2620241
 """

--- a/src/metrics/reef_indices.jl
+++ b/src/metrics/reef_indices.jl
@@ -153,6 +153,11 @@ end
 
 Estimate tourism index.
 
+Note:
+This metric assumes all inputs (relative cover, evenness, shelter volume, coral juveniles)
+are scaled between 0 and 1. For evenness, shelter volume and coral juveniles, a value of 1
+may represent a theoretical maximum.
+
 # Arguments
 - `rc` : Relative coral cover across all groups
 - `evenness` : Evenness across all coral groups

--- a/src/metrics/reef_indices.jl
+++ b/src/metrics/reef_indices.jl
@@ -198,7 +198,7 @@ function _reef_fish_index(rc::AbstractArray, intcp_u1, intcp_u2)
     # 0.01 coefficient is to convert from kg ha to kg km2
     return round.(rfi, digits=2)
 end
-function _reef_fish_index(rs::ResultSet; intcp_u1::Bool=true, intcp_u2::Bool=true)
+function _reef_fish_index(rs::ResultSet; intcp_u1::Bool=false, intcp_u2::Bool=false)
     rc = relative_cover(rs)
     n_scens = size(rc, :scenarios)
     icp1 = intcp_u1 ? rand(Normal(0.0, 0.195), n_scens) : zeros(n_scens)

--- a/src/metrics/reef_indices.jl
+++ b/src/metrics/reef_indices.jl
@@ -123,19 +123,19 @@ scenario_rci = Metric(_scenario_rci, (:timesteps, :scenarios))
 
 
 function _reef_tourism_index(rc::AbstractArray, evenness::AbstractArray, sv::AbstractArray, juves::AbstractArray, intcp_u::Vector)::AbstractArray
-    intcp = -0.498 .+ intcp_u
+    intcp = 0.47947 .+ intcp_u
 
     # TODO: Ryan to reinterpolate to account for no CoTS and no rubble
     # Apply unique intercepts for each scenario
-    rti = cat(map(axe -> (intcp[axe] .+ (0.291 .* rc[:, :, axe]) .+
-                          (0.056 .* evenness[:, :, axe]) .+
-                          (0.628 .* sv[:, :, axe]) .+
-                          (1.335 .* juves[:, :, axe])
+    rti = cat(map(axe -> (intcp[axe] .+ (0.12764 .* rc[:, :, axe]) .+
+                          (0.31946 .* evenness[:, :, axe]) .+
+                          (0.11676 .* sv[:, :, axe]) .+
+                          (-0.0036065 .* juves[:, :, axe])
             ), axes(rc, 3))..., dims=3)
 
     return round.(clamp.(rti, 0.1, 0.9), digits=2)
 end
-function _reef_tourism_index(rs::ResultSet; intcp_u::Bool=true)::AbstractArray
+function _reef_tourism_index(rs::ResultSet; intcp_u::Bool=false)::AbstractArray
     rc::AbstractArray{<:Real} = relative_cover(rs)
     juves::AbstractArray{<:Real} = juvenile_indicator(rs)
     evenness::AbstractArray{<:Real} = coral_evenness(rs)


### PR DESCRIPTION
Stopgap update to coefficients used for the Reef Tourism Index metric.

Notes from Ryan:
Note the coral juveniles coefficient is not significant. The overall model fit isn’t great either – 13.4% R-squared. 
This is a very ad-hoc solution for the tourism indicator until something better is thought of.