### PR TITLE
Add option to show GBRMPA management zones

### DIFF
--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -148,14 +148,21 @@ function ADRIA.viz.map(
 end
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
+    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
     opts[:colorbar_label] = get(opts, :colorbar_label, "Coral Real Estate [%]")
+
+    opts[:show_management_zones] = get(opts, :show_management_zones, false)
+    if opts[:show_management_zones]
+        highlight = rs.site_data.zone_type .|> lowercase .|> Symbol
+        opts[:highlight] = highlight
+    end
+
     ADRIA.viz.map!(g, rs, rs.site_data.k; opts, axis_opts)
 
     return f


### PR DESCRIPTION
Add option to mapping to show management zones (defaults to false.

```julia
ADRIA.viz.map(dom; opts=Dict{Symbol,Any}(:show_management_zones=>true))
```

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/af740cf5-57aa-4d44-a108-e10441f21ed1)

Awkward dictionary-based option setting needs to be addressed somehow.
Specifying the types in the dictionary is necessary, otherwise Julia tries to optimize by restricting the Dict only to `Symbol=>Bool` pairs, which causes an issue when other options with different types get set (such as `Symbol=>String`).

