### PR TITLE
Transform ICC from relative to absolute area to relative to k area

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -185,6 +185,32 @@ function component_params(spec::DataFrame, components::Vector{T})::DataFrame whe
     return spec[spec.component.∈[replace.(string.(components), "ADRIA." => "")], :]
 end
 
+"""
+    _convert_k_to_abs(coral_cover::Union{NamedDimsArray,Matrix{Float64}}, site_data::DataFrame)::NamedDimsArray
+
+Convert coral cover data from being relative to absolute location area to relative to
+\$k\$ area.
+"""
+function _convert_abs_to_k(
+    coral_cover::Union{NamedDimsArray,Matrix{Float64}},
+    site_data::DataFrame
+)::Union{NamedDimsArray,Matrix{Float64}}
+    # Initial coral cover is provided as values relative to location area.
+    # Convert coral covers to be relative to k area, ignoring locations with 0 carrying
+    # capacity (k area = 0.0).
+    absolute_k_area = (site_data.k .* site_data.area)'  # max possible coral area in m^2
+    valid_locs::BitVector = absolute_k_area' .> 0.0
+    coral_cover[:, valid_locs] .= (
+        (coral_cover[:, valid_locs] .* site_data.area[valid_locs]')
+        ./
+        absolute_k_area[valid_locs]'
+    )
+
+    # Ensure initial coral cover values are <= maximum carrying capacity
+    @assert all(sum(coral_cover, dims=1) .<= 1.0)
+
+    return coral_cover
+end
 
 """
     site_area(domain::Domain)::Vector{Float64}

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -56,7 +56,6 @@ function load_domain(::Type{ReefModDomain}, fn_path::String, RCP::String)::ReefM
     site_dist, med_site_dist = ADRIA.site_distances(site_data)
     site_id_col = "LOC_NAME_S"
     unique_site_id_col = "LOC_NAME_S"
-    init_coral_cover = load_initial_cover(ReefModDomain, data_files, loc_ids)
     site_ids = site_data[:, unique_site_id_col]
 
     id_list = CSV.read(joinpath(data_files, "id", "id_list_2023_03_30.csv"), DataFrame, header=false, comment="#")
@@ -75,6 +74,9 @@ function load_domain(::Type{ReefModDomain}, fn_path::String, RCP::String)::ReefM
 
     # Calculate `k` area (1.0 - "ungrazable" area)
     site_data[:, :k] .= 1.0 .- id_list[:, 3]
+
+    # Need to load initial coral cover after we know `k` area.
+    init_coral_cover = load_initial_cover(ReefModDomain, data_files, loc_ids, site_data)
 
     conn_data = load_connectivity(ReefModDomain, data_files, loc_ids)
     in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(conn_data, vec(site_data.area .* site_data.k))
@@ -286,7 +288,7 @@ function load_cyclones(::Type{ReefModDomain}, data_path::String, loc_ids::Vector
 end
 
 """
-    load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::Vector{String})::NamedDimsArray
+    load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::Vector{String}, site_data::DataFrame)::NamedDimsArray
 
 # Arguments
 - `ReefModDomain`
@@ -296,7 +298,7 @@ end
 # Returns
 NamedDimsArray[locs, species]
 """
-function load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::Vector{String})::NamedDimsArray
+function load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::Vector{String}, site_data::DataFrame)::NamedDimsArray
     icc_path = joinpath(data_path, "initial")
     icc_files = _get_relevant_files(icc_path, "coral_")
     if isempty(icc_files)
@@ -327,6 +329,9 @@ function load_initial_cover(::Type{ReefModDomain}, data_path::String, loc_ids::V
     # Repeat species over each size class and reshape to give ADRIA compatible size (36 * n_locs).
     # Multiply by size class weights to give initial cover distribution over each size class.
     icc_data = Matrix(hcat(reduce.(vcat, eachrow(icc_data .* [size_class_weights]))...))
+
+    # Convert values relative to absolute area to values relative to k area
+    icc_data = _convert_abs_to_k(icc_data, site_data)
 
     return NamedDimsArray(icc_data, species=1:(length(icc_files)*6), locs=loc_ids)
 end

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -13,7 +13,8 @@ function _check_compat(dpkg_details::Dict{String,Any})::Nothing
     if haskey(dpkg_details, "version") || haskey(dpkg_details, "dpkg_version")
         dpkg_version::String = dpkg_details["version"]
         if dpkg_version ∉ COMPAT_DPKG
-            error("Incompatible Domain data package. Detected $(dpkg_version), but only support one of $(COMPAT_DPKG)")
+            error("""Incompatible Domain data package. Detected $(dpkg_version),
+            but only support one of $(COMPAT_DPKG)""")
         end
     else
         error("Incompatible Domain data package.")
@@ -61,7 +62,7 @@ end
     _process_inputs!(d::Domain, df::DataFrame)::Nothing
     _process_inputs!(spec::DataFrame, df::DataFrame)::Nothing
     _process_inputs!(bnds::AbstractArray, p_types::AbstractArray, df::DataFrame)::Nothing
-    
+
 Map sampled values in `df` back to discrete bounds for parameters
 indicated to be of integer type in the Domain spec.
 
@@ -189,6 +190,7 @@ function load_covers(data_fn::String, attr::String, site_data::DataFrame)::Named
 
     # Reorder sites to match site_data
     data = data[sites=Key(site_data[:, :reef_siteid])]
+    data = _convert_abs_to_k(data, site_data)
 
     return data
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -376,8 +376,8 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     ode_u = zeros(n_species, n_sites)
     max_cover = site_k(domain)  # Max coral cover at each site (0 - 1).
 
-    # Proportionally adjust initial cover (handles inappropriate initial conditions)
-    proportional_adjustment!(@view(Y_cover[1, :, :]), p.cover, max_cover)
+    # Locations that can support corals
+    valid_locs::BitVector = max_cover .> 0.0
 
     site_ranks = SparseArray(zeros(tf, n_sites, 2))  # log seeding/fogging/shading ranks
     Yshade = SparseArray(spzeros(tf, n_sites))


### PR DESCRIPTION
Closes #484

Loads initial coral cover (icc) data in a more consistent way. 

`icc` is always provided in values relative to absolute area, but on load, it gets transformed to be relative to k area instead.