### PR TITLE
Adjust `run_model()` to only require values relative to $k$ area

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -115,7 +115,7 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     Base.precompile(Tuple{typeof(bleaching_mortality!),Matrix{Float64},Matrix{Float64},Vector{Float64},Int64,Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Float64})   # time: 0.1940948
     Base.precompile(Tuple{typeof(create_decision_matrix),Vector{Int64},Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Matrix{Float64},Matrix{Float64},Float64})   # time: 0.1929096
     Base.precompile(Tuple{typeof(scenario_attributes),String,String,Vector{String},String,EnvLayer{String,Vector{Any}},Dict{String,Any},Vector{Any},Vector{Float64},Vector{Float64},Vector{Any}})   # time: 0.1755622
-    Base.precompile(Tuple{typeof(proportional_adjustment!),Matrix{Float64},Vector{Float64},Vector{Float64}})   # time: 0.1680073
+    Base.precompile(Tuple{typeof(proportional_adjustment!),Matrix{Float64},Vector{Float64}})   # time: 0.1680073
     Base.precompile(Tuple{typeof(_remove_workers)})   # time: 0.1593244
     Base.precompile(Tuple{typeof(_setup_workers)})   # time: 0.1571776
     Base.precompile(Tuple{typeof(switch_RCPs!),Domain,String})   # time: 0.1284853

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -240,16 +240,18 @@ function n_locations(domain::Domain)::Int64
 end
 
 """
-    relative_leftover_space(domain::Domain)::Vector{Float64}
-    relative_leftover_space(site_k::Matrix{Float64}, site_coral_cover::Matrix{Float64})::Matrix{Float64}
+    relative_leftover_space(loc_coral_cover::Matrix{Float64})::Matrix{Float64}
 
 Get proportion of leftover space, given site_k and proportional cover on each site, summed over species.
+
+# Arguments
+- `loc_coral_cover` : Proportion of coral cover relative to `k` (maximum carrying capacity).
+
+# Returns
+Leftover space ∈ [0, 1]
 """
-function relative_leftover_space(domain::Domain, site_coral_cover::Matrix{Float64})::Matrix{Float64}
-    return relative_leftover_space(site_k(domain)', site_coral_cover)
-end
-function relative_leftover_space(site_k::AbstractArray{Float64,2}, site_coral_cover::Matrix{Float64})::Matrix{Float64}
-    return max.(site_k .- site_coral_cover, 0.0)
+function relative_leftover_space(loc_coral_cover::Matrix{Float64})::Matrix{Float64}
+    return max.(1.0 .- loc_coral_cover, 0.0)
 end
 
 """

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -595,25 +595,30 @@ Note: Units for all areas are assumed to be in m².
 # Returns
 Area covered by recruited larvae (in m²)
 """
-function settler_cover(fec_scope::T,
-    TP_data::T, leftover_space::T,
-    α::V, β::V, basal_area_per_settler::V)::T where {T<:Matrix{Float64},V<:Vector{Float64}}
+function settler_cover(
+    fec_scope::T,
+    TP_data::T,
+    leftover_space::T,
+    α::V,
+    β::V,
+    basal_area_per_settler::V
+)::T where {T<:Matrix{Float64},V<:Vector{Float64}}
+    # Constrain to locations with connectivity
+    valid_locs::BitVector = sum.(eachcol(TP_data)) .> 0.0
+
+    # Reduce fecundity based on past stress events
+    # Note: deactivated for now as no empirical data to support approach.
+    # fec_scope .= (fec_scope .* sf)
 
     # Send larvae out into the world (reuse fec_scope to reduce allocations)
-    # fec_scope .= (fec_scope .* sf)
-    # fec_scope .= (fec_scope * TP_data) .* (1.0 .- Mwater)  # larval pool for each site (in larvae/m²)
-
-    valid_locs::BitVector = sum.(eachcol(TP_data)) .> 0.0
-    # _subset = TP_data[valid_locs, valid_locs]
+    # Larval pool for each site (in larvae/m²)
+    # fec_scope .= (fec_scope * TP_data) .* (1.0 .- Mwater)
 
     # As above, but more performant, less readable.
     Mwater::Float64 = 0.95
-    fec_scope[:, valid_locs] .= (fec_scope[:, valid_locs] * TP_data[valid_locs, valid_locs]) .* (1.0 .- Mwater)
-    # fec_scope .*= (1.0 .- Mwater)
-    # fec_scope .= (fec_scope * TP_data) .* (1.0 .- Mwater)
-    # fec_scope .*= (1.0 .- Mwater)
-    # fec_scope *= fec_scope * TP_data
-    # fec_scope .*= (1.0 .- Mwater)
+    fec_scope[:, valid_locs] .= (
+        fec_scope[:, valid_locs] * TP_data[valid_locs, valid_locs]
+    ) .* (1.0 .- Mwater)
 
     # Larvae have landed, work out how many are recruited
     # recruits per m^2 per site multiplied by area per settler

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -25,27 +25,34 @@ end
 
 
 """
-    proportional_adjustment!(covers::Matrix{T}, cover_tmp::Vector{T}, max_cover::Array{T})::Nothing where {T<:Real}
+    proportional_adjustment!(coral_cover::Matrix{T}, max_cover::Array{T})::Nothing where {T<:Float64}
 
-Helper method to proportionally adjust coral cover.
+Helper method to proportionally adjust coral cover, such that:
+- `coral_cover` ∈ [0, 1].
+- `sum(coral_cover, dims=1)` ≯  1.0
+
 Modifies arrays in-place.
 
 # Arguments
-- `covers` : Coral cover result set
-- `cover_tmp` : Temporary cache matrix used to hold sum over species. Avoids memory allocations
+- `coral_cover` : Coral cover
 - `max_cover` : Maximum possible coral cover for each site
+
+# Returns
+nothing
 """
-function proportional_adjustment!(covers::Union{SubArray{T},Matrix{T}}, cover_tmp::Vector{T}, max_cover::Array{T})::Nothing where {T<:Float64}
-    # Proportionally adjust initial covers
-    cover_tmp .= vec(sum(covers, dims=1))
+function proportional_adjustment!(
+    coral_cover::Union{SubArray{T},Matrix{T}},
+    max_cover::Array{T}
+)::Nothing where {T<:Float64}
+    cover_tmp = vec(sum(coral_cover, dims=1))
     if any(cover_tmp .> max_cover)
         exceeded::Vector{Int64} = findall(cover_tmp .> max_cover)
-        @views @. covers[:, exceeded] = (covers[:, exceeded] / cover_tmp[exceeded]') * max_cover[exceeded]'
+        @views @. coral_cover[:, exceeded] = (coral_cover[:, exceeded] / cover_tmp[exceeded]') * max_cover[exceeded]'
     end
 
-    covers .= max.(covers, 0.0)
+    coral_cover .= max.(coral_cover, 0.0)
 
-    return
+    return nothing
 end
 
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -35,7 +35,6 @@ function seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space::V,
     #     proportion * (area of 1 coral * num seeded corals)
     # Convert to relative cover proportion by dividing by site area
     scaled_seed = ((prop_area_avail .* seeded_area') ./ loc_k_area[seed_locs])'
-    # scaled_seed = distribute_seeded_corals(loc_k_area[seed_locs], leftover_space[seed_locs], seeded_area)
 
     # Seed each site and log
     @views cover[seed_sc, seed_locs] .+= scaled_seed

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -26,17 +26,17 @@ function seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space::V,
 
     # Calculate proportion to seed based on current available space
 
-    # Proportion of available space on each site relative to total space available on these
-    # sites
+    # Proportion of available space on each site relative to available space at these
+    # locations
     prop_area_avail = leftover_space[seed_locs] ./ sum(loc_k_area[seed_locs])
 
-    # Distribute seeded corals (as area) across sites according to available space
+    # Distribute seeded corals (as area) across locations according to available space
     # proportions:
     #     proportion * (area of 1 coral * num seeded corals)
-    # Convert to relative cover proportion by dividing by site area
+    # Convert to relative cover proportion by dividing by location area
     scaled_seed = ((prop_area_avail .* seeded_area') ./ loc_k_area[seed_locs])'
 
-    # Seed each site and log
+    # Seed each location and log
     @views cover[seed_sc, seed_locs] .+= scaled_seed
     Yseed[:, seed_locs] .= scaled_seed
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -1,37 +1,4 @@
 """
-    distribute_seeded_corals(seed_loc_area::Vector{Float64},
-        available_space::Vector{Float64},
-        seeded_area::NamedDimsArray)::NamedDimsArray
-
-Calculate proportion of deployed corals to be seeded at each of the selected locations.
-Distributes seeded corals according to current available space at each selected site.
-
-# Arguments
-- seed_loc_area : area of locations to seed in m².
-- available_space : currently available space at each seed location in m².
-- seeded_area : area (in m²) of each coral type to be seeded with dim taxa.
-
-# Returns
-scaled_seed : NamedDimsArray [taxa to seed ⋅ number of seed locations]
-"""
-function distribute_seeded_corals(seed_loc_area::Vector{Float64},
-    available_space::Vector{Float64},
-    seeded_area::NamedDimsArray)::NamedDimsArray
-
-    # Proportion of available space on each site relative to total space available on these
-    # sites
-    prop_area_avail = available_space ./ sum(available_space)
-
-    # Distribute seeded corals (as area) across sites according to available space
-    # proportions:
-    #     proportion * (area of 1 coral * num seeded corals)
-    # Convert to relative cover proportion by dividing by site area
-    scaled_seed = ((prop_area_avail .* seeded_area') ./ seed_loc_area)'
-
-    return scaled_seed
-end
-
-"""
     seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
         seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
         Yseed::SubArray, stdev::V, c_dist_t::Matrix)::Nothing where {V<:Vector{Float64}}
@@ -53,12 +20,22 @@ Note: Units for all areas are expected to be identical, and are assumed to be in
 - `Yseed` : Log of seeded locations to update
 - `c_dist_t` : Critical DHW distributions of corals to update (i.e., for time \$t\$)
 """
-function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
+function seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space::V,
     seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
     Yseed::SubArray, stdev::V, c_dist_t::Matrix{<:Truncated})::Nothing where {V<:Vector{Float64}}
 
     # Calculate proportion to seed based on current available space
-    scaled_seed = distribute_seeded_corals(total_location_area[seed_locs], leftover_space[seed_locs], seeded_area)
+
+    # Proportion of available space on each site relative to total space available on these
+    # sites
+    prop_area_avail = leftover_space[seed_locs] ./ sum(loc_k_area[seed_locs])
+
+    # Distribute seeded corals (as area) across sites according to available space
+    # proportions:
+    #     proportion * (area of 1 coral * num seeded corals)
+    # Convert to relative cover proportion by dividing by site area
+    scaled_seed = ((prop_area_avail .* seeded_area') ./ loc_k_area[seed_locs])'
+    # scaled_seed = distribute_seeded_corals(loc_k_area[seed_locs], leftover_space[seed_locs], seeded_area)
 
     # Seed each site and log
     @views cover[seed_sc, seed_locs] .+= scaled_seed

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -381,17 +381,6 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     # Locations that can support corals
     valid_locs::BitVector = max_cover .> 0.0
 
-    # Initial coral cover is provided as values relative to location area.
-    # Convert coral covers to be relative to k area, ignoring locations with 0 carrying
-    # capacity (k area = 0.0).
-    absolute_k_area = site_k_area(domain)'  # max possible coral area in m^2
-    valid_locs::BitVector = absolute_k_area' .> 0.0
-    C_cover[1, :, valid_locs] .= (
-        (C_cover[1, :, valid_locs] .* cache.site_area[valid_locs]')
-        ./
-        absolute_k_area[valid_locs]'
-    )
-
     site_ranks = SparseArray(zeros(tf, n_locs, 2))  # log seeding/fogging/shading ranks
     Yshade = SparseArray(spzeros(tf, n_locs))
     Yfog = SparseArray(spzeros(tf, n_locs))
@@ -634,8 +623,13 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         @views C_cover[tstep, :, valid_locs] .= clamp!(sol.u[end][:, valid_locs], 0.0, 1.0)
 
         if tstep <= tf
-            adjust_DHW_distribution!(@view(C_cover[tstep-1:tstep, :, :]), n_groups, c_dist_t,
-                p.r, corals.dist_std)
+            adjust_DHW_distribution!(
+                @view(C_cover[tstep-1:tstep, :, :]),
+                n_groups,
+                c_dist_t,
+                p.r,
+                corals.dist_std
+            )
 
             if in_debug_mode
                 # Log dhw tolerances if in debug mode

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -24,7 +24,8 @@ function setup_cache(domain::Domain)::NamedTuple
         dhw_step=zeros(n_sites),  # DHW for each time step
         cov_tmp=zeros(n_species, n_sites),  # Cover for previous timestep
         depth_coeff=zeros(n_sites),  # store for depth coefficient
-        site_area=Matrix{Float64}(site_area(domain)'),  # site areas
+        site_area=Matrix{Float64}(site_area(domain)'),  # area of locations
+        site_k_area=Matrix{Float64}(site_k_area(domain)'),  # location carrying capacity
         wave_scen=zeros(tf, n_sites),  # tmp store for wave scenario
         wave_damage=zeros(tf, n_species, n_sites),  # damage coefficient for each size class
         dhw_tol_mean_log=zeros(tf, n_species, n_sites),  # tmp log for mean dhw tolerances
@@ -343,7 +344,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     sim_params = domain.sim_constants
     tf::Int64 = size(dhw_scen, 1)
     n_site_int::Int64 = sim_params.n_site_int
-    n_sites::Int64 = domain.coral_growth.n_sites
+    n_locs::Int64 = domain.coral_growth.n_sites
     n_species::Int64 = domain.coral_growth.n_species
     n_groups::Int64 = domain.coral_growth.n_groups
 
@@ -356,7 +357,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     seed_years::Int64 = param_set("seed_years")  # number of years to seed
     shade_years::Int64 = param_set("shade_years")  # number of years to shade
 
-    total_loc_area::Matrix{Float64} = cache.site_area
+    loc_k_area::Matrix{Float64} = cache.site_k_area
     fec_params_per_m²::Vector{Float64} = corals.fecundity  # number of larvae produced per m²
 
     # Caches
@@ -371,18 +372,30 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     site_data = domain.site_data
     depth_coeff .= depth_coefficient.(site_data.depth_med)
 
-    Y_cover::Array{Float64,3} = zeros(tf, n_species, n_sites)  # Coral cover relative to total site area
-    Y_cover[1, :, :] .= domain.init_coral_cover
-    ode_u = zeros(n_species, n_sites)
+    # Coral cover relative to total site area
+    C_cover::Array{Float64,3} = zeros(tf, n_species, n_locs)
+    C_cover[1, :, :] .= domain.init_coral_cover
+    ode_u = zeros(n_species, n_locs)
     max_cover = site_k(domain)  # Max coral cover at each site (0 - 1).
 
     # Locations that can support corals
     valid_locs::BitVector = max_cover .> 0.0
 
-    site_ranks = SparseArray(zeros(tf, n_sites, 2))  # log seeding/fogging/shading ranks
-    Yshade = SparseArray(spzeros(tf, n_sites))
-    Yfog = SparseArray(spzeros(tf, n_sites))
-    Yseed = SparseArray(zeros(tf, 3, n_sites))  # 3 = the number of seeded coral types
+    # Initial coral cover is provided as values relative to location area.
+    # Convert coral covers to be relative to k area, ignoring locations with 0 carrying
+    # capacity (k area = 0.0).
+    absolute_k_area = site_k_area(domain)'  # max possible coral area in m^2
+    valid_locs::BitVector = absolute_k_area' .> 0.0
+    C_cover[1, :, valid_locs] .= (
+        (C_cover[1, :, valid_locs] .* cache.site_area[valid_locs]')
+        ./
+        absolute_k_area[valid_locs]'
+    )
+
+    site_ranks = SparseArray(zeros(tf, n_locs, 2))  # log seeding/fogging/shading ranks
+    Yshade = SparseArray(spzeros(tf, n_locs))
+    Yfog = SparseArray(spzeros(tf, n_locs))
+    Yseed = SparseArray(zeros(tf, 3, n_locs))  # 3 = the number of seeded coral types
 
     # Prep scenario-specific flags/values
     # Intervention strategy: < 0 is no intervention, 0 is random location selection, > 0 is guided
@@ -415,8 +428,8 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         shade_decision_years[shade_start_year] = true
     end
 
-    seed_locs::Vector{Int64} = zeros(Int, n_site_int)
-    shade_locs::Vector{Int64} = zeros(Int, n_site_int)
+    seed_locs::Vector{Int64} = zeros(Int64, n_site_int)
+    shade_locs::Vector{Int64} = zeros(Int64, n_site_int)
 
     # Set other params for ODE
     p.r .= corals.growth_rate  # Assumed growth_rate
@@ -443,7 +456,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     seed_corals = any(param_set(taxa_names) .> 0.0)
 
     # Defaults to considering all sites if depth cannot be considered.
-    depth_priority = collect(1:n_sites)
+    depth_priority = collect(1:n_locs)
 
     # Calculate total area to seed respecting tolerance for minimum available space to still
     # seed at a site
@@ -468,7 +481,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         rankings = [depth_priority zeros(Int, length(depth_priority)) zeros(Int, length(depth_priority))]
 
         # Prep site selection
-        mcda_vars = DMCDA_vars(domain, param_set, depth_priority, sum(Y_cover[1, :, :], dims=1), area_to_seed)
+        mcda_vars = DMCDA_vars(domain, param_set, depth_priority, sum(C_cover[1, :, :], dims=1), area_to_seed)
 
         # Number of time steps in environmental layers to look ahead when making decisions
         plan_horizon::Int64 = Int64(param_set("plan_horizon"))
@@ -482,7 +495,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
             corals.dist_mean .+ HEAT_UB
         ),
         1,
-        n_sites
+        n_locs
     )
     c_dist_t = copy(c_dist_t_1)
 
@@ -491,7 +504,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     dhw_tol_std_log = cache.dhw_tol_std_log  # tmp log for stdev dhw tolerances
 
     # Cache for proportional mortality and coral population increases
-    bleaching_mort = zeros(tf, n_species, n_sites)
+    bleaching_mort = zeros(tf, n_species, n_locs)
 
     #### End coral constants
 
@@ -509,30 +522,28 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     # Pre-calculate proportion of survivers from wave stress
     # Sw_t = wave_damage!(cache.wave_damage, wave_scen, corals.wavemort90, n_species)
 
-    site_k_prop = max_cover'
-    absolute_k_area = site_k_area(domain)'  # max possible coral area in m^2
     growth::ODEProblem = ODEProblem{true}(growthODE, ode_u, tspan, p)
-    tmp::Matrix{Float64} = zeros(size(Y_cover[1, :, :]))  # temporary array to hold intermediate covers
+    tmp::Matrix{Float64} = zeros(size(C_cover[1, :, :]))  # temporary array to hold intermediate covers
 
     # basal_area_per_settler is the area in m^2 of a size class one coral
     basal_area_per_settler = colony_mean_area(corals.mean_colony_diameter_m[corals.class_id.==1])
     for tstep::Int64 in 2:tf
         p_step::Int64 = tstep - 1
-        Y_pstep .= Y_cover[p_step, :, :]
+        Y_pstep .= C_cover[p_step, :, :]
 
         # Calculates scope for coral fedundity for each size class and at each site.
-        fecundity_scope!(fec_scope, fec_all, fec_params_per_m², Y_pstep, total_loc_area)
+        fecundity_scope!(fec_scope, fec_all, fec_params_per_m², Y_pstep, loc_k_area)
 
-        site_coral_cover = sum(Y_pstep, dims=1)  # dims: nsites * 1
-        leftover_space_prop = relative_leftover_space(site_k_prop, site_coral_cover)
-        leftover_space_m² = leftover_space_prop .* total_loc_area
+        loc_coral_cover = sum(Y_pstep, dims=1)  # dims: 1 * nsites
+        leftover_space_prop = relative_leftover_space(loc_coral_cover)
+        leftover_space_m² = leftover_space_prop .* loc_k_area
 
         # Recruitment represents additional cover, relative to total site area
         # Gets used in ODE
         p.rec .= settler_cover(fec_scope, TP_data, leftover_space_prop,
             sim_params.max_settler_density, sim_params.max_larval_density, basal_area_per_settler)
 
-        settler_DHW_tolerance!(Y_pstep, c_dist_t_1, c_dist_t, site_k_area(domain), TP_data,
+        settler_DHW_tolerance!(Y_pstep, c_dist_t_1, c_dist_t, vec(loc_k_area), TP_data,
             p.rec, corals.dist_std, fec_params_per_m², param_set("heritability"))
 
         in_shade_years = (shade_start_year <= tstep) && (tstep <= (shade_start_year + shade_years - 1))
@@ -563,11 +574,11 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
             mcda_vars.dam_prob .= vec((mean(env_horizon, dims=1) .+ std(env_horizon, dims=1)) .* 0.5)
         end
         if is_guided && (in_seed_years || in_shade_years)
-            mcda_vars.sum_cover .= site_coral_cover
+            mcda_vars.sum_cover .= loc_coral_cover
 
             # Determine connectivity strength
             # Account for cases where there is no coral cover
-            in_conn, out_conn, strong_pred = connectivity_strength(domain.TP_data .* site_k_area(domain), vec(site_coral_cover))
+            in_conn, out_conn, strong_pred = connectivity_strength(domain.TP_data .* site_k_area(domain), vec(loc_coral_cover))
             (seed_locs, shade_locs, rankings) = guided_site_selection(mcda_vars, MCDA_approach,
                 seed_decision_years[tstep], shade_decision_years[tstep],
                 seed_locs, shade_locs, rankings, in_conn[mcda_vars.site_ids], out_conn[mcda_vars.site_ids], strong_pred[mcda_vars.site_ids])
@@ -603,31 +614,27 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         # Apply seeding
         if seed_corals && in_seed_years && has_seed_sites
             # Seed each selected site
-            seed_corals!(Y_pstep, vec(total_loc_area), vec(leftover_space_m²),
+            seed_corals!(Y_pstep, vec(loc_k_area), vec(leftover_space_m²),
                 seed_locs, seeded_area, seed_sc, a_adapt, @view(Yseed[tstep, :, :]),
                 corals.dist_std, c_dist_t)
         end
 
-        # Note: ODE is run relative to `k` area, but values are otherwise recorded
-        #       in relative to absolute area.
         # Update initial condition
-        @. tmp = (Y_pstep * total_loc_area) / absolute_k_area
-        replace!(tmp, Inf => 0.0, NaN => 0.0)
+        tmp .= Y_pstep
         growth.u0 .= tmp
 
-        # X is cover relative to `k` (max. carrying capacity)
-        # So we subtract from 1.0 to get leftover/available space, relative to `k`
-        p.sXr .= max.(1.0 .- sum(tmp, dims=1), 0.0) .* tmp .* p.r  # leftover space * current cover * growth_rate
+        # leftover space * current cover * growth_rate
+        p.sXr .= relative_leftover_space(sum(tmp, dims=1)) .* tmp .* p.r
         p.X_mb .= tmp .* p.mb    # current cover * background mortality
 
         sol::ODESolution = solve(growth, solver, save_everystep=false, save_start=false,
             alg_hints=[:nonstiff], adaptive=false, dt=0.5)
 
         # Ensure values are ∈ [0, 1]
-        @views Y_cover[tstep, :, :] .= clamp.(sol.u[end] .* absolute_k_area ./ total_loc_area, 0.0, 1.0)
+        @views C_cover[tstep, :, valid_locs] .= clamp!(sol.u[end][:, valid_locs], 0.0, 1.0)
 
         if tstep <= tf
-            adjust_DHW_distribution!(@view(Y_cover[tstep-1:tstep, :, :]), n_groups, c_dist_t,
+            adjust_DHW_distribution!(@view(C_cover[tstep-1:tstep, :, :]), n_groups, c_dist_t,
                 p.r, corals.dist_std)
 
             if in_debug_mode
@@ -648,7 +655,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     if in_debug_mode
         collated_dhw_tol_log = NamedDimsArray(cat(dhw_tol_mean_log, dhw_tol_std_log, dims=ndims(dhw_tol_mean_log) + 1),
-            timesteps=1:tf, species=corals.coral_id, sites=1:n_sites, stat=[:mean, :stdev])
+            timesteps=1:tf, species=corals.coral_id, sites=1:n_locs, stat=[:mean, :stdev])
     else
         collated_dhw_tol_log = false
     end
@@ -661,6 +668,6 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
     # Avoid placing importance on sites that were not considered
     # (lower values are higher importance)
-    site_ranks[site_ranks.==0.0] .= n_sites + 1
-    return (raw=Y_cover, seed_log=Yseed, fog_log=Yfog, shade_log=Yshade, site_ranks=site_ranks, bleaching_mortality=bleaching_mort, coral_dhw_log=collated_dhw_tol_log)
+    site_ranks[site_ranks.==0.0] .= n_locs + 1
+    return (raw=C_cover, seed_log=Yseed, fog_log=Yfog, shade_log=Yshade, site_ranks=site_ranks, bleaching_mortality=bleaching_mort, coral_dhw_log=collated_dhw_tol_log)
 end

--- a/test/growth.jl
+++ b/test/growth.jl
@@ -4,9 +4,9 @@ using ADRIA
 
 @testset "Coral Spec" begin
     linear_extension = Array{Float64,2}([
-        1.0 3.0 3.0 4.4 4.4 4.4     # Abhorescent Acropora 
-        1.0 3.0 3.0 4.4 4.4 4.4     # Tabular Acropora 
-        1.0 3.0 3.0 3.0 3.0 3.0     # Corymbose Acropora 
+        1.0 3.0 3.0 4.4 4.4 4.4     # Abhorescent Acropora
+        1.0 3.0 3.0 4.4 4.4 4.4     # Tabular Acropora
+        1.0 3.0 3.0 3.0 3.0 3.0     # Corymbose Acropora
         1.0 2.4 2.4 2.4 2.4 2.4     # Corymbose non-Acropora
         1.0 1.0 1.0 1.0 0.8 0.8     # small massives
         1.0 1.0 1.0 1.0 1.2 1.2])   # large massives
@@ -17,10 +17,10 @@ using ADRIA
     #growth_rates[:, 6] .= 0.8 * growth_rates[:, 6]
 
     mb = Array{Float64,2}([
-        0.2 0.2 0.004 0.004 0.002 0.002    # Arborescent Acropora 
-        0.2 0.2 0.190 0.190 0.098 0.098    # Tabular Acropora 
-        0.2 0.2 0.172 0.172 0.088 0.088    # Corymbose Acropora 
-        0.2 0.2 0.226 0.226 0.116 0.116    # Corymbose non-Acropora 
+        0.2 0.2 0.004 0.004 0.002 0.002    # Arborescent Acropora
+        0.2 0.2 0.190 0.190 0.098 0.098    # Tabular Acropora
+        0.2 0.2 0.172 0.172 0.088 0.088    # Corymbose Acropora
+        0.2 0.2 0.226 0.226 0.116 0.116    # Corymbose non-Acropora
         0.2 0.2 0.040 0.026 0.020 0.020    # Small massives and encrusting
         0.2 0.2 0.040 0.026 0.020 0.020])   # Large massives
 
@@ -135,7 +135,7 @@ end
     # Generate initial cover
     Y_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
 
-    ADRIA.proportional_adjustment!(Y_cover[1, :, :], cover_tmp, max_cover)
+    ADRIA.proportional_adjustment!(Y_cover[1, :, :], max_cover)
     growthODE(du, Y_cover[1, :, :], p, 1)
     @test !any(abs.(du) .> 1.0) || "growth function is producing inappropriate values (abs(du) > 1.0)"
 
@@ -150,7 +150,7 @@ end
     p.X_mb .= rand(36, 32)
     Y_cover = zeros(10, 36, n_sites)
     Y_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
-    ADRIA.proportional_adjustment!(Y_cover[1, :, :], cover_tmp, max_cover)
+    ADRIA.proportional_adjustment!(Y_cover[1, :, :], max_cover)
     for tstep = 2:10
         growthODE(du, Y_cover[tstep-1, :, :], p, tstep)
         Y_cover[tstep, :, :] .= Y_cover[tstep-1, :, :] .+ du

--- a/test/growth.jl
+++ b/test/growth.jl
@@ -130,44 +130,44 @@ end
     max_cover = min.(vec(absolute_k_area ./ total_site_area), 0.5)
 
     # Test magnitude of change are within bounds
-    Y_cover = zeros(2, 36, n_sites)
+    C_cover = zeros(2, 36, n_sites)
 
     # Generate initial cover
-    Y_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
+    C_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
 
-    ADRIA.proportional_adjustment!(Y_cover[1, :, :], max_cover)
-    growthODE(du, Y_cover[1, :, :], p, 1)
+    ADRIA.proportional_adjustment!(C_cover[1, :, :], max_cover)
+    growthODE(du, C_cover[1, :, :], p, 1)
     @test !any(abs.(du) .> 1.0) || "growth function is producing inappropriate values (abs(du) > 1.0)"
 
     # Test zero recruit and coverage conditions
-    Y_cover = zeros(2, 36, n_sites)
+    C_cover = zeros(2, 36, n_sites)
     p.rec .= zeros(6, n_sites)
-    growthODE(du, Y_cover[1, :, :], p, 1)
+    growthODE(du, C_cover[1, :, :], p, 1)
     @test all(du .== 0.0) || "Growth produces non-zero values with zero recuitment and zero initial cover."
 
     # Test direction and magnitude of change
     p.rec .= rand(0:0.001:0.5, 6, n_sites)
     p.X_mb .= rand(36, 32)
-    Y_cover = zeros(10, 36, n_sites)
-    Y_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
-    ADRIA.proportional_adjustment!(Y_cover[1, :, :], max_cover)
+    C_cover = zeros(10, 36, n_sites)
+    C_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
+    ADRIA.proportional_adjustment!(C_cover[1, :, :], max_cover)
     for tstep = 2:10
-        growthODE(du, Y_cover[tstep-1, :, :], p, tstep)
-        Y_cover[tstep, :, :] .= Y_cover[tstep-1, :, :] .+ du
+        growthODE(du, C_cover[tstep-1, :, :], p, tstep)
+        C_cover[tstep, :, :] .= C_cover[tstep-1, :, :] .+ du
     end
-    @test any(diff(Y_cover, dims=1) .< 0) || "ODE never decreases, du being restricted to >=0."
-    @test any(diff(Y_cover, dims=1) .>= 0) || "ODE never increases, du being restricted to <=0."
+    @test any(diff(C_cover, dims=1) .< 0) || "ODE never decreases, du being restricted to >=0."
+    @test any(diff(C_cover, dims=1) .>= 0) || "ODE never increases, du being restricted to <=0."
 
     # Test change in smallest size class under no recruitment
     p.rec .= zeros(6, n_sites)
-    Y_cover = zeros(10, 36, n_sites)
-    Y_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
+    C_cover = zeros(10, 36, n_sites)
+    C_cover[1, :, :] = hcat(map(x -> rand(x, 36), Uniform.(0.0, max_cover))...)
 
     for tstep = 2:10
-        growthODE(du, Y_cover[tstep-1, :, :], p, 1)
-        Y_cover[tstep, :, :] .= Y_cover[tstep-1, :, :] .+ du
+        growthODE(du, C_cover[tstep-1, :, :], p, 1)
+        C_cover[tstep, :, :] .= C_cover[tstep-1, :, :] .+ du
     end
-    @test all((diff(Y_cover[:, [1, 7, 13, 19, 25, 31], :], dims=1) .<= 0)) || "Smallest size class growing with no recruitment.."
+    @test all((diff(C_cover[:, [1, 7, 13, 19, 25, 31], :], dims=1) .<= 0)) || "Smallest size class growing with no recruitment.."
 
-    @test all(abs.(diff(Y_cover, dims=1)) .< 1.0) || "ODE more than doubles or halves area."
+    @test all(abs.(diff(C_cover, dims=1)) .< 1.0) || "ODE more than doubles or halves area."
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
     max_cover = rand(20)
 
     for i in axes(Y, 1)
-        ADRIA.proportional_adjustment!(Y[i, :, :], tmp, max_cover)
+        ADRIA.proportional_adjustment!(Y[i, :, :], max_cover)
 
         @test all(0.0 .<= Y[i, :, :] .<= 1.0)
     end


### PR DESCRIPTION
As in title.

Note: initial coral covers are still being converted from values relative to absolute area.

Part of #480 (Current item 2 - " Scenario running methods to be refactored to expect only values relative to area")