### PR TITLE
Add function to alter sampling bounds on parameters to specified value.

### DIFF
--- a/docs/src/usage/scenario_generation.md
+++ b/docs/src/usage/scenario_generation.md
@@ -132,6 +132,11 @@ ADRIA.set_factor_bounds!(dom, :N_seed_SA, (500000.0, 1000000.0 + 1.0))
 # is a triangualr distribution.
 ADRIA.set_factor_bounds!(dom, :fogging, (0.2, 0.3, 0.1))
 
+# Adjust multiple parameter in one function evaluation
+ADRIA.set_factor_bounds!(dom;
+    heat_stress=(0.3, 0.7),
+    N_seed_TA=(500000.0, 1000000.0 + 1.0),
+    N_seed_CA=(500000.0, 1000000.0 + 1.0))
 ```
 ## Sampling counterfactuals only
 

--- a/docs/src/usage/scenario_generation.md
+++ b/docs/src/usage/scenario_generation.md
@@ -115,7 +115,24 @@ ADRIA.fix_factor!(dom;
     coral_cover_tol=1.0
 )
 ```
+The ranges for sampling can also be constrained if running scenarios for a particular 
+range of a parameter is of interest. For example, if one wanted to investigate only 
+scenarios with high fogging and seeding, the following example could be used:
 
+```julia
+dom = ADRIA.load_domain()
+
+# Adjust seeding bounds. Note only lower and upper bounds needed because it is a 
+# uniform distribution.
+ADRIA.set_factor_bounds!(dom, :N_seed_TA, (500000.0, 1000000.0 + 1.0))
+ADRIA.set_factor_bounds!(dom, :N_seed_CA, (500000.0, 1000000.0 + 1.0))
+ADRIA.set_factor_bounds!(dom, :N_seed_SA, (500000.0, 1000000.0 + 1.0))
+
+# Adjust fogging bounds. Note lower, upper and mode parameters are needed because it 
+# is a triangualr distribution.
+ADRIA.set_factor_bounds!(dom, :fogging, (0.2, 0.3, 0.1))
+
+```
 ## Sampling counterfactuals only
 
 A convenience function to create scenarios with no interventions (counterfactuals).

--- a/docs/src/usage/scenario_generation.md
+++ b/docs/src/usage/scenario_generation.md
@@ -115,24 +115,23 @@ ADRIA.fix_factor!(dom;
     coral_cover_tol=1.0
 )
 ```
-The ranges for sampling can also be constrained if running scenarios for a particular 
-range of a parameter is of interest. For example, if one wanted to investigate only 
-scenarios with high fogging and seeding, the following example could be used:
+Samples can also be taken over a constrained range. For example, if one wanted to investigate only 
+scenarios with high fogging and seeding, the following could be used:
 
 ```julia
 dom = ADRIA.load_domain()
 
-# Adjust seeding bounds. Note only lower and upper bounds needed because it is a 
-# uniform distribution.
+# Adjust seeding bounds. Note only lower and upper bounds are needed because the factors in  
+# question have a uniform distribution.
 ADRIA.set_factor_bounds!(dom, :N_seed_TA, (500000.0, 1000000.0 + 1.0))
 ADRIA.set_factor_bounds!(dom, :N_seed_CA, (500000.0, 1000000.0 + 1.0))
 ADRIA.set_factor_bounds!(dom, :N_seed_SA, (500000.0, 1000000.0 + 1.0))
 
 # Adjust fogging bounds. Note lower, upper and mode parameters are needed because it 
-# is a triangualr distribution.
+# is a triangular distribution.
 ADRIA.set_factor_bounds!(dom, :fogging, (0.2, 0.3, 0.1))
 
-# Adjust multiple parameter in one function evaluation
+# Adjust multiple factors simultaneously.
 ADRIA.set_factor_bounds!(dom;
     heat_stress=(0.3, 0.7),
     N_seed_TA=(500000.0, 1000000.0 + 1.0),

--- a/src/decision/Criteria.jl
+++ b/src/decision/Criteria.jl
@@ -118,7 +118,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
     )
     use_dist::N = Param(
         1;
-        ptype="integer",
+        ptype="categorical",
         bounds=(0.0, 1.0 + 1.0),
         default_bounds=(0.0, 1.0 + 1.0),
         dists="unif",

--- a/src/decision/Criteria.jl
+++ b/src/decision/Criteria.jl
@@ -3,6 +3,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Wave Stress",
         description="Importance of avoiding wave stress. Higher values places more weight on areas with low wave stress.",
@@ -11,6 +12,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Heat Stress",
         description="Importance of avoiding heat stress. Higher values places more weight on areas with low heat stress.",
@@ -19,6 +21,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Shade Connectivity",
         description="Higher values give preference to locations with high connectivity for shading deployments.",
@@ -27,6 +30,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Incoming Connectivity (Seed)",
         description="Higher values give preference to locations with high incoming connectivity (i.e., receives larvae from other sites) for enhanced coral deployments.",
@@ -35,6 +39,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Outgoing Connectivity (Seed)",
         description="Higher values give preference to locations with high outgoing connectivity (i.e., provides larvae to other sites) for enhanced coral deployments.",
@@ -43,6 +48,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Low Coral Cover",
         description="Higher values give greater preference to sites with low coral cover for seeding deployments.",
@@ -51,6 +57,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="High Coral Cover",
         description="Higher values give preference to sites with high coral cover for shading deployments.",
@@ -59,6 +66,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Predecessor Priority (Seed)",
         description="Importance of seeding sites that provide larvae to priority reefs.",
@@ -67,6 +75,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Predecessor Priority (Shade)",
         description="Importance of shading sites that provide larvae to priority reefs.",
@@ -75,6 +84,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Zone Predecessor (Seed)",
         description="Importance of seeding sites that provide larvae to priority (target) zones.",
@@ -83,6 +93,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.0;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Zone Predecessor (Shade)",
         description="Importance of shading sites that provide larvae to priority (target) zones.",
@@ -91,6 +102,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.2;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Low Area Tolerance",
         description="Tolerance for low proportional space for seeding deployments.",
@@ -99,14 +111,16 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         1.0;
         ptype="real",
         bounds=(0.75, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Risk Tolerance",
         description="Filters out sites with heat/wave stress above threshold.",
     )
     use_dist::N = Param(
         1;
-        ptype="categorical",
+        ptype="integer",
         bounds=(0.0, 1.0 + 1.0),
+        default_bounds=(0.0, 1.0 + 1.0),
         dists="unif",
         name="Use Distance Threshold",
         description="Turns distance sorting on or off.",
@@ -115,6 +129,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         0.1;
         ptype="real",
         bounds=(0.0, 1.0),
+        default_bounds=(0.0, 1.0),
         dists="unif",
         name="Distance Threshold",
         description="Sites selected by MCDA must be further apart than median(dist)-dist_thresh*median(dist).",
@@ -123,6 +138,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         5.0;
         ptype="real",
         bounds=(3.0, 5.0),
+        default_bounds=(3.0, 5.0),
         dists="unif",
         name="Minimum Depth",
         description="Minimum depth for a site to be included for consideration.\nNote: This value will be replaced with the shallowest depth value found if all sites are found to be deeper than `depth_min + depth_offset`.",
@@ -131,6 +147,7 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         10.0;
         ptype="real",
         bounds=(10.0, 25.0),
+        default_bounds=(10.0, 25.0),
         dists="unif",
         name="Depth Offset",
         description="Offset from minimum depth, used to indicate maximum depth.",

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -5,110 +5,100 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Bounds are defined as floats to maintain type stability
     guided::N = Param(
         0;
-        ptype="categorical",
+        ptype="integer",
         bounds=(-1.0, length(methods_mcda) + 1.0),
+        default_bounds=(-1.0, length(methods_mcda) + 1.0),
         dists="unif",
-        name="Guided",
-        description="Choice of MCDA approach.",
-    )
+        name="Guided", description="Choice of MCDA approach.")
     N_seed_TA::N = Param(
         0;
         ptype="integer",
         bounds=(0.0, 1000000.0 + 1.0),
+        default_bounds=(0.0, 1000000.0 + 1.0),
         dists="unif",
-        name="Seeded Tabular Acropora",
-        description="Number of Tabular Acropora to seed per deployment year.",
-    )
+        name="Seeded Tabular Acropora", description="Number of Tabular Acropora to seed per deployment year.")
     N_seed_CA::N = Param(
         0;
         ptype="integer",
         bounds=(0.0, 1000000.0 + 1.0),
+        default_bounds=(0.0, 1000000.0 + 1.0),
         dists="unif",
-        name="Seeded Corymbose Acropora",
-        description="Number of Corymbose Acropora to seed per deployment year.",
-    )
+        name="Seeded Corymbose Acropora", description="Number of Corymbose Acropora to seed per deployment year.")
     N_seed_SM::N = Param(
         0;
         ptype="integer",
         bounds=(0.0, 1000000.0 + 1.0),
+        default_bounds=(0.0, 1000000.0 + 1.0),
         dists="unif",
-        name="Seeded Small Massives",
-        description="Number of small massives/encrusting to seed per deployment year.",
-    )
-    fogging::P = Param(0.16, ptype="real", bounds=(0.0, 0.3, 0.16 / 0.3), dists="triang",
-        name="Fogging",
-        description="Assumed reduction in bleaching mortality.",
-    )
+        name="Seeded Small Massives", description="Number of small massives/encrusting to seed per deployment year.")
+    fogging::P = Param(
+        0.16;
+        ptype="real",
+        bounds=(0.0, 0.3, 0.16 / 0.3),
+        default_bounds=(0.0, 0.3, 0.16 / 0.3),
+        dists="triang",
+        name="Fogging", description="Assumed reduction in bleaching mortality.")
     SRM::P = Param(
         0.0;
         ptype="real",
         bounds=(0.0, 7.0, 0.0),
+        default_bounds=(0.0, 7.0, 0.0),
         dists="triang",
-        name="SRM",
-        description="Reduction in DHWs due to shading.",
-    )
+        name="SRM", description="Reduction in DHWs due to shading.")
     a_adapt::P = Param(
         0.0;
         ptype="real",
         bounds=(0.0, 8.0, 0.0),
+        default_bounds=(0.0, 8.0, 0.0),
         dists="triang",
-        name="Assisted Adaptation",
-        description="Assisted adaptation in terms of DHW resistance.",
-    )
+        name="Assisted Adaptation", description="Assisted adaptation in terms of DHW resistance.")
     seed_years::P2 = Param(
         10;
         ptype="integer",
         bounds=(5.0, 74.0 + 1.0, 5 / 70),
+        default_bounds=(5.0, 74.0 + 1.0, 5 / 70),
         dists="triang",
-        name="Years to Seed",
-        description="Number of years to seed for.",
-    )
+        name="Years to Seed", description="Number of years to seed for.")
     shade_years::P2 = Param(
         10;
         ptype="integer",
         bounds=(5.0, 74.0 + 1.0, 5 / 70),
+        default_bounds=(5.0, 74.0 + 1.0, 5 / 70),
         dists="triang",
-        name="Years to Shade",
-        description="Number of years to shade for.",
-    )
+        name="Years to Shade", description="Number of years to shade for.")
     plan_horizon::N = Param(
         5;
         ptype="integer",
         bounds=(0.0, 40.0 + 1.0),
+        default_bounds=(0.0, 40.0 + 1.0),
         dists="unif",
-        name="Planning Horizon",
-        description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current year).",
-    )
+        name="Planning Horizon", description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current year).")
     seed_freq::N = Param(
         5;
         ptype="integer",
         bounds=(0.0, 15.0 + 1.0),
+        default_bounds=(0.0, 15.0 + 1.0),
         dists="unif",
-        name="Seeding Frequency",
-        description="Frequency of seeding site selection (0 is set and forget).",
-    )
+        name="Seeding Frequency", description="Frequency of seeding site selection (0 is set and forget).")
     shade_freq::N = Param(
         1;
         ptype="integer",
         bounds=(0.0, 15.0 + 1.0),
+        default_bounds=(0.0, 15.0 + 1.0),
         dists="unif",
-        name="Shading Frequency",
-        description="Frequency of shading site selection (0 is set and forget).",
-    )
+        name="Shading Frequency", description="Frequency of shading site selection (0 is set and forget).")
     seed_year_start::N = Param(
         2;
         ptype="integer",
         bounds=(2.0, 25.0 + 1.0),
+        default_bounds=(2.0, 25.0 + 1.0),
         dists="unif",
-        name="Seeding Start Year",
-        description="Start seeding deployments after this number of years has elapsed.",
-    )
+        name="Seeding Start Year", description="Start seeding deployments after this number of years has elapsed.")
     shade_year_start::N = Param(
         2;
         ptype="integer",
         bounds=(2.0, 25.0 + 1.0),
+        default_bounds=(2.0, 25.0 + 1.0),
         dists="unif",
-        name="Shading Start Year",
-        description="Start of shading deployments after this number of years has elapsed.",
-    )
+        name="Shading Start Year", description="Start of shading deployments after this number of years has elapsed.")
 end

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -5,7 +5,7 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Bounds are defined as floats to maintain type stability
     guided::N = Param(
         0;
-        ptype="integer",
+        ptype="categorical",
         bounds=(-1.0, length(methods_mcda) + 1.0),
         default_bounds=(-1.0, length(methods_mcda) + 1.0),
         dists="unif",

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -369,12 +369,20 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
     # Check new parameter bounds are within old parameter bounds
-    if (new_bnds[1] < params[params.fieldname.==factor, :bounds][1][1]) || (new_bnds[2] > params[params.fieldname.==factor, :bounds][1][2])
+    if (new_bnds[1] < params[params.fieldname .== factor, :bounds][1][1]) ||
+        (new_bnds[2] > params[params.fieldname .== factor, :bounds][1][2])
         error("New bounds should be within default bounds.")
+    end
+    if (params[params.fieldname .== factor, :dists] == "triang") && (length(new_bnds) !== 3)
+        error("Triangular dist requires three parameters.")
+    elseif (params[params.fieldname .== factor, :dists] == "unif") &&
+        (length(new_bnds) !== 2)
+        error("Uniform dist requires two parameters.")
     end
 
     params[params.fieldname.==factor, :bounds] .= [new_bnds]
-    params[params.fieldname.==factor, :val] .= new_bnds[1] + 0.5 * (new_bnds[2] - new_bnds[1])
+    params[params.fieldname .== factor, :val] .=
+        new_bnds[1] + 0.5 * (new_bnds[2] - new_bnds[1])
 
     update!(d, params)
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -386,9 +386,15 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
         error("Uniform dist requires two parameters (minimum, maximum).")
     end
 
-    params[params.fieldname.==factor, :bounds] .= [new_bnds]
-    params[params.fieldname .== factor, :val] .=
-        new_bnds[1] + 0.5 * (new_bnds[2] - new_bnds[1])
+    new_val = new_lwr + 0.5 * (new_upr - new_lwr)
+
+    if _check_discrete(params[params.fieldname .== factor, :ptype][1])
+        new_val = ceil(new_val)
+        new_bnds = (round(new_lwr), round(new_upper) + 1.0)
+    end
+
+    params[params.fieldname .== factor, :bounds] .= [new_bnds]
+    params[params.fieldname .== factor, :val] .= new_val
 
     update!(d, params)
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -373,9 +373,11 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
         (new_bnds[2] > params[params.fieldname .== factor, :default_bounds][1][2])
         error("New bounds should be within default bounds.")
     end
-    if (params[params.fieldname .== factor, :dists] == "triang") && (length(new_bnds) !== 3)
+    if (params[params.fieldname .== factor, :dists][1] == "triang") &&
+        (length(new_bnds) !== 3)
         error("Triangular dist requires three parameters.")
-    elseif (params[params.fieldname .== factor, :dists] == "unif") &&
+    end
+    if (params[params.fieldname .== factor, :dists][1] == "unif") &&
         (length(new_bnds) !== 2)
         error("Uniform dist requires two parameters.")
     end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -389,7 +389,7 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     new_val = new_lower + 0.5 * (new_upper - new_lower)
 
     if _check_discrete(params[params.fieldname .== factor, :ptype][1])
-        new_val = ceil(Int64, new_val)
+        new_val = floor(Int64, new_val)
         new_bnds = (round(new_lower), round(new_upper) + 1.0)
     end
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -369,13 +369,13 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
     # get upper and lower bounds for default and new distributions
-    default_upper, default_lower = params[params.fieldname .== factor, :default_bounds][1]
-    new_upper, new_lower = new_bnds[1], new_bnds[2]
+    default_lower, default_upper = params[params.fieldname .== factor, :default_bounds][1]
+    new_lower, new_upper = new_bnds[1], new_bnds[2]
 
     # Check new parameter bounds are within default parameter bounds
-    if (new_bnds[1] < default_lower) || (new_bnds[2] > default_upper)
+    if (new_lower < default_lower) || (new_upper > default_upper)
         error(
-            "New bounds should be within [$default_upper, $default_lower], received: ($new_upper, $new_lower).",
+            "New bounds should be within ($default_lower, $default_upper), received: ($new_lower, $new_upper).",
         )
     end
     if (params[params.fieldname .== factor, :dists][1] == "triang") &&

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -351,8 +351,8 @@ function fix_factor!(d::Domain; factors...)::Nothing
 end
 
 """
-    set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)
-    set_factor_bounds!(d::Domain; factors...)
+    set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
+    set_factor_bounds!(d::Domain; factors...)::Nothing
 
 Fix bounds of a parameter for sampling to those provided.
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -351,8 +351,8 @@ function fix_factor!(d::Domain; factors...)::Nothing
 end
 
 """
-    fix_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)
-    fix_factor_bounds!(d::Domain; factors...)
+    set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)
+    set_factor_bounds!(d::Domain; factors...)
 
 Fix bounds of a parameter for sampling to those provided.
 
@@ -362,10 +362,10 @@ Note: Changes are permanent. To reset, either specify the original value(s)
 # Examples
 ```julia
 # Fix `wave_stress` to specified bounds
-fix_factor_bounds!(dom, :wave_stress, (0.1,0.2))
+set_factor_bounds!(dom, :wave_stress, (0.1,0.2))
 ```
 """
-function fix_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
+function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
     # Check new parameter bounds are within old parameter bounds
@@ -378,9 +378,9 @@ function fix_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
 
     update!(d, params)
 end
-function fix_factor_bounds!(d::Domain; factors...)::Nothing
+function set_factor_bounds!(d::Domain; factors...)::Nothing
     for (factor, bounds) in factors
-        fix_factor_bounds!(d, factor, bounds)
+        set_factor_bounds!(d, factor, bounds)
 
     end
 end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -369,8 +369,8 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
     # Check new parameter bounds are within old parameter bounds
-    if (new_bnds[1] < params[params.fieldname .== factor, :bounds][1][1]) ||
-        (new_bnds[2] > params[params.fieldname .== factor, :bounds][1][2])
+    if (new_bnds[1] < params[params.fieldname .== factor, :default_bounds][1][1]) ||
+        (new_bnds[2] > params[params.fieldname .== factor, :default_bounds][1][2])
         error("New bounds should be within default bounds.")
     end
     if (params[params.fieldname .== factor, :dists] == "triang") && (length(new_bnds) !== 3)

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -372,7 +372,7 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     default_upr, default_lwr = params[params.fieldname .== factor, :default_bounds][1]
     new_lwr, new_upr = new_bnds[1], new_bnds[2]
 
-    # Check new parameter bounds are within old parameter bounds
+    # Check new parameter bounds are within default parameter bounds
     if (new_bnds[1] < default_upr) || (new_bnds[2] > default_lwr)
         error(
             "New bounds should be within [$default_upr, $default_lwr], received: ($new_upr, $new_lwr).",

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -380,11 +380,10 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     end
     if (params[params.fieldname .== factor, :dists][1] == "triang") &&
         (length(new_bnds) !== 3)
-        error("Triangular dist requires three parameters.")
-    end
-    if (params[params.fieldname .== factor, :dists][1] == "unif") &&
+        error("Triangular dist requires three parameters (minimum, maximum, peak).")
+    elseif (params[params.fieldname .== factor, :dists][1] == "unif") &&
         (length(new_bnds) !== 2)
-        error("Uniform dist requires two parameters.")
+        error("Uniform dist requires two parameters (minimum, maximum).")
     end
 
     params[params.fieldname.==factor, :bounds] .= [new_bnds]

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -368,10 +368,15 @@ set_factor_bounds!(dom, :wave_stress, (0.1,0.2))
 function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
+    # get upper and lower bounds for default and new distributions
+    default_upr, default_lwr = params[params.fieldname .== factor, :default_bounds][1]
+    new_lwr, new_upr = new_bnds[1], new_bnds[2]
+
     # Check new parameter bounds are within old parameter bounds
-    if (new_bnds[1] < params[params.fieldname .== factor, :default_bounds][1][1]) ||
-        (new_bnds[2] > params[params.fieldname .== factor, :default_bounds][1][2])
-        error("New bounds should be within default bounds.")
+    if (new_bnds[1] < default_upr) || (new_bnds[2] > default_lwr)
+        error(
+            "New bounds should be within [$default_upr, $default_lwr], received: ($new_upr, $new_lwr).",
+        )
     end
     if (params[params.fieldname .== factor, :dists][1] == "triang") &&
         (length(new_bnds) !== 3)

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -377,12 +377,15 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params[params.fieldname.==factor, :val] .= new_bnds[1] + 0.5 * (new_bnds[2] - new_bnds[1])
 
     update!(d, params)
+
+    return nothing
 end
 function set_factor_bounds!(d::Domain; factors...)::Nothing
     for (factor, bounds) in factors
         set_factor_bounds!(d, factor, bounds)
-
     end
+
+    return nothing
 end
 
 _unzip(a) = map(x -> getfield.(a, x), fieldnames(eltype(a)))

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -389,8 +389,8 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     new_val = new_lwr + 0.5 * (new_upr - new_lwr)
 
     if _check_discrete(params[params.fieldname .== factor, :ptype][1])
-        new_val = ceil(new_val)
-        new_bnds = (round(new_lwr), round(new_upper) + 1.0)
+        new_val = ceil(Int64, new_val)
+        new_bnds = (round(new_lwr), round(new_upr) + 1.0)
     end
 
     params[params.fieldname .== factor, :bounds] .= [new_bnds]

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -369,13 +369,13 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
     params = DataFrame(d.model)
 
     # get upper and lower bounds for default and new distributions
-    default_upr, default_lwr = params[params.fieldname .== factor, :default_bounds][1]
-    new_lwr, new_upr = new_bnds[1], new_bnds[2]
+    default_upper, default_lower = params[params.fieldname .== factor, :default_bounds][1]
+    new_upper, new_lower = new_bnds[1], new_bnds[2]
 
     # Check new parameter bounds are within default parameter bounds
-    if (new_bnds[1] < default_upr) || (new_bnds[2] > default_lwr)
+    if (new_bnds[1] < default_lower) || (new_bnds[2] > default_upper)
         error(
-            "New bounds should be within [$default_upr, $default_lwr], received: ($new_upr, $new_lwr).",
+            "New bounds should be within [$default_upper, $default_lower], received: ($new_upper, $new_lower).",
         )
     end
     if (params[params.fieldname .== factor, :dists][1] == "triang") &&
@@ -386,11 +386,11 @@ function set_factor_bounds!(d::Domain, factor::Symbol, new_bnds::Tuple)::Nothing
         error("Uniform dist requires two parameters (minimum, maximum).")
     end
 
-    new_val = new_lwr + 0.5 * (new_upr - new_lwr)
+    new_val = new_lower + 0.5 * (new_upper - new_lower)
 
     if _check_discrete(params[params.fieldname .== factor, :ptype][1])
         new_val = ceil(Int64, new_val)
-        new_bnds = (round(new_lwr), round(new_upr) + 1.0)
+        new_bnds = (round(new_lower), round(new_upper) + 1.0)
     end
 
     params[params.fieldname .== factor, :bounds] .= [new_bnds]


### PR DESCRIPTION
`fix_factor_bounds!()` adjusts the sampling bounds of a specified factor. Currently the function checks against the previously set values to make sure the range is meaningful. This means the domain needs to be reloaded if the requested new interval is larger than the previous altered one. Alternatively, a new parameter called `:default_bounds` could be added to the Param type and used to check the new bounds are meaningful (e.g. criteria weights are between 0 and 1, no negatives etc.).