### PR TITLE
Rename time_series_clustering and ts_cluster

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -191,7 +191,7 @@ s_tac = ADRIA.metrics.scenario_total_cover(rs)
 
 # Cluster scenarios
 n_clusters = 6
-clusters = ADRIA.analysis.cluster_series(s_tac, n_clusters)
+clusters = ADRIA.analysis.cluster_scenarios(s_tac, n_clusters)
 
 axis_opts = Dict(
     :title => "Time Series Clustering with $n_clusters clusters",
@@ -227,7 +227,7 @@ tac_site_series = ADRIA.metrics.loc_trajectory(median, tac)
 
 # Cluster scenarios
 n_clusters = 6
-clusters = ADRIA.analysis.cluster_series(tac_site_series, n_clusters)
+clusters = ADRIA.analysis.cluster_scenarios(tac_site_series, n_clusters)
 
 # Get a vector summarizing the scenarios and timesteps for each site
 tac_sites = ADRIA.metrics.per_loc(median, tac)

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -198,7 +198,7 @@ axis_opts = Dict(
     :ylabel => "TAC [m²]",
     :xlabel => "Timesteps [years]"
 )
-tsc_fig = ADRIA.viz.ts_cluster(
+tsc_fig = ADRIA.viz.clustered_scenarios(
     s_tac,
     clusters;
     fig_opts=fig_opts,

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -191,7 +191,7 @@ s_tac = ADRIA.metrics.scenario_total_cover(rs)
 
 # Cluster scenarios
 n_clusters = 6
-clusters = ADRIA.analysis.time_series_clustering(s_tac, n_clusters)
+clusters = ADRIA.analysis.cluster_series(s_tac, n_clusters)
 
 axis_opts = Dict(
     :title => "Time Series Clustering with $n_clusters clusters",
@@ -227,7 +227,7 @@ tac_site_series = ADRIA.metrics.loc_trajectory(median, tac)
 
 # Cluster scenarios
 n_clusters = 6
-clusters = ADRIA.analysis.time_series_clustering(tac_site_series, n_clusters)
+clusters = ADRIA.analysis.cluster_series(tac_site_series, n_clusters)
 
 # Get a vector summarizing the scenarios and timesteps for each site
 tac_sites = ADRIA.metrics.per_loc(median, tac)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,8 +1,8 @@
 using JuliennedArrays
 
 """
-    ts_cluster(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    ts_cluster!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
+    clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    clustered_scenarios(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
 
 Visualize clustered time series of scenarios.
 
@@ -13,7 +13,7 @@ Visualize clustered time series of scenarios.
 # Returns
 Figure
 """
-function ADRIA.viz.ts_cluster(
+function ADRIA.viz.clustered_scenarios(
     data::AbstractMatrix,
     clusters::Vector{Int64};
     fig_opts::Dict=Dict(),
@@ -22,11 +22,11 @@ function ADRIA.viz.ts_cluster(
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
-    ADRIA.viz.ts_cluster!(g, data, clusters; axis_opts=axis_opts)
+    ADRIA.viz.clustered_scenarios(g, data, clusters; axis_opts=axis_opts)
 
     return f
 end
-function ADRIA.viz.ts_cluster!(
+function ADRIA.viz.clustered_scenarios(
     g::Union{GridLayout,GridPosition},
     data::AbstractMatrix,
     clusters::Vector{Int64};

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -2,7 +2,7 @@ using JuliennedArrays
 
 """
     clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    clustered_scenarios(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
+    clustered_scenarios!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
 
 Visualize clustered time series of scenarios.
 
@@ -22,11 +22,11 @@ function ADRIA.viz.clustered_scenarios(
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
-    ADRIA.viz.clustered_scenarios(g, data, clusters; axis_opts=axis_opts)
+    ADRIA.viz.clustered_scenarios!(g, data, clusters; axis_opts=axis_opts)
 
     return f
 end
-function ADRIA.viz.clustered_scenarios(
+function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
     data::AbstractMatrix,
     clusters::Vector{Int64};

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -91,9 +91,9 @@ function complexity_invariance_distance(
 end
 
 """
-    time_series_clustering(data::AbstractMatrix{T}, n_clusters::Int64)::Vector{Int64} where {T<:Real}
+    cluster_series(data::AbstractMatrix{T}, n_clusters::Int64)::Vector{Int64} where {T<:Real}
 
-Hierarchical clustering between \$S\$ scenarios with \$T\$ time steps each.
+Hierarchical cluster \$S\$ scenarios with \$T\$ time steps each.
 
 # Arguments
 - `data` : Matrix of \$T ⋅ S\$, where \$T\$ is total number of time steps and \$S\$ is
@@ -114,7 +114,7 @@ Hierarchical clustering between \$S\$ scenarios with \$T\$ time steps each.
    Data Min Knowl Disc 28, 634-669.
    https://doi.org/10.1007/s10618-013-0312-3
 """
-function time_series_clustering(
+function cluster_series(
     data::AbstractMatrix{T},
     n_clusters::Int64
 )::Vector where {T<:Real}

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -93,7 +93,8 @@ end
 """
     cluster_series(data::AbstractMatrix{T}, n_clusters::Int64)::Vector{Int64} where {T<:Real}
 
-Hierarchical cluster \$S\$ scenarios with \$T\$ time steps each.
+Hierarchically cluster \$S\$ scenarios with \$T\$ time steps each.
+
 
 # Arguments
 - `data` : Matrix of \$T ⋅ S\$, where \$T\$ is total number of time steps and \$S\$ is

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -128,6 +128,26 @@ function cluster_series(
 end
 
 """
+    cluster_scenarios(data::AbstractMatrix{T}, n_clusters::Int64)::Vector{Int64} where {T<:Real}
+
+Alias to cluster_series.
+
+# Arguments
+- `data` : Matrix of \$T ⋅ S\$, where \$T\$ is total number of time steps and \$S\$ is
+  number of scenarios
+- `n_clusters` : Number of clusters determined _a priori_.
+
+# Returns
+- `Vector` : Cluster ids indicating which cluster each scenario belongs to.
+"""
+function cluster_scenarios(
+    data::AbstractMatrix{T},
+    n_clusters::Int64
+)::Vector where {T<:Real}
+    return cluster_series(data, n_clusters)
+end
+
+"""
     target_clusters(clusters::Vector{T}, outcomes::AbstractMatrix{F}; metric=temporal_variability, size_limit=0.01) where {T<:Int64,F<:Real}
 
 Categorize all clusters into target or non-target according to some metric.

--- a/src/viz/viz.jl
+++ b/src/viz/viz.jl
@@ -27,8 +27,8 @@ function outcome_map() end
 function outcome_map!() end
 
 # Clustering
-function ts_cluster() end
-function ts_cluster!() end
+function clustered_scenarios() end
+function clustered_scenarios() end
 function ts_spatial_cluster() end
 function ts_spatial_cluster!() end
 

--- a/src/viz/viz.jl
+++ b/src/viz/viz.jl
@@ -28,7 +28,7 @@ function outcome_map!() end
 
 # Clustering
 function clustered_scenarios() end
-function clustered_scenarios() end
+function clustered_scenarios!() end
 function ts_spatial_cluster() end
 function ts_spatial_cluster!() end
 

--- a/src/viz/viz.jl
+++ b/src/viz/viz.jl
@@ -29,8 +29,6 @@ function outcome_map!() end
 # Clustering
 function clustered_scenarios() end
 function clustered_scenarios!() end
-function ts_spatial_cluster() end
-function ts_spatial_cluster!() end
 
 # Rule extraction
 function rules_scatter() end

--- a/test/clustering.jl
+++ b/test/clustering.jl
@@ -53,9 +53,9 @@
             @test cid[1, 1] == cid[2, 2] == cid[3, 3] == 0.0
         end
 
-        @testset "Call time_series_clustering function" begin
+        @testset "Call cluster_series function" begin
             num_clusters = 5
-            clusters = ADRIA.analysis.time_series_clustering(test_data, num_clusters)
+            clusters = ADRIA.analysis.cluster_series(test_data, num_clusters)
 
             @test length(clusters) == size(test_data, 2)
             @test -1 ∉ clusters
@@ -89,9 +89,9 @@
             @test ce[5] == 1
         end
 
-        @testset "Call time_series_clustering function" begin
+        @testset "Call cluster_series function" begin
             num_clusters = 5
-            clusters = ADRIA.analysis.time_series_clustering(const_test_data, num_clusters)
+            clusters = ADRIA.analysis.cluster_series(const_test_data, num_clusters)
 
             @test length(clusters) == size(const_test_data, 2)
         end


### PR DESCRIPTION
Those two functions names were not according to blue style guide and were not very meaningful (in particular `ts_cluster`). We should have functions whose names tell "what they do" (like `cluster_series`) or what they return (like `clustered_scenarios`).