### PR TITLE
Fix bug in how `sensitivity.outcome_map()` treats categorical variables.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ADRIA"
 uuid = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
 authors = ["Takuya Iwanaga", "Rose Crocker", "Pedro Ribeiro de Almeida", "Ken Anthony"]
-version = "0.9.0"
+version = "0.10.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -314,8 +314,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
             f_name = Symbol(factors[curr])
             f_vals = rs.inputs[:, f_name]
             
-            if f_name .== :guided
-                fv_labels = ["unguided", "cf", last.(split.(string.(ADRIA.methods_mcda),"."))...]
+            if f_name == :guided
                 fv_s = collect(1:length(fv_labels))
             else
                 fv_s = round.(quantile(f_vals, b_slices), digits=2)
@@ -336,6 +335,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
                 fv_s,
                 outcomes(factors=f_name, CI=:mean), markersize=15
             )
+
             if f_name == :guided
                 ax.xticks = (fv_s,fv_labels)
                 ax.xticklabelrotation = pi/4

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -310,7 +310,11 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
         for c in 1:n_cols
             f_name = Symbol(factors[curr])
             f_vals = rs.inputs[:, f_name]
-            fv_s = round.(quantile(f_vals, b_slices), digits=2)
+            if all(mod.(f_vals, 1.0) .== 0.0)
+                fv_s = sort(unique(f_vals))
+            else
+                fv_s = round.(quantile(f_vals, b_slices), digits=2)
+            end
 
             ax::Axis = Axis(
                 g[r, c],

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -304,6 +304,9 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
     bin_slices, factor_list, CIs = axiskeys(outcomes)
     b_slices = parse.(Float64, bin_slices)
 
+    if any(f_names .== :guided)
+        fv_labels = ["unguided", "cf", last.(split.(string.(ADRIA.methods_mcda), "."))...]
+    end
     curr::Int64 = 1
     axs = Axis[]
     for r in 1:n_rows

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -310,8 +310,10 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
         for c in 1:n_cols
             f_name = Symbol(factors[curr])
             f_vals = rs.inputs[:, f_name]
-            if all(mod.(f_vals, 1.0) .== 0.0)
-                fv_s = sort(unique(f_vals))
+            
+            if f_name .== :guided
+                fv_labels = ["unguided", "cf", last.(split.(string.(ADRIA.methods_mcda),"."))...]
+                fv_s = collect(1:length(fv_labels))
             else
                 fv_s = round.(quantile(f_vals, b_slices), digits=2)
             end
@@ -331,6 +333,10 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
                 fv_s,
                 outcomes(factors=f_name, CI=:mean), markersize=15
             )
+            if f_name == :guided
+                ax.xticks = (fv_s,fv_labels)
+                ax.xticklabelrotation = pi/4
+            end
 
             push!(axs, ax)
             curr += 1

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -152,7 +152,7 @@ function update_params!(d::Domain, params::Union{AbstractVector,DataFrameRow})::
         end
     end
 
-    to_floor = (p_df.ptype .== "integer")
+    to_floor = (p_df.ptype .== "integer") .| (p_df.ptype .== "categorical")
     if any(to_floor)
         p_df[to_floor, :val] .= map_to_discrete.(p_df[to_floor, :val], Int64.(getindex.(p_df[to_floor, :bounds], 2)))
     end

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -152,7 +152,7 @@ function update_params!(d::Domain, params::Union{AbstractVector,DataFrameRow})::
         end
     end
 
-    to_floor = (p_df.ptype .== "integer") .| (p_df.ptype .== "categorical")
+    to_floor = _check_discrete(p_df.ptype)
     if any(to_floor)
         p_df[to_floor, :val] .= map_to_discrete.(p_df[to_floor, :val], Int64.(getindex.(p_df[to_floor, :bounds], 2)))
     end

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -1,6 +1,5 @@
 using NCDatasets
 
-const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
 
 """
     ADRIADomain{Σ,M,I,D,X,Y,Z}
@@ -33,10 +32,6 @@ mutable struct ADRIADomain{Σ<:NamedDimsArray,M<:NamedDimsArray,D<:DataFrame,X<:
     sim_constants::SimConstants
 end
 
-function _check_discrete(p_type::String)
-    check = any(p_type .== DISCRETE_FACTOR_TYPES)
-    return check
-end
 """
 Barrier function to create Domain struct without specifying Intervention/Criteria/Coral/SimConstant parameters.
 """

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -1,5 +1,6 @@
 using NCDatasets
 
+const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
 
 """
     ADRIADomain{Σ,M,I,D,X,Y,Z}
@@ -32,6 +33,10 @@ mutable struct ADRIADomain{Σ<:NamedDimsArray,M<:NamedDimsArray,D<:DataFrame,X<:
     sim_constants::SimConstants
 end
 
+function _check_discrete(p_type::String)
+    check = any(p_type .== DISCRETE_FACTOR_TYPES)
+    return check
+end
 """
 Barrier function to create Domain struct without specifying Intervention/Criteria/Coral/SimConstant parameters.
 """

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -98,8 +98,6 @@ function series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matri
     return quantile.(Slices(data, slice_dim), [0.025 0.5 0.975])
 end
 
-include("clustering.jl")
-include("intervention.jl")
 include("pareto.jl")
 include("intervention.jl")
 include("clustering.jl")

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -101,8 +101,8 @@ end
 include("clustering.jl")
 include("intervention.jl")
 include("pareto.jl")
+include("intervention.jl")
+include("clustering.jl")
 include("rule_extraction.jl")
-include("scenario.jl")
-include("sensitivity.jl")
 
 end

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -459,7 +459,7 @@ function outcome_map(
             fact_idx = foi_spec.fieldname .== fact_t
             lb = foi_spec.lower_bound[fact_idx][1]
             ub = foi_spec.upper_bound[fact_idx][1]
-            X_q .= round.(quantile(lb:1:ub, steps)) .- 1
+            X_q .= round.(quantile(lb:ub, steps)) .- 1
         else
             X_q .= quantile(X[:, fact_t], steps)
         end

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -406,7 +406,7 @@ function outcome_map(
     X::DataFrame,
     y::AbstractVecOrMat{<:Real},
     rule::Union{Function,BitVector,Vector{Int64}},
-    target_factors::Vector,
+    target_factors::Vector{String},
     model_spec::DataFrame;
     S::Int64=20,
     n_boot::Int64=100,

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -412,6 +412,7 @@ function outcome_map(
     n_boot::Int64=100,
     conf::Float64=0.95
 )::NamedDimsArray
+
     if !all([tf in model_spec.fieldname for tf in target_factors])
         missing_factor = .!([tf in model_spec.fieldname for tf in target_factors])
         error("Invalid target factors: $(target_factors[missing_factor])")
@@ -455,9 +456,9 @@ function outcome_map(
     for (j, fact_t) in enumerate(target_factors)
         ptype = model_spec.ptype[model_spec.fieldname .== fact_t][1]
         if ptype == "categorical"
-            fact_indx = foi_spec.fieldname .== fact_t
-            lb = foi_spec.lower_bound[fact_indx][1]
-            ub = foi_spec.upper_bound[fact_indx][1]
+            fact_idx = foi_spec.fieldname .== fact_t
+            lb = foi_spec.lower_bound[fact_idx][1]
+            ub = foi_spec.upper_bound[fact_idx][1]
             X_q .= round.(quantile(lb:1:ub, steps)) .- 1
         else
             X_q .= quantile(X[:, fact_t], steps)

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -453,9 +453,9 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        fact_indx = model_spec.fieldname .== fact_t
-        ptype = model_spec.ptype[fact_indx][1]
+        ptype = model_spec.ptype[model_spec.fieldname .== fact_t][1]
         if ptype == "categorical"
+            fact_indx = foi_spec.fieldname .== fact_t
             lb = foi_spec.lower_bound[fact_indx][1]
             ub = foi_spec.upper_bound[fact_indx][1]
             X_q .= round.(quantile(lb:1:ub, steps)) .- 1

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -434,7 +434,12 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        X_q .= quantile(X[:, fact_t], steps)
+        if all(typeof.(X[:, fact_t]) .== Int64)
+            X_q .= [0, sort(unique(X[:, fact_t]))...]
+        else
+            X_q .= quantile(X[:, fact_t], steps)
+        end
+
         for (i, s) in enumerate(X_q[1:end-1])
             local b::BitVector
             if i == 1

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -453,14 +453,16 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        ptype = model_spec[model_spec.name.==fact_t, :ptype]
-        if ptype == "integer"
-            X_q .= sort(unique(X[:, fact_t]))
+        ptype = model_spec.ptype[model_spec.fieldname.==fact_t][1]
+        if ptype == "categorical"
+            lb = foi_spec.lower_bound[foi_spec.fieldname.==fact_t][1]
+            ub = foi_spec.upper_bound[foi_spec.fieldname.==fact_t][1]
+            X_q .= round.(quantile(lb:1:ub, steps))
         else
             X_q .= quantile(X[:, fact_t], steps)
         end
 
-        for (i, s) in enumerate(X_q[1:end-1])
+        for i in 1:length(X_q[1:end-1])
             local b::BitVector
             if i == 1
                 b = (X_q[i] .<= X[:, fact_t] .<= X_q[i+1])

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -412,7 +412,6 @@ function outcome_map(
     n_boot::Int64=100,
     conf::Float64=0.95
 )::NamedDimsArray
-
     if !all(target_factors .∈ [model_spec.fieldname])
         missing_factor = .!(target_factors .∈ [model_spec.fieldname])
         error("Invalid target factors: $(target_factors[missing_factor])")

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -413,8 +413,8 @@ function outcome_map(
     conf::Float64=0.95
 )::NamedDimsArray
 
-    if !all([tf in model_spec.fieldname for tf in target_factors])
-        missing_factor = .!([tf in model_spec.fieldname for tf in target_factors])
+    if !all(target_factors .∈ [model_spec.fieldname])
+        missing_factor = .!(target_factors .∈ [model_spec.fieldname])
         error("Invalid target factors: $(target_factors[missing_factor])")
     end
 

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -457,7 +457,7 @@ function outcome_map(
         if ptype == "categorical"
             lb = foi_spec.lower_bound[foi_spec.fieldname.==fact_t][1]
             ub = foi_spec.upper_bound[foi_spec.fieldname.==fact_t][1]
-            X_q .= round.(quantile(lb:1:ub, steps))
+            X_q .= round.(quantile(lb:1:ub, steps)) .-1
         else
             X_q .= quantile(X[:, fact_t], steps)
         end

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -453,11 +453,12 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        ptype = model_spec.ptype[model_spec.fieldname.==fact_t][1]
+        fact_indx = model_spec.fieldname .== fact_t
+        ptype = model_spec.ptype[][1]
         if ptype == "categorical"
-            lb = foi_spec.lower_bound[foi_spec.fieldname.==fact_t][1]
-            ub = foi_spec.upper_bound[foi_spec.fieldname.==fact_t][1]
-            X_q .= round.(quantile(lb:1:ub, steps)) .-1
+            lb = foi_spec.lower_bound[fact_indx][1]
+            ub = foi_spec.upper_bound[fact_indx][1]
+            X_q .= round.(quantile(lb:1:ub, steps)) .- 1
         else
             X_q .= quantile(X[:, fact_t], steps)
         end

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -412,6 +412,16 @@ function outcome_map(
     n_boot::Int64=100,
     conf::Float64=0.95
 )::NamedDimsArray
+
+
+    model_spec.ptype[model_spec.fieldname .∈ [target_factors]]
+    factors_to_assess = model_spec.fieldname .∈ [target_factors]
+    foi_details = model_spec[factors_to_assess, [:fieldname, :ptype, :lower_bound, :upper_bound]]
+
+    foi_cat = (foi_details.ptype .== "categorical")
+    max_cat_bound = maximum(foi_details[foi_cat, :upper_bound] .- foi_details[foi_cat, :lower_bound])
+    S = max(S, max_cat_bound)
+
     step_size = 1 / S
     steps = collect(0:step_size:1.0)
 
@@ -436,7 +446,8 @@ function outcome_map(
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
         ptype = model_spec[model_spec.name.==fact_t, :ptype]
-        if ptype == "integer"
+        
+        if ptype == "categorical"
             X_q .= sort(unique(X[:, fact_t]))
         else
             X_q .= quantile(X[:, fact_t], steps)

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -454,7 +454,7 @@ function outcome_map(
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
         fact_indx = model_spec.fieldname .== fact_t
-        ptype = model_spec.ptype[][1]
+        ptype = model_spec.ptype[fact_indx][1]
         if ptype == "categorical"
             lb = foi_spec.lower_bound[fact_indx][1]
             ub = foi_spec.upper_bound[fact_indx][1]

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -453,21 +453,16 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        ptype = model_spec[model_spec.name.==fact_t, :ptype]
-        
+        ptype = model_spec.ptype[model_spec.fieldname.==fact_t][1]
         if ptype == "categorical"
-            X_q .= sort(unique(X[:, fact_t]))
+            lb = foi_spec.lower_bound[foi_spec.fieldname.==fact_t][1]
+            ub = foi_spec.upper_bound[foi_spec.fieldname.==fact_t][1]
+            X_q .= round.(quantile(lb:1:ub, steps))
         else
             X_q .= quantile(X[:, fact_t], steps)
         end
 
-        # if all(typeof.(X[:, fact_t]) .== Int64)
-        #     X_q .= [0, sort(unique(X[:, fact_t]))...]
-        # else
-        #     X_q .= quantile(X[:, fact_t], steps)
-        # end
-
-        for (i, s) in enumerate(X_q[1:end-1])
+        for i in 1:length(X_q[1:end-1])
             local b::BitVector
             if i == 1
                 b = (X_q[i] .<= X[:, fact_t] .<= X_q[i+1])

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -453,16 +453,13 @@ function outcome_map(
 
     X_q = zeros(S + 1)
     for (j, fact_t) in enumerate(target_factors)
-        ptype = model_spec.ptype[model_spec.fieldname.==fact_t][1]
-        if ptype == "categorical"
-            lb = foi_spec.lower_bound[foi_spec.fieldname.==fact_t][1]
-            ub = foi_spec.upper_bound[foi_spec.fieldname.==fact_t][1]
-            X_q .= round.(quantile(lb:1:ub, steps)) .-1
+        if all(typeof.(X[:, fact_t]) .== Int64)
+            X_q .= [0, sort(unique(X[:, fact_t]))...]
         else
             X_q .= quantile(X[:, fact_t], steps)
         end
 
-        for i in 1:length(X_q[1:end-1])
+        for (i, s) in enumerate(X_q[1:end-1])
             local b::BitVector
             if i == 1
                 b = (X_q[i] .<= X[:, fact_t] .<= X_q[i+1])

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -412,6 +412,10 @@ function outcome_map(
     n_boot::Int64=100,
     conf::Float64=0.95
 )::NamedDimsArray
+    if !all([tf in model_spec.fieldname for tf in target_factors])
+        missing_factor = .!([tf in model_spec.fieldname for tf in target_factors])
+        error("Invalid target factors: $(target_factors[missing_factor])")
+    end
 
 
     model_spec.ptype[model_spec.fieldname .∈ [target_factors]]

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -417,14 +417,18 @@ function outcome_map(
         error("Invalid target factors: $(target_factors[missing_factor])")
     end
 
-
-    model_spec.ptype[model_spec.fieldname .∈ [target_factors]]
     factors_to_assess = model_spec.fieldname .∈ [target_factors]
-    foi_details = model_spec[factors_to_assess, [:fieldname, :ptype, :lower_bound, :upper_bound]]
+    foi_attributes = Symbol[:fieldname, :ptype, :lower_bound, :upper_bound]
+    foi_spec = model_spec[factors_to_assess, foi_attributes]
 
-    foi_cat = (foi_details.ptype .== "categorical")
-    max_cat_bound = maximum(foi_details[foi_cat, :upper_bound] .- foi_details[foi_cat, :lower_bound])
-    S = max(S, max_cat_bound)
+    foi_cat = (foi_spec.ptype .== "categorical")
+    if any(foi_cat)
+        max_bounds = maximum(
+            foi_spec[foi_cat, :upper_bound] .-
+            foi_spec[foi_cat, :lower_bound]
+        )
+        S = round(Int64, max(S, max_bounds))
+    end
 
     step_size = 1 / S
     steps = collect(0:step_size:1.0)

--- a/src/decision/Criteria.jl
+++ b/src/decision/Criteria.jl
@@ -48,13 +48,9 @@ Base.@kwdef struct Criteria{P,N} <: EcoModel
         description="Tolerance for low proportional space for seeding deployments.",
     )
     deployed_coral_risk_tol::P = Param(1.0, ptype="real", bounds=(0.75, 1.0), dists="unif",
-        name="Risk Tolerance",
-        description="Filters out sites with heat/wave stress above threshold.",
-    )
-    use_dist::N = Param(1, ptype="integer", bounds=(0.0, 1.0 + 1.0), dists="unif",
-        name="Use Distance Threshold",
-        description="Turns distance sorting on or off.",
-    )
+        name="Risk Tolerance", description="Filters out sites with heat/wave stress above threshold.")
+    use_dist::N = Param(1, ptype="categorical", bounds=(0.0, 1.0 + 1.0), dists="unif",
+        name="Use Distance Threshold", description="Turns distance sorting on or off.")
     dist_thresh::P = Param(0.1, ptype="real", bounds=(0.0, 1.0), dists="unif",
         name="Distance Threshold",
         description="Sites selected by MCDA must be further apart than median(dist)-dist_thresh*median(dist).",

--- a/src/decision/Criteria.jl
+++ b/src/decision/Criteria.jl
@@ -1,65 +1,138 @@
 Base.@kwdef struct Criteria{P,N} <: EcoModel
-    wave_stress::P = Param(1.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    wave_stress::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Wave Stress",
         description="Importance of avoiding wave stress. Higher values places more weight on areas with low wave stress.",
     )
-    heat_stress::P = Param(1.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    heat_stress::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Heat Stress",
         description="Importance of avoiding heat stress. Higher values places more weight on areas with low heat stress.",
     )
-    shade_connectivity::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    shade_connectivity::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Shade Connectivity",
         description="Higher values give preference to locations with high connectivity for shading deployments.",
     )
-    in_seed_connectivity::P = Param(1.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    in_seed_connectivity::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Incoming Connectivity (Seed)",
         description="Higher values give preference to locations with high incoming connectivity (i.e., receives larvae from other sites) for enhanced coral deployments.",
     )
-    out_seed_connectivity::P = Param(1.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    out_seed_connectivity::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Outgoing Connectivity (Seed)",
         description="Higher values give preference to locations with high outgoing connectivity (i.e., provides larvae to other sites) for enhanced coral deployments.",
     )
-    coral_cover_low::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    coral_cover_low::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Low Coral Cover",
         description="Higher values give greater preference to sites with low coral cover for seeding deployments.",
     )
-    coral_cover_high::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    coral_cover_high::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="High Coral Cover",
         description="Higher values give preference to sites with high coral cover for shading deployments.",
     )
-    seed_priority::P = Param(1.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    seed_priority::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Predecessor Priority (Seed)",
         description="Importance of seeding sites that provide larvae to priority reefs.",
     )
-    shade_priority::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    shade_priority::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Predecessor Priority (Shade)",
         description="Importance of shading sites that provide larvae to priority reefs.",
     )
-    zone_seed::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    zone_seed::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Zone Predecessor (Seed)",
         description="Importance of seeding sites that provide larvae to priority (target) zones.",
     )
-    zone_shade::P = Param(0.0, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    zone_shade::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Zone Predecessor (Shade)",
         description="Importance of shading sites that provide larvae to priority (target) zones.",
     )
-    coral_cover_tol::P = Param(0.2, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    coral_cover_tol::P = Param(
+        0.2;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Low Area Tolerance",
         description="Tolerance for low proportional space for seeding deployments.",
     )
-    deployed_coral_risk_tol::P = Param(1.0, ptype="real", bounds=(0.75, 1.0), dists="unif",
-        name="Risk Tolerance", description="Filters out sites with heat/wave stress above threshold.")
-    use_dist::N = Param(1, ptype="categorical", bounds=(0.0, 1.0 + 1.0), dists="unif",
-        name="Use Distance Threshold", description="Turns distance sorting on or off.")
-    dist_thresh::P = Param(0.1, ptype="real", bounds=(0.0, 1.0), dists="unif",
+    deployed_coral_risk_tol::P = Param(
+        1.0;
+        ptype="real",
+        bounds=(0.75, 1.0),
+        dists="unif",
+        name="Risk Tolerance",
+        description="Filters out sites with heat/wave stress above threshold.",
+    )
+    use_dist::N = Param(
+        1;
+        ptype="categorical",
+        bounds=(0.0, 1.0 + 1.0),
+        dists="unif",
+        name="Use Distance Threshold",
+        description="Turns distance sorting on or off.",
+    )
+    dist_thresh::P = Param(
+        0.1;
+        ptype="real",
+        bounds=(0.0, 1.0),
+        dists="unif",
         name="Distance Threshold",
         description="Sites selected by MCDA must be further apart than median(dist)-dist_thresh*median(dist).",
     )
-    depth_min::P = Param(5.0, ptype="real", bounds=(3.0, 5.0), dists="unif",
+    depth_min::P = Param(
+        5.0;
+        ptype="real",
+        bounds=(3.0, 5.0),
+        dists="unif",
         name="Minimum Depth",
         description="Minimum depth for a site to be included for consideration.\nNote: This value will be replaced with the shallowest depth value found if all sites are found to be deeper than `depth_min + depth_offset`.",
     )
-    depth_offset::P = Param(10.0, ptype="real", bounds=(10.0, 25.0), dists="unif", name="Depth Offset",
+    depth_offset::P = Param(
+        10.0;
+        ptype="real",
+        bounds=(10.0, 25.0),
+        dists="unif",
+        name="Depth Offset",
         description="Offset from minimum depth, used to indicate maximum depth.",
     )
 end

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -10,8 +10,9 @@ abstract type EcoModel end
 const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
 
 """
-Check ptype for discrete variable types.
+    _check_discrete(p_type::String)
 
+Check ptype for discrete variable types.
 Returns true if discrete, false otherwise.
 
 # Arguments

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -7,6 +7,19 @@ using Distributions
 
 abstract type EcoModel end
 
+const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
+
+"""
+Check ptype for discrete variable types.
+
+Returns true if discrete, false otherwise.
+
+# Arguments
+- `ptype` : String representing variable type.
+"""
+function _check_discrete(p_type::String)
+    return any(p_type .== DISCRETE_FACTOR_TYPES)
+end
 
 """Set a model parameter value directly."""
 function set(p::Param, val::Union{Int64,Float64})

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -10,7 +10,7 @@ abstract type EcoModel end
 const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
 
 """
-    _check_discrete(p_type::String)
+    _check_discrete(p_type::String)::Bool
 
 Check ptype for discrete variable types.
 Returns true if discrete, false otherwise.
@@ -18,7 +18,7 @@ Returns true if discrete, false otherwise.
 # Arguments
 - `ptype` : String representing variable type.
 """
-function _check_discrete(p_type::String)
+function _check_discrete(p_type::String)::Bool
     return any(p_type .== DISCRETE_FACTOR_TYPES)
 end
 

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -10,8 +10,10 @@ abstract type EcoModel end
 
 """Set a model parameter value directly."""
 function set(p::Param, val::Union{Int64,Float64})
-    if hasproperty(p, :ptype) && p.ptype == "integer" && !isinteger(val)
-        val = map_to_discrete(val, p.bounds[2])
+    if hasproperty(p, :ptype) 
+        if (p.ptype == "integer" | p.ptype == "categorical") && !isinteger(val)
+            val = map_to_discrete(val, p.bounds[2])
+        end
     end
 
     return val

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -11,7 +11,7 @@ abstract type EcoModel end
 """Set a model parameter value directly."""
 function set(p::Param, val::Union{Int64,Float64})
     if hasproperty(p, :ptype) 
-        if (p.ptype == "integer" | p.ptype == "categorical") && !isinteger(val)
+        if _check_discrete(p.ptype) && !isinteger(val)
             val = map_to_discrete(val, p.bounds[2])
         end
     end

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -3,7 +3,7 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Integer values have a +1 offset to allow for discrete value mapping
     # (see `set()` and `map_to_discrete()` methods)
     # Bounds are defined as floats to maintain type stability
-    guided::N = Param(0, ptype="integer", bounds=(-1.0, length(methods_mcda) + 1.0), dists="unif",
+    guided::N = Param(0, ptype="categorical", bounds=(-1.0, length(methods_mcda) + 1.0), dists="unif",
         name="Guided", description="Choice of MCDA approach.")
     N_seed_TA::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
         name="Seeded Tabular Acropora", description="Number of Tabular Acropora to seed per deployment year.")

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -3,32 +3,112 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     # Integer values have a +1 offset to allow for discrete value mapping
     # (see `set()` and `map_to_discrete()` methods)
     # Bounds are defined as floats to maintain type stability
-    guided::N = Param(0, ptype="categorical", bounds=(-1.0, length(methods_mcda) + 1.0), dists="unif",
-        name="Guided", description="Choice of MCDA approach.")
-    N_seed_TA::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
-        name="Seeded Tabular Acropora", description="Number of Tabular Acropora to seed per deployment year.")
-    N_seed_CA::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
-        name="Seeded Corymbose Acropora", description="Number of Corymbose Acropora to seed per deployment year.")
-    N_seed_SM::N = Param(0, ptype="integer", bounds=(0.0, 1000000.0 + 1.0), dists="unif",
-        name="Seeded Small Massives", description="Number of small massives/encrusting to seed per deployment year.")
+    guided::N = Param(
+        0;
+        ptype="categorical",
+        bounds=(-1.0, length(methods_mcda) + 1.0),
+        dists="unif",
+        name="Guided",
+        description="Choice of MCDA approach.",
+    )
+    N_seed_TA::N = Param(
+        0;
+        ptype="integer",
+        bounds=(0.0, 1000000.0 + 1.0),
+        dists="unif",
+        name="Seeded Tabular Acropora",
+        description="Number of Tabular Acropora to seed per deployment year.",
+    )
+    N_seed_CA::N = Param(
+        0;
+        ptype="integer",
+        bounds=(0.0, 1000000.0 + 1.0),
+        dists="unif",
+        name="Seeded Corymbose Acropora",
+        description="Number of Corymbose Acropora to seed per deployment year.",
+    )
+    N_seed_SM::N = Param(
+        0;
+        ptype="integer",
+        bounds=(0.0, 1000000.0 + 1.0),
+        dists="unif",
+        name="Seeded Small Massives",
+        description="Number of small massives/encrusting to seed per deployment year.",
+    )
     fogging::P = Param(0.16, ptype="real", bounds=(0.0, 0.3, 0.16 / 0.3), dists="triang",
-        name="Fogging", description="Assumed reduction in bleaching mortality.")
-    SRM::P = Param(0.0, ptype="real", bounds=(0.0, 7.0, 0.0), dists="triang",
-        name="SRM", description="Reduction in DHWs due to shading.")
-    a_adapt::P = Param(0.0, ptype="real", bounds=(0.0, 8.0, 0.0), dists="triang",
-        name="Assisted Adaptation", description="Assisted adaptation in terms of DHW resistance.")
-    seed_years::P2 = Param(10, ptype="integer", bounds=(5.0, 74.0 + 1.0, 5 / 70), dists="triang",
-        name="Years to Seed", description="Number of years to seed for.")
-    shade_years::P2 = Param(10, ptype="integer", bounds=(5.0, 74.0 + 1.0, 5 / 70), dists="triang",
-        name="Years to Shade", description="Number of years to shade for.")
-    plan_horizon::N = Param(5, ptype="integer", bounds=(0.0, 40.0 + 1.0), dists="unif",
-        name="Planning Horizon", description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current year).")
-    seed_freq::N = Param(5, ptype="integer", bounds=(0.0, 15.0 + 1.0), dists="unif",
-        name="Seeding Frequency", description="Frequency of seeding site selection (0 is set and forget).")
-    shade_freq::N = Param(1, ptype="integer", bounds=(0.0, 15.0 + 1.0), dists="unif",
-        name="Shading Frequency", description="Frequency of shading site selection (0 is set and forget).")
-    seed_year_start::N = Param(2, ptype="integer", bounds=(2.0, 25.0 + 1.0), dists="unif",
-        name="Seeding Start Year", description="Start seeding deployments after this number of years has elapsed.")
-    shade_year_start::N = Param(2, ptype="integer", bounds=(2.0, 25.0 + 1.0), dists="unif",
-        name="Shading Start Year", description="Start of shading deployments after this number of years has elapsed.")
+        name="Fogging",
+        description="Assumed reduction in bleaching mortality.",
+    )
+    SRM::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 7.0, 0.0),
+        dists="triang",
+        name="SRM",
+        description="Reduction in DHWs due to shading.",
+    )
+    a_adapt::P = Param(
+        0.0;
+        ptype="real",
+        bounds=(0.0, 8.0, 0.0),
+        dists="triang",
+        name="Assisted Adaptation",
+        description="Assisted adaptation in terms of DHW resistance.",
+    )
+    seed_years::P2 = Param(
+        10;
+        ptype="integer",
+        bounds=(5.0, 74.0 + 1.0, 5 / 70),
+        dists="triang",
+        name="Years to Seed",
+        description="Number of years to seed for.",
+    )
+    shade_years::P2 = Param(
+        10;
+        ptype="integer",
+        bounds=(5.0, 74.0 + 1.0, 5 / 70),
+        dists="triang",
+        name="Years to Shade",
+        description="Number of years to shade for.",
+    )
+    plan_horizon::N = Param(
+        5;
+        ptype="integer",
+        bounds=(0.0, 40.0 + 1.0),
+        dists="unif",
+        name="Planning Horizon",
+        description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current year).",
+    )
+    seed_freq::N = Param(
+        5;
+        ptype="integer",
+        bounds=(0.0, 15.0 + 1.0),
+        dists="unif",
+        name="Seeding Frequency",
+        description="Frequency of seeding site selection (0 is set and forget).",
+    )
+    shade_freq::N = Param(
+        1;
+        ptype="integer",
+        bounds=(0.0, 15.0 + 1.0),
+        dists="unif",
+        name="Shading Frequency",
+        description="Frequency of shading site selection (0 is set and forget).",
+    )
+    seed_year_start::N = Param(
+        2;
+        ptype="integer",
+        bounds=(2.0, 25.0 + 1.0),
+        dists="unif",
+        name="Seeding Start Year",
+        description="Start seeding deployments after this number of years has elapsed.",
+    )
+    shade_year_start::N = Param(
+        2;
+        ptype="integer",
+        bounds=(2.0, 25.0 + 1.0),
+        dists="unif",
+        name="Shading Start Year",
+        description="Start of shading deployments after this number of years has elapsed.",
+    )
 end

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -79,7 +79,7 @@ function _process_inputs!(spec::DataFrame, df::DataFrame)::Nothing
 end
 function _process_inputs!(bnds::Tuple, p_types::Tuple, df::DataFrame)::Nothing
     for (i, dt) in enumerate(p_types)
-        if dt == "integer" && (bnds[i][1] < bnds[i][2])
+        if (dt == "integer" .|| dt == "categorical") && (bnds[i][1] < bnds[i][2])
             @inbounds df[!, i] .= map_to_discrete.(df[!, i], Int64(bnds[i][2]))
         end
     end

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -79,7 +79,7 @@ function _process_inputs!(spec::DataFrame, df::DataFrame)::Nothing
 end
 function _process_inputs!(bnds::Tuple, p_types::Tuple, df::DataFrame)::Nothing
     for (i, dt) in enumerate(p_types)
-        if (dt == "integer" .|| dt == "categorical") && (bnds[i][1] < bnds[i][2])
+        if _check_discrete(dt) && (bnds[i][1] < bnds[i][2])
             @inbounds df[!, i] .= map_to_discrete.(df[!, i], Int64(bnds[i][2]))
         end
     end

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -263,7 +263,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Store post-processed table of input parameters.
     # +1 skips the RCP column
-    integer_params = findall([_check_discrete(dd) for dd in domain.model[:ptype]])
+    integer_params = findall(_check_discrete.(domain.model[:ptype]))
     map_to_discrete!(scen_spec[:, integer_params.+1], getindex.(domain.model[:bounds], 2)[integer_params])
     inputs[:, :] = Matrix(scen_spec)
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -263,9 +263,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Store post-processed table of input parameters.
     # +1 skips the RCP column
-    is_cat = domain.model[:ptype] .== "categorical"
-    is_int = domain.model[:ptype] .== "integer"
-    integer_params = findall(is_int .| is_cat)
+    integer_params = findall([_check_discrete(dd) for dd in domain.model[:ptype]])
     map_to_discrete!(scen_spec[:, integer_params.+1], getindex.(domain.model[:bounds], 2)[integer_params])
     inputs[:, :] = Matrix(scen_spec)
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -263,7 +263,9 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Store post-processed table of input parameters.
     # +1 skips the RCP column
-    integer_params = findall(domain.model[:ptype] .== "integer")
+    is_cat = domain.model[:ptype] .== "categorical"
+    is_int = domain.model[:ptype] .== "integer"
+    integer_params = findall(is_int .| is_cat)
     map_to_discrete!(scen_spec[:, integer_params.+1], getindex.(domain.model[:bounds], 2)[integer_params])
     inputs[:, :] = Matrix(scen_spec)
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -284,8 +284,6 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
         _row = to_update.fieldname .== c
         _bnds = length(to_update[_row, :bounds][1]) == 2 ? (0.0, 0.0) : (0.0, 0.0, 0.0)
 
-        # Handle special cases for discrete valued factors.
-        # This will break if meanings/possible values of `ptype` changes.
         dval = _check_discrete(to_update[_row, :ptype][1]) ? 0 : 0.0
         to_update[_row, [:val, :lower_bound, :upper_bound, :bounds, :is_constant]] .= [dval 0.0 0.0 _bnds true]
     end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -286,9 +286,7 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
 
         # Handle special cases for discrete valued factors.
         # This will break if meanings/possible values of `ptype` changes.
-        is_int = to_update[_row, :ptype][1] == "integer"
-        is_cat = to_update[_row, :ptype][1] == "categorical"
-        dval = (is_int .| is_cat) ? 0 : 0.0
+        dval = _check_discrete(to_update[_row, :ptype][1]) ? 0 : 0.0
         to_update[_row, [:val, :lower_bound, :upper_bound, :bounds, :is_constant]] .= [dval 0.0 0.0 _bnds true]
     end
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -284,7 +284,9 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
         _row = to_update.fieldname .== c
         _bnds = length(to_update[_row, :bounds][1]) == 2 ? (0.0, 0.0) : (0.0, 0.0, 0.0)
 
-        dval = to_update[_row, :ptype][1] == "integer" ? 0 : 0.0
+        is_int = to_update[_row, :ptype][1] == "integer"
+        is_cat = to_update[_row, :ptype][1] == "categorical"
+        dval = (is_int .| is_cat) ? 0 : 0.0
         to_update[_row, [:val, :lower_bound, :upper_bound, :bounds, :is_constant]] .= [dval 0.0 0.0 _bnds true]
     end
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -6,6 +6,8 @@ import Surrogates: sample
 import Surrogates.QuasiMonteCarlo: SobolSample
 
 
+const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
+
 """
     adjust_samples(d::Domain, df::DataFrame)::DataFrame
     adjust_samples!(spec::DataFrame, df::DataFrame)::DataFrame
@@ -369,6 +371,19 @@ function _check_bounds(lower, upper)
     if any(lower .> upper)
         error("Bounds are not legal (upper bound must be greater than lower bound)")
     end
+end
+
+"""
+Check ptype for discrete variable types.
+
+Returns true if discrete, false otherwise.
+
+# Arguments
+- `ptype` : String representing variable type.
+"""
+function _check_discrete(p_type::String)
+    check = any(p_type .== DISCRETE_FACTOR_TYPES)
+    return check
 end
 
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -284,6 +284,8 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
         _row = to_update.fieldname .== c
         _bnds = length(to_update[_row, :bounds][1]) == 2 ? (0.0, 0.0) : (0.0, 0.0, 0.0)
 
+        # Handle special cases for discrete valued factors.
+        # This will break if meanings/possible values of `ptype` changes.
         is_int = to_update[_row, :ptype][1] == "integer"
         is_cat = to_update[_row, :ptype][1] == "categorical"
         dval = (is_int .| is_cat) ? 0 : 0.0

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -6,8 +6,6 @@ import Surrogates: sample
 import Surrogates.QuasiMonteCarlo: SobolSample
 
 
-const DISCRETE_FACTOR_TYPES = ["integer", "categorical"]
-
 """
     adjust_samples(d::Domain, df::DataFrame)::DataFrame
     adjust_samples!(spec::DataFrame, df::DataFrame)::DataFrame
@@ -372,20 +370,6 @@ function _check_bounds(lower, upper)
         error("Bounds are not legal (upper bound must be greater than lower bound)")
     end
 end
-
-"""
-Check ptype for discrete variable types.
-
-Returns true if discrete, false otherwise.
-
-# Arguments
-- `ptype` : String representing variable type.
-"""
-function _check_discrete(p_type::String)
-    check = any(p_type .== DISCRETE_FACTOR_TYPES)
-    return check
-end
-
 
 _offdiag_iter(A) = collect(ι for ι in CartesianIndices(A) if ι[1] ≠ ι[2])
 


### PR DESCRIPTION
In `sensitivity.outcome_map()` factor splittings are determined using the number of bins provided and the function `quantile()` from the Statisitcs.jl package. This is an issue for categorical functions as `quantile()` treats the lowest and highest values in the set of samples provided as the upper and lower bounds of the splitting. This means, with the number of bins being equal to the number of categories, there are duplicate values because there are not enough splittings for the number of categorical variables. Providing the number of bins as (number of categories) +1 does not solve this either because quantile tries to split the range of values into smaller splittings without adjusting the upper and lower bounds. 

The fix provided here checks whether the variable is categorical and if so, sets the number of bins as the (number of categories) + 1. The splittings are then set as [0 , [ordered set of categories]]. The lower bound of zero means that when the bounds checks are applied scenarios are correctly categorised.

Setting this as a draft however because it means that categorical and continuous variables cannot be calculated (or plotted)  together as the size of the storage matrix may not be compatible for both. Do we want to a) keep it this way so the two must be considered separately (and have an error message if requested)? b) make the size of the storage as the maximum number of splittings between categorical factors and the n_bins provided? c) another alternative ?