### PR TITLE
Update viz.clustered_scenarios to allow confidence interval plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ examples/Outputs/
 /build/*.dll
 /build/*.so
 .vscode/
+.JuliaFormatter.toml
 
 JuliaSysimage.dll
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADRIA"
 uuid = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
 authors = ["Takuya Iwanaga", "Rose Crocker", "Pedro Ribeiro de Almeida", "Ken Anthony"]
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -56,16 +56,16 @@ function _plot_clusters_series!(
     clusters::Vector{Int64};
     opts::Dict=Dict(),
 )::Nothing
+    unique_clusters = sort(unique(clusters))
     alphas = _get_alphas(clusters)
     clusters_colors = unique(_get_colors(clusters, alphas))
 
     leg_entry::Vector{Any} = [
         series!(ax, data[:, clusters .== cluster]'; solid_color=clusters_colors[idx_c]) for
-        (idx_c, cluster) in enumerate(unique(clusters))
+        (idx_c, cluster) in enumerate(unique_clusters)
     ]
 
-    n_clusters = length(unique(clusters))
-    Legend(g[1, 2], leg_entry, "Cluster " .* string.(1:n_clusters); framevisible=false)
+    Legend(g[1, 2], leg_entry, "Cluster " .* string.(unique_clusters); framevisible=false)
 
     return nothing
 end
@@ -85,13 +85,15 @@ function _plot_clusters_confint!(
         slice_dimension = filter(x -> x != :timesteps, dimnames(data))[1]
     end
 
+    unique_clusters = sort(unique(clusters))
+
     band_colors = unique(_get_colors(clusters, 0.5))
     line_colors = unique(_get_colors(clusters))
-    legend_entry = Vector{Any}(undef, length(unique(clusters)))
+    legend_entry = Vector{Any}(undef, length(unique_clusters))
 
     x_timesteps::UnitRange{Int64} = 1:length(timesteps(data))
 
-    for (idx_c, cluster) in enumerate(unique(clusters))
+    for (idx_c, cluster) in enumerate(unique_clusters)
         cluster_data = data[:, clusters .== cluster]
         data_slices = Slices(cluster_data, NamedDims.dim(cluster_data, slice_dimension))
 
@@ -105,8 +107,9 @@ function _plot_clusters_confint!(
         legend_entry[idx_c] = scatterlines!(ax, y_median; color=line_color, markersize=5)
     end
 
-    n_clusters = length(unique(clusters))
-    Legend(g[1, 2], legend_entry, "Cluster " .* string.(1:n_clusters); framevisible=false)
+    Legend(
+        g[1, 2], legend_entry, "Cluster " .* string.(unique_clusters); framevisible=false
+    )
 
     return nothing
 end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,4 +1,5 @@
-using JuliennedArrays
+using JuliennedArrays: Slices
+using Statistics
 
 """
     clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
@@ -17,12 +18,13 @@ function ADRIA.viz.clustered_scenarios(
     data::AbstractMatrix,
     clusters::Vector{Int64};
     fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
-)
+    axis_opts::Dict=Dict(),
+    opts::Dict=Dict()
+)::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
-    ADRIA.viz.clustered_scenarios!(g, data, clusters; axis_opts=axis_opts)
+    ADRIA.viz.clustered_scenarios!(g, data, clusters; axis_opts=axis_opts, opts=opts)
 
     return f
 end
@@ -30,40 +32,90 @@ function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
     data::AbstractMatrix,
     clusters::Vector{Int64};
-    axis_opts::Dict=Dict()
-)
+    axis_opts::Dict=Dict(),
+    opts::Dict=Dict()
+)::Union{GridLayout,GridPosition}
     # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(data)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
-    ax = Axis(
-        g[1, 1],
-        xticks=xtick_vals,
-        xticklabelrotation=xtick_rot;
-        axis_opts...
-    )
+    ax = Axis(g[1, 1], xticks=xtick_vals, xticklabelrotation=xtick_rot; axis_opts...)
 
-    # Compute cluster colors
-    clusters_colors = _clusters_colors(clusters)
-    unique_cluster_colors = unique(clusters_colors)
+    if get(opts, :method, :series) == :confint
+        _plot_clusters_confint!(g, ax, data, clusters; opts=opts)
+    else
+        _plot_clusters_series!(g, ax, data, clusters; opts=opts)
+    end
 
+    return g
+end
+
+function _plot_clusters_series!(
+    g::Union{GridLayout,GridPosition},
+    ax::Axis,
+    data::AbstractMatrix,
+    clusters::Vector{Int64};
+    opts::Dict=Dict()
+)::Nothing
+    alphas = _get_alphas(clusters)
+    clusters_colors = unique(_get_colors(clusters, alphas))
     leg_entry = Any[]
-    for cluster in unique(clusters)
-        cluster_color = _cluster_color(unique_cluster_colors, clusters, cluster)
+
+    for (idx_c, cluster) in enumerate(unique(clusters))
         push!(
             leg_entry,
             series!(
                 ax,
                 data[:, clusters.==cluster]',
-                solid_color=cluster_color
+                solid_color=clusters_colors[idx_c]
             )
         )
     end
 
-    # Plot Legend
     n_clusters = length(unique(clusters))
     Legend(g[1, 2], leg_entry, "Cluster " .* string.(1:n_clusters), framevisible=false)
 
-    return g
+    return nothing
+end
+
+function _plot_clusters_confint!(
+    g::Union{GridLayout,GridPosition},
+    ax::Axis,
+    data::AbstractMatrix,
+    clusters::Vector{Int64};
+    opts::Dict=Dict()
+)::Nothing
+    band_colors = unique(_get_colors(clusters, 0.5))
+    line_colors = unique(_get_colors(clusters))
+    leg_entry = Any[]
+
+    # TODO if data is not a NamedDimsArray this won't work
+    xs::Vector{Float32} = data.timesteps
+
+    for (idx_c, cluster) in enumerate(unique(clusters))
+        cluster_data = data[:, clusters.==cluster]
+        data_slices = Slices(cluster_data, NamedDims.dim(cluster_data, :scenarios))
+
+        y_lower = quantile.(data_slices, [0.025])
+        y_upper = quantile.(data_slices, [0.975])
+
+        if get(opts, :fill_confint, true)
+            band!(ax, xs, y_lower, y_upper, color=band_colors[idx_c])
+        else
+            lines!(ax, xs, y_lower, linestyle=:dash, color=band_colors[idx_c])
+            lines!(ax, xs, y_upper, linestyle=:dash, color=band_colors[idx_c])
+        end
+
+        y_median = median.(data_slices)
+        push!(
+            leg_entry,
+            scatterlines!(ax, xs, y_median, color=line_colors[idx_c], markersize=5)
+        )
+    end
+
+    n_clusters = length(unique(clusters))
+    Legend(g[1, 2], leg_entry, "Cluster " .* string.(1:n_clusters), framevisible=false)
+
+    return nothing
 end
 
 """
@@ -91,7 +143,7 @@ function ADRIA.viz.map(
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict()
-)
+)::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
     ADRIA.viz.map!(g, rs, data, clusters; opts=opts, axis_opts=axis_opts)
@@ -105,8 +157,8 @@ function ADRIA.viz.map!(
     clusters::Vector{Int64};
     opts::Dict=Dict(),
     axis_opts::Dict=Dict()
-)
-    cluster_colors = _clusters_colors(clusters)
+)::Union{GridLayout,GridPosition}
+    cluster_colors = _get_colors(clusters)
     legend_params = _cluster_legend_params(clusters, cluster_colors, data)
 
     opts[:highlight] = get(opts, :highlight, cluster_colors)
@@ -118,51 +170,65 @@ function ADRIA.viz.map!(
 end
 
 """
-    _cluster_colors(clusters::Vector{Int64})
-
+    _get_colors(clusters::Vector{Int64}, alphas::Vector{Float64})::Vector{RGBA{Float32}}
+    _get_colors(clusters::Vector{Int64}, alpha::Float64)::Vector{RGBA{Float32}}
+    _get_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}
 Vector of cluster colors.
 
 # Arguments
 - `clusters` : Vector of numbers corresponding to clusters
+- `alphas` : Vector of alphas to be used for cluster color
 
 # Returns
 Vector{RGBA{Float32}}
 """
-function _clusters_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}
+function _get_colors(clusters::Vector{Int64}, alphas::Vector{Float64})::Vector{RGBA{Float32}}
     # Number of non-zero clusters
     n_clusters = length(unique(filter(cluster -> cluster != 0, clusters)))
 
     # Vector of clusters colors for non-zero clusters
-    clusters_colors = categorical_colors(:seaborn_bright, n_clusters)
+    colors = categorical_colors(:seaborn_bright, n_clusters)
+
+    # Apply alpha to cluster colors
+    if !isempty(alphas)
+        colors = [RGBA(c.r, c.g, c.b, a) for (c, a) in zip(colors, alphas)]
+    end
 
     # Assign color "black" to cluster == 0
     rgba_black = parse(RGBA{Float32}, "transparent")
-    return [cluster == 0 ? rgba_black : clusters_colors[cluster] for cluster in clusters]
+    return [cluster == 0 ? rgba_black : colors[cluster] for cluster in clusters]
+end
+function _get_colors(clusters::Vector{Int64}, alpha::Float64)::Vector{RGBA{Float32}}
+    alphas::Vector{Float64} = fill(alpha, length(clusters))
+    return _get_colors(clusters, alphas)
+end
+function _get_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}
+    return _get_colors(clusters, 1.0)
 end
 
 """
-    _cluster_color(unique_cluster_colors::Vector{RGBA{Float32}}, clusters::Vector{Int64}, cluster::Int64)
+    _get_alphas(clusters::Vector{Int64})::Vector{Float64}
 
-Color parameter for current cluster weighted by number of scenarios
+Vector of color alphas for each clusters weighted by number of scenarios
 
 # Arguments
-- `unique_cluster_colors` : Vector of all cluster options that are being used
-- `clusters` : Vector of numbers corresponding to clusters
-- `cluster` : Current cluster
+- `clusters` : Vector with scenario cluster numbers
 
 # Returns
-Tuple{RGBA{Float32}, Float64}
+Vector with one color alpha for each cluster
 """
-function _cluster_color(unique_cluster_colors::Vector{RGBA{Float32}},
-    clusters::Vector{Int64}, cluster::Int64)::Tuple{RGBA{Float32},Float64}
-    # Number of scenarios for a cluster
-    n_scens = count(clusters .== cluster)
+function _get_alphas(clusters::Vector{Int64})::Vector{Float64}
+    alphas::Vector{Float64} = zeros(Float64, length(unique(clusters)))
 
-    # Compute line weight
-    color_weight = max(min((1.0 / (n_scens * 0.05)), 0.6), 0.1)
+    for (i, cluster) in enumerate(unique(clusters))
+        n_scens = count(clusters .== cluster)
+        base_alpha = 1.0 / (n_scens * 0.05)
+        alphas[i] = max(min(base_alpha, 0.6), 0.1)
+    end
 
-    return (unique_cluster_colors[cluster], color_weight)
+    return alphas
 end
+
 
 """
     _cluster_legend_params(clusters::Vector{Int64}, clusters_colors::Vector{RGBA{Float32}}, data_statistics::Vector{Float32})

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -16,7 +16,7 @@ Visualize clustered time series of scenarios.
 Figure
 """
 function ADRIA.viz.clustered_scenarios(
-    data::AbstractMatrix,
+    data::NamedDimsArray,
     clusters::Vector{Int64};
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
@@ -31,7 +31,7 @@ function ADRIA.viz.clustered_scenarios(
 end
 function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
-    data::AbstractMatrix,
+    data::NamedDimsArray,
     clusters::Vector{Int64};
     axis_opts::Dict=Dict(),
     opts::Dict=Dict()
@@ -53,7 +53,7 @@ end
 function _plot_clusters_series!(
     g::Union{GridLayout,GridPosition},
     ax::Axis,
-    data::AbstractMatrix,
+    data::NamedDimsArray,
     clusters::Vector{Int64};
     opts::Dict=Dict()
 )::Nothing
@@ -74,7 +74,7 @@ end
 function _plot_clusters_confint!(
     g::Union{GridLayout,GridPosition},
     ax::Axis,
-    data::AbstractMatrix,
+    data::NamedDimsArray,
     clusters::Vector{Int64};
     opts::Dict=Dict()
 )::Nothing

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -40,7 +40,7 @@ function ADRIA.viz.clustered_scenarios!(
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
     ax = Axis(g[1, 1], xticks=xtick_vals, xticklabelrotation=xtick_rot; axis_opts...)
 
-    if get(opts, :method, :series) == :confint
+    if get(opts, :summarize, true)
         _plot_clusters_confint!(g, ax, data, clusters; opts=opts)
     else
         _plot_clusters_series!(g, ax, data, clusters; opts=opts)
@@ -98,12 +98,7 @@ function _plot_clusters_confint!(
         y_lower = quantile.(data_slices, [0.025])
         y_upper = quantile.(data_slices, [0.975])
 
-        if get(opts, :fill_confint, true)
-            band!(ax, xs, y_lower, y_upper, color=band_colors[idx_c])
-        else
-            lines!(ax, xs, y_lower, linestyle=:dash, color=band_colors[idx_c])
-            lines!(ax, xs, y_upper, linestyle=:dash, color=band_colors[idx_c])
-        end
+        band!(ax, xs, y_lower, y_upper, color=band_colors[idx_c])
 
         y_median = median.(data_slices)
         push!(

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -83,7 +83,7 @@ function _plot_clusters_confint!(
     leg_entry = Vector{Any}(undef, length(unique(clusters)))
 
     # TODO if data is not a NamedDimsArray this won't work
-    xs::Vector{Float32} = data.timesteps
+    x_timestep::Vector{Float32} = data.timesteps
 
     for (idx_c, cluster) in enumerate(unique(clusters))
         cluster_data = data[:, clusters.==cluster]
@@ -92,13 +92,13 @@ function _plot_clusters_confint!(
         y_lower = quantile.(data_slices, [0.025])
         y_upper = quantile.(data_slices, [0.975])
 
-        band!(ax, xs, y_lower, y_upper, color=band_colors[idx_c])
+        band!(ax, x_timestep, y_lower, y_upper, color=band_colors[idx_c])
 
         y_median = median.(data_slices)
 
         leg_entry[idx_c] = scatterlines!(
             ax,
-            xs,
+            x_timestep,
             y_median,
             color=line_colors[idx_c],
             markersize=5

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -18,9 +18,9 @@ Figure
 function ADRIA.viz.clustered_scenarios(
     data::NamedDimsArray,
     clusters::Vector{Int64};
+    opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
-    opts::Dict=Dict()
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -33,8 +33,8 @@ function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
     data::NamedDimsArray,
     clusters::Vector{Int64};
+    opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
-    opts::Dict=Dict()
 )::Union{GridLayout,GridPosition}
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(data)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
@@ -54,7 +54,7 @@ function _plot_clusters_series!(
     ax::Axis,
     data::NamedDimsArray,
     clusters::Vector{Int64};
-    opts::Dict=Dict()
+    opts::Dict=Dict(),
 )::Nothing
     alphas = _get_alphas(clusters)
     clusters_colors = unique(_get_colors(clusters, alphas))
@@ -75,7 +75,7 @@ function _plot_clusters_confint!(
     ax::Axis,
     data::NamedDimsArray,
     clusters::Vector{Int64};
-    opts::Dict=Dict()
+    opts::Dict=Dict(),
 )::Nothing
     band_colors = unique(_get_colors(clusters, 0.5))
     line_colors = unique(_get_colors(clusters))
@@ -127,7 +127,7 @@ function ADRIA.viz.map(
     clusters::Vector{Int64};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
+    axis_opts::Dict=Dict(),
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -141,7 +141,7 @@ function ADRIA.viz.map!(
     data::AbstractVector{<:Real},
     clusters::Vector{Int64};
     opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
+    axis_opts::Dict=Dict(),
 )::Union{GridLayout,GridPosition}
     cluster_colors = _get_colors(clusters)
     legend_params = _cluster_legend_params(clusters, cluster_colors, data)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -81,7 +81,7 @@ function _plot_clusters_confint!(
     line_colors = unique(_get_colors(clusters))
     legend_entry = Vector{Any}(undef, length(unique(clusters)))
 
-    x_timesteps::UnitRange{Int64} = 1:length(data.timesteps)
+    x_timesteps::UnitRange{Int64} = 1:length(timesteps(data))
 
     for (idx_c, cluster) in enumerate(unique(clusters))
         cluster_data = data[:, clusters .== cluster]

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,6 +1,7 @@
 using JuliennedArrays: Slices
 using Statistics
 
+
 """
     clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
     clustered_scenarios!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -9,7 +9,7 @@ using Statistics
 Visualize clustered time series of scenarios.
 
 # Arguments
-- `data` : Matrix of scenario data
+- `data` : Matrix of time series data for several scenarios or sites
 - `clusters` : Vector of numbers corresponding to clusters
 
 # Returns
@@ -77,6 +77,14 @@ function _plot_clusters_confint!(
     clusters::Vector{Int64};
     opts::Dict=Dict(),
 )::Nothing
+    if :timesteps ∉ dimnames(data)
+        throw(ArgumentError("data does not have :timesteps axis"))
+    elseif length(dimnames(data)) != 2
+        throw(ArgumentError("data does not have two dimensions"))
+    else
+        slice_dimension = filter(x -> x != :timesteps, dimnames(data))[1]
+    end
+
     band_colors = unique(_get_colors(clusters, 0.5))
     line_colors = unique(_get_colors(clusters))
     legend_entry = Vector{Any}(undef, length(unique(clusters)))
@@ -85,7 +93,7 @@ function _plot_clusters_confint!(
 
     for (idx_c, cluster) in enumerate(unique(clusters))
         cluster_data = data[:, clusters .== cluster]
-        data_slices = Slices(cluster_data, NamedDims.dim(cluster_data, :scenarios))
+        data_slices = Slices(cluster_data, NamedDims.dim(cluster_data, slice_dimension))
 
         y_lower = quantile.(data_slices, [0.025])
         y_upper = quantile.(data_slices, [0.975])

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -59,18 +59,11 @@ function _plot_clusters_series!(
 )::Nothing
     alphas = _get_alphas(clusters)
     clusters_colors = unique(_get_colors(clusters, alphas))
-    leg_entry = Any[]
 
-    for (idx_c, cluster) in enumerate(unique(clusters))
-        push!(
-            leg_entry,
-            series!(
-                ax,
-                data[:, clusters.==cluster]',
-                solid_color=clusters_colors[idx_c]
-            )
-        )
-    end
+    leg_entry::Vector{Any} = [
+        series!(ax, data[:, clusters.==cluster]', solid_color=clusters_colors[idx_c])
+        for (idx_c, cluster) in enumerate(unique(clusters))
+    ]
 
     n_clusters = length(unique(clusters))
     Legend(g[1, 2], leg_entry, "Cluster " .* string.(1:n_clusters), framevisible=false)
@@ -87,7 +80,7 @@ function _plot_clusters_confint!(
 )::Nothing
     band_colors = unique(_get_colors(clusters, 0.5))
     line_colors = unique(_get_colors(clusters))
-    leg_entry = Any[]
+    leg_entry = Vector{Any}(undef, length(unique(clusters)))
 
     # TODO if data is not a NamedDimsArray this won't work
     xs::Vector{Float32} = data.timesteps
@@ -102,9 +95,13 @@ function _plot_clusters_confint!(
         band!(ax, xs, y_lower, y_upper, color=band_colors[idx_c])
 
         y_median = median.(data_slices)
-        push!(
-            leg_entry,
-            scatterlines!(ax, xs, y_median, color=line_colors[idx_c], markersize=5)
+
+        leg_entry[idx_c] = scatterlines!(
+            ax,
+            xs,
+            y_median,
+            color=line_colors[idx_c],
+            markersize=5
         )
     end
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -81,7 +81,7 @@ function _plot_clusters_confint!(
     line_colors = unique(_get_colors(clusters))
     legend_entry = Vector{Any}(undef, length(unique(clusters)))
 
-    x_timesteps::Vector{Int64} = 1:length(data.timesteps)
+    x_timesteps::UnitRange{Int64} = 1:length(data.timesteps)
 
     for (idx_c, cluster) in enumerate(unique(clusters))
         cluster_data = data[:, clusters.==cluster]

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -36,7 +36,6 @@ function ADRIA.viz.clustered_scenarios!(
     axis_opts::Dict=Dict(),
     opts::Dict=Dict()
 )::Union{GridLayout,GridPosition}
-    # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(data)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
     ax = Axis(g[1, 1], xticks=xtick_vals, xticklabelrotation=xtick_rot; axis_opts...)
@@ -80,10 +79,9 @@ function _plot_clusters_confint!(
 )::Nothing
     band_colors = unique(_get_colors(clusters, 0.5))
     line_colors = unique(_get_colors(clusters))
-    leg_entry = Vector{Any}(undef, length(unique(clusters)))
+    legend_entry = Vector{Any}(undef, length(unique(clusters)))
 
-    # TODO if data is not a NamedDimsArray this won't work
-    x_timestep::Vector{Float32} = data.timesteps
+    x_timesteps::Vector{Int64} = 1:length(data.timesteps)
 
     for (idx_c, cluster) in enumerate(unique(clusters))
         cluster_data = data[:, clusters.==cluster]
@@ -92,21 +90,15 @@ function _plot_clusters_confint!(
         y_lower = quantile.(data_slices, [0.025])
         y_upper = quantile.(data_slices, [0.975])
 
-        band!(ax, x_timestep, y_lower, y_upper, color=band_colors[idx_c])
+        band!(ax, x_timesteps, y_lower, y_upper, color=band_colors[idx_c])
 
         y_median = median.(data_slices)
-
-        leg_entry[idx_c] = scatterlines!(
-            ax,
-            x_timestep,
-            y_median,
-            color=line_colors[idx_c],
-            markersize=5
-        )
+        line_color = line_colors[idx_c]
+        legend_entry[idx_c] = scatterlines!(ax, y_median, color=line_color, markersize=5)
     end
 
     n_clusters = length(unique(clusters))
-    Legend(g[1, 2], leg_entry, "Cluster " .* string.(1:n_clusters), framevisible=false)
+    Legend(g[1, 2], legend_entry, "Cluster " .* string.(1:n_clusters), framevisible=false)
 
     return nothing
 end


### PR DESCRIPTION
- Updated functions _clusters_colors and _cluster_color to _get_colors and _get_alphas
- Added return type to all functions in this file
- Adapted the whole file to the style guide

There is an option to fill or not the area inside the confidence interval - the best visualization option may depend on the situation. The default value of `:fill_confint` is currently set to `true`:

![clustered_scenarios_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/c0887d15-3a50-48b0-9e8c-f95473f58f78)

This is how it looks with `:fill-confint` set to `false`:

![clustered_scenarios_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/3255612f-33df-42f1-aceb-7fe7cb937561)

Closes #464 