### PR TITLE
Fix _time_labels missing last label

### DIFF
--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -11,7 +11,7 @@ using GLMakie.Colors
 
 Extract time step labels, ensuring last entry is always included.
 """
-function _time_labels(labels; label_step=5)
+function _time_labels(labels; label_step=5)::Tuple{Vector{Int64},Vector{String}}
     labels_length = length(labels)
     labels_strings = string.(labels)
 

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -11,9 +11,14 @@ using GLMakie.Colors
 
 Extract time step labels, ensuring last entry is always included.
 """
-function _time_labels(labels)
-    tick_pos = vcat(1:5:length(labels), [length(labels)])
-    tick_label = vcat(string.(labels)[1:5:end], string.(labels)[end])
+function _time_labels(labels; label_step=5)
+    tick_pos = collect(1:label_step:length(labels))
+    tick_label = collect(string.(labels)[1:label_step:end])
+
+    # Prevent missing last label if (length(labels) - 1) is not multiple of label_step
+    if (length(labels) - 1) % label_step != 0
+        return vcat(tick_pos, length(labels)), vcat(tick_label, string.(labels)[end])
+    end
 
     return tick_pos, tick_label
 end

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -12,15 +12,18 @@ using GLMakie.Colors
 Extract time step labels, ensuring last entry is always included.
 """
 function _time_labels(labels; label_step=5)
-    tick_pos = collect(1:label_step:length(labels))
-    tick_label = collect(string.(labels)[1:label_step:end])
+    labels_length = length(labels)
+    labels_strings = string.(labels)
 
-    # Prevent missing last label if (length(labels) - 1) is not multiple of label_step
-    if (length(labels) - 1) % label_step != 0
-        return vcat(tick_pos, length(labels)), vcat(tick_label, string.(labels)[end])
+    tick_position = collect(1:label_step:labels_length)
+    tick_label = collect(labels_strings[1:label_step:end])
+
+    # Prevent missing last label
+    if (labels_length - 1) % label_step != 0
+        return vcat(tick_position, labels_length), vcat(tick_label, labels_strings[end])
     end
 
-    return tick_pos, tick_label
+    return tick_position, tick_label
 end
 
 function _dimkeys(outcomes::NamedDimsArray)


### PR DESCRIPTION
Prevent missing last label if (length(labels) - 1) is not multiple of label_step.

Here are some examples plotting `ADRIA.metrics.total_absolute_cover(rs)[timesteps=1:last_year]` for different values of `last_year`. I have clustered scenarios, targeted, and I am plotting using `ADRIA.viz.clustered_scenarios()`:

| last_year = 26 |  last_year = 27 |
|----------------|-----------------|
| ![tac_outcome_series_26](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/b903c45c-5507-4466-8e39-85f1ddd2038a) | ![tac_outcome_series_27](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/46e864c6-6e29-40b6-9ceb-c63c8d2d7e46) |

| last_year = 28 | last_year = 29 |
|----------------|----------------|
|![tac_outcome_series_28](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/f453921b-4494-4534-bd39-4b6e487b540d) | ![tac_outcome_series_29](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/30e4290a-b68c-4c1a-ad08-60e27d28d052) |

| last_year = 30 | last_year = 31 |
|----------------|----------------|
| ![tac_outcome_series_30](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/878304b9-6778-4a78-9d69-d7e8102f658d) | ![tac_outcome_series_31](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/a99f5f24-3d8b-4d00-87bd-a1568b3a39f8) |


Close #495 

