### PR TITLE
Consistent treatment of k area on data load

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -232,7 +232,7 @@ end
 Get maximum coral cover area as a proportion of site area.
 """
 function site_k(domain::Domain)::Vector{Float64}
-    return domain.site_data.k ./ 100.0
+    return domain.site_data.k
 end
 
 """Extract the time steps represented in the data package."""

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -231,15 +231,6 @@ function load_domain(path::String, rcp::Int64)::ADRIADomain
 end
 
 
-"""
-    site_k(domain::ADRIADomain)::Vector{Float64}
-
-Get maximum coral cover area as a proportion of site area.
-"""
-function site_k(domain::ADRIADomain)::Vector{Float64}
-    return domain.site_data.k ./ 100.0
-end
-
 """Get the path to the DHW data associated with the domain."""
 function get_DHW_data(d::ADRIADomain, RCP::String)::String
     return joinpath(d.env_layer_md.dpkg_path, "DHWs", "dhwRCP$(RCP).nc")

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -120,6 +120,7 @@ function Domain(name::String, dpkg_path::String, rcp::String, timeframe::Vector,
 
     # Filter out missing entries
     site_data = site_data[coalesce.(in.(conn_ids, [site_conn.site_ids]), false), :]
+    site_data.k .= site_data.k / 100.0  # Make `k` non-dimensional (provided as a percent)
     site_dists::Matrix{Float64}, median_site_distance::Float64 = site_distances(site_data)
 
     coral_growth::CoralGrowth = CoralGrowth(nrow(site_data))

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -331,17 +331,6 @@ function load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::V
     return NamedDimsArray(icc_data, species=1:(length(icc_files)*6), locs=loc_ids)
 end
 
-"""
-    site_k(dom::ReefModDomain)::Vector{Float64}
-
-Get maximum coral cover area as a proportion of site area.
-
-Note: ReefMod `k` area is already ∈ [0, 1] so no adjustment is necessary.
-"""
-function site_k(dom::ReefModDomain)::Vector{Float64}
-    return dom.site_data.k
-end
-
 
 """
     switch_RCPs!(d::ReefModDomain, RCP::String)::Domain


### PR DESCRIPTION
Closes #483

Ensures k area (coral carrying capacity for each location) is loaded as a non-dimensional value indicating the proportion of absolute location area.

As a consequences, we can simplify/remove the `site_k()` interface methods.