### PR TITLE
Add `:summary` option to `viz.scenarios`

### DIFF
--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -2,8 +2,8 @@ using JuliennedArrays: Slices
 using Statistics
 
 """
-    clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    clustered_scenarios!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
+    clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    clustered_scenarios!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), axis_opts::Dict=Dict())
 
 Visualize clustered time series of scenarios.
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -98,7 +98,9 @@ function _plot_clusters_confint!(
         line_color = line_colors[idx_c]
 
         y_lower, y_median, y_upper = eachcol(
-            series_confint(data[:, clusters .== cluster]; agg_dim=slice_dimension)
+            ADRIA.analysis.series_confint(
+                data[:, clusters .== cluster]; agg_dim=slice_dimension
+            ),
         )
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,7 +1,6 @@
 using JuliennedArrays: Slices
 using Statistics
 
-
 """
     clustered_scenarios(data::AbstractMatrix, clusters::Vector{Int64}; fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
     clustered_scenarios!(g::Union{GridLayout,GridPosition}, data::AbstractMatrix, clusters::Vector{Int64}; axis_opts::Dict=Dict())
@@ -94,16 +93,12 @@ function _plot_clusters_confint!(
     x_timesteps::UnitRange{Int64} = 1:length(timesteps(data))
 
     for (idx_c, cluster) in enumerate(unique_clusters)
-        cluster_data = data[:, clusters .== cluster]
-        data_slices = Slices(cluster_data, NamedDims.dim(cluster_data, slice_dimension))
-
-        y_lower = quantile.(data_slices, [0.025])
-        y_upper = quantile.(data_slices, [0.975])
-
-        band!(ax, x_timesteps, y_lower, y_upper; color=band_colors[idx_c])
-
-        y_median = median.(data_slices)
+        band_color = band_colors[idx_c]
         line_color = line_colors[idx_c]
+
+        y_lower, y_upper, y_median = confint(data[:, clusters .== cluster], slice_dimension)
+
+        band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
         legend_entry[idx_c] = scatterlines!(ax, y_median; color=line_color, markersize=5)
     end
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -82,8 +82,6 @@ function _plot_clusters_confint!(
         throw(ArgumentError("data does not have :timesteps axis"))
     elseif length(dimnames(data)) != 2
         throw(ArgumentError("data does not have two dimensions"))
-    else
-        slice_dimension = filter(x -> x != :timesteps, dimnames(data))[1]
     end
 
     unique_clusters = sort(unique(clusters))
@@ -93,6 +91,7 @@ function _plot_clusters_confint!(
     legend_entry = Vector{Any}(undef, length(unique_clusters))
 
     x_timesteps::UnitRange{Int64} = 1:length(timesteps(data))
+    slice_dimension = filter(x -> x != :timesteps, dimnames(data))[1]
 
     for (idx_c, cluster) in enumerate(unique_clusters)
         band_color = band_colors[idx_c]

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -10,6 +10,8 @@ Visualize clustered time series of scenarios.
 # Arguments
 - `data` : Matrix of time series data for several scenarios or sites
 - `clusters` : Vector of numbers corresponding to clusters
+- `opts` : Aviz options
+    - `summarize` : plot confidence interval. Defaults to true
 
 # Returns
 Figure

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -91,7 +91,8 @@ function _plot_clusters_confint!(
     legend_entry = Vector{Any}(undef, length(unique_clusters))
 
     x_timesteps::UnitRange{Int64} = 1:length(timesteps(data))
-    slice_dimension = filter(x -> x != :timesteps, dimnames(data))[1]
+    data_dims = dimnames(data)
+    slice_dimension = data_dims[findfirst(data_dims .!= :timesteps)]
 
     for (idx_c, cluster) in enumerate(unique_clusters)
         band_color = band_colors[idx_c]

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -97,7 +97,7 @@ function _plot_clusters_confint!(
         band_color = band_colors[idx_c]
         line_color = line_colors[idx_c]
 
-        y_lower, y_upper, y_median = confint(data[:, clusters .== cluster], slice_dimension)
+        y_lower, y_median, y_upper = confint(data[:, clusters .== cluster], slice_dimension)
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
         legend_entry[idx_c] = scatterlines!(ax, y_median; color=line_color, markersize=5)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -80,7 +80,7 @@ function _plot_clusters_confint!(
 )::Nothing
     if :timesteps ∉ dimnames(data)
         throw(ArgumentError("data does not have :timesteps axis"))
-    elseif length(dimnames(data)) != 2
+    elseif ndims(data) != 2
         throw(ArgumentError("data does not have two dimensions"))
     end
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -97,7 +97,9 @@ function _plot_clusters_confint!(
         band_color = band_colors[idx_c]
         line_color = line_colors[idx_c]
 
-        y_lower, y_median, y_upper = confint(data[:, clusters .== cluster], slice_dimension)
+        y_lower, y_median, y_upper = eachcol(
+            series_confint(data[:, clusters .== cluster]; agg_dim=slice_dimension)
+        )
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
         legend_entry[idx_c] = scatterlines!(ax, y_median; color=line_color, markersize=5)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -92,7 +92,8 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
         selected_scenarios = scenario_type(rs)[type]
 
         base_color = scenario_colors(rs)[selected_scenarios][1][1]
-        band_color = (base_color, max(0.7 - idx * 0.1, 0.4))
+        band_alpha = max(0.7 - idx * 0.1, 0.4)
+        band_color = (base_color, band_alpha)
         line_color = (base_color, 1.0)
 
         y_lower, y_upper, y_median = confint(data[:, selected_scenarios], :scenarios)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -23,7 +23,7 @@ ADRIA.viz.scenarios(rs, s_tac[:, scens.SRM .< 1.0])
 
 # Arguments
 - `rs` : ResultSet
-- `y` : results of scenario metric
+- `data` : results of scenario metric
 - `opts` : Aviz options
     - `by_RCP` : color by RCP otherwise color by scenario type. Defaults to false.
     - `legend` : show legend. Defaults to true.
@@ -209,7 +209,16 @@ function _render_scenarios_legend(
     return nothing
 end
 
-# Sort types by variance in reverse order to plot highest variances first
+"""
+    function _order_by_variance(data::NamedDimsArray, scenario_types::NamedTuple)::Tuple{Symbol,Symbol,Symbol}
+
+Sort types by variance in reverse order to plot highest variances first
+
+# Arguments
+- `data` : Results of scenario metric
+- `scenario_types` : Named tuple with Vector{Bool} to filter scenarios of each type (
+    :guided, :unguided or :counterfactual)
+"""
 function _order_by_variance(
     data::NamedDimsArray, scenario_types::NamedTuple
 )::Tuple{Symbol,Symbol,Symbol}

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -97,7 +97,9 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
 
     confints = zeros(n_timesteps, length(scenario_types), 3)
     for (idx_s, scenario) in enumerate(selected_scenarios)
-        confints[:, idx_s, :] = series_confint(data[:, scenario]; agg_dim=:scenarios)
+        confints[:, idx_s, :] = ADRIA.analysis.series_confint(
+            data[:, scenario]; agg_dim=:scenarios
+        )
     end
 
     for idx in eachindex(ordered_types)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -225,8 +225,10 @@ Sort types by variance in reverse order to plot highest variances first
 
 # Arguments
 - `data` : Results of scenario metric
-- `scenario_types` : Named tuple with BitVectors to filter scenarios of each type (
-    :guided, :unguided or :counterfactual)
+- `scenario_types` : NamedTuple with BitVectors to filter scenarios of each type. One of:
+    - :guided
+    - :unguided
+    - :counterfactual
 """
 function _order_by_variance(
     data::NamedDimsArray, scenario_types::NamedTuple

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -221,7 +221,7 @@ Sort types by variance in reverse order to plot highest variances first
 
 # Arguments
 - `data` : Results of scenario metric
-- `scenario_types` : Named tuple with Vector{Bool} to filter scenarios of each type (
+- `scenario_types` : Named tuple with BitVectors to filter scenarios of each type (
     :guided, :unguided or :counterfactual)
 """
 function _order_by_variance(

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -87,29 +87,17 @@ function ADRIA.viz.scenarios!(
 end
 
 function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)::Nothing
-    for type in _order_by_variance(data, scenario_type(rs))
+    x_timesteps::UnitRange{Int64} = 1:size(data, 1)
+    for (idx, type) in enumerate(_order_by_variance(data, scenario_type(rs)))
         selected_scenarios = scenario_type(rs)[type]
 
-        # Plot colors
         base_color = scenario_colors(rs)[selected_scenarios][1][1]
-        band_color = (base_color, 0.4)
-        bandline_color = (base_color, 0.6)
+        band_color = (base_color, max(0.7 - idx * 0.1, 0.4))
         line_color = (base_color, 1.0)
 
-        # TODO Extract to external function to be used by scenarios and clustered_scenarios
-        x_timesteps::UnitRange{Int64} = 1:size(data, 1)
-
-        type_data = data[:, selected_scenarios]
-        data_slices = Slices(type_data, NamedDims.dim(type_data, :scenarios))
-
-        y_lower = quantile.(data_slices, [0.025])
-        y_upper = quantile.(data_slices, [0.975])
+        y_lower, y_upper, y_median = confint(data[:, selected_scenarios], :scenarios)
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
-        lines!(ax, x_timesteps, y_lower; color=bandline_color)
-        lines!(ax, x_timesteps, y_upper; color=bandline_color)
-
-        y_median = median.(data_slices)
         scatterlines!(ax, y_median; color=line_color, markersize=5)
     end
 

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -27,6 +27,7 @@ ADRIA.viz.scenarios(rs, s_tac[:, scens.SRM .< 1.0])
 - `opts` : Aviz options
     - `by_RCP` : color by RCP otherwise color by scenario type. Defaults to false.
     - `legend` : show legend. Defaults to true.
+    - `summarize` : plot confidence interval. Defaults to true
 - `axis_opts` : Additional options to pass to adjust Axis attributes
   See: https://docs.makie.org/v0.19/api/index.html#Axis
 - `series_opts` : Additional options to pass to adjust Series attributes

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -71,7 +71,7 @@ function ADRIA.viz.scenarios!(
 
         legend_position = (1, 2)
     else
-        _plot_scenarios_series!(ax, data, series_opts)
+        _plot_scenarios_series!(ax, rs, data, series_opts)
         _plot_scenarios_hist(g, rs, data)
 
         legend_position = (1, 3)
@@ -104,8 +104,16 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
     return nothing
 end
 
-function _plot_scenarios_series!(ax::Axis, data::NamedDimsArray, series_opts::Dict)::Nothing
-    series!(ax, data'; series_opts...)
+function _plot_scenarios_series!(
+    ax::Axis, rs::ResultSet, data::NamedDimsArray, series_opts::Dict
+)::Nothing
+    series_colors = pop!(series_opts, :color)
+    for type in _order_by_variance(data, scenario_type(rs))
+        selected_scenarios = scenario_type(rs)[type]
+        _color = series_colors[selected_scenarios]
+
+        series!(ax, data[:, selected_scenarios]'; solid_color=_color, series_opts...)
+    end
     return nothing
 end
 

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -114,8 +114,9 @@ function _plot_scenarios_series!(
     ax::Axis, rs::ResultSet, data::NamedDimsArray, series_opts::Dict
 )::Nothing
     series_colors = pop!(series_opts, :color)
-    for type in _order_by_variance(data, scenario_type(rs))
-        selected_scenarios = scenario_type(rs)[type]
+    scenario_types = scenario_type(rs)
+    for type in _order_by_variance(data, scenario_types)
+        selected_scenarios = scenario_types[type]
         _color = series_colors[selected_scenarios]
 
         series!(ax, data[:, selected_scenarios]'; solid_color=_color, series_opts...)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -97,7 +97,7 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
         band_color = (base_color, band_alpha)
         line_color = (base_color, 1.0)
 
-        y_lower, y_upper, y_median = confint(data[:, selected_scenarios], :scenarios)
+        y_lower, y_median, y_upper = confint(data[:, selected_scenarios], :scenarios)
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
         scatterlines!(ax, y_median; color=line_color, markersize=5)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -97,7 +97,7 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
 
     confints = zeros(n_timesteps, length(scenario_types), 3)
     for (idx_s, scenario) in enumerate(selected_scenarios)
-        confints[:, idx_s, :] = reduce(hcat, confint(data[:, scenario], :scenarios))
+        confints[:, idx_s, :] = series_confint(data[:, scenario]; agg_dim=:scenarios)
     end
 
     for idx in eachindex(ordered_types)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -73,14 +73,11 @@ function ADRIA.viz.scenarios!(
         _plot_scenarios_series!(ax, rs, data, series_opts)
     end
 
-    if get(opts, :histogram, true)
-        _plot_scenarios_hist(g, rs, data)
-        legend_position = (1, 3)
-    else
-        legend_position = (1, 2)
-    end
+    # Plot Histograms when opts[:histogram] is true
+    get(opts, :histogram, true) && _plot_scenarios_hist(g, rs, data)
 
     # Render legend
+    legend_position = get(opts, :histogram, true) ? (1, 3) : (1, 2)
     _render_scenarios_legend(g, rs, legend_position, opts)
 
     ax.xlabel = "Year"

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -69,13 +69,15 @@ function ADRIA.viz.scenarios!(
 
     if get(opts, :summarize, true)
         _plot_scenarios_confint!(ax, rs, data)
-
-        legend_position = (1, 2)
     else
         _plot_scenarios_series!(ax, rs, data, series_opts)
-        _plot_scenarios_hist(g, rs, data)
+    end
 
+    if get(opts, :histogram, true)
+        _plot_scenarios_hist(g, rs, data)
         legend_position = (1, 3)
+    else
+        legend_position = (1, 2)
     end
 
     # Render legend

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -88,9 +88,10 @@ end
 
 function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)::Nothing
     x_timesteps::UnitRange{Int64} = 1:size(data, 1)
-    ordered_types = _order_by_variance(data, scenario_type(rs))
+    scenario_types = scenario_type(rs)
+    ordered_types = _order_by_variance(data, scenario_types)
 
-    selected_scenarios = [scenario_type(rs)[type] for type in ordered_types]
+    selected_scenarios = [scenario_types[type] for type in ordered_types]
     confints = [confint(data[:, scenario], :scenarios) for scenario in selected_scenarios]
     colors = [scenario_colors(rs)[scenario][1][1] for scenario in selected_scenarios]
 

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -219,7 +219,7 @@ function _render_scenarios_legend(
 end
 
 """
-    function _order_by_variance(data::NamedDimsArray, scenario_types::NamedTuple)::Tuple{Symbol,Symbol,Symbol}
+    _order_by_variance(data::NamedDimsArray, scenario_types::NamedTuple)::Tuple{Symbol,Symbol,Symbol}
 
 Sort types by variance in reverse order to plot highest variances first
 

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -225,7 +225,7 @@ Sort types by variance in reverse order to plot highest variances first
 
 # Arguments
 - `data` : Results of scenario metric
-- `scenario_types` : NamedTuple with BitVectors to filter scenarios of each type. One of:
+- `scenario_types` : NamedTuple of BitVectors to filter scenarios for each scenario type of:
     - :guided
     - :unguided
     - :counterfactual

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -104,9 +104,7 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
     for idx in eachindex(ordered_types)
         line_color = (colors[idx], 0.8)
         y_median = confints[idx][2]
-        scatterlines!(
-            ax, y_median; color=line_color, linewidth=3, markersize=20, marker=:xcross
-        )
+        lines!(ax, y_median; color=line_color, linewidth=4)
     end
 
     return nothing

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -81,10 +81,21 @@ function _calc_gridsize(n_factors::Int64; max_cols::Int64=4)::Tuple{Int64,Int64}
     return n_rows, n_cols
 end
 
-function confint(data::NamedDimsArray, dimension::Symbol)::Vector{Vector{Float64}}
-    data_slices = Slices(data, NamedDims.dim(data, dimension))
-    quantiles::Matrix{Float64} = quantile.(data_slices, [0.025 0.5 0.975])
-    return [collect(q) for q in eachcol(quantiles)]
+"""
+    series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
+
+Computes confidence interval for series of data
+
+# Arguments
+- `data` : Matrix with series of data
+- `agg_dim` : Dimension used to aggregate data if a NamedDimsArray is passed
+
+# Returns
+Confidence interval (lower bound, median and higher bound) for each series step
+"""
+function series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
+    slice_dim = data isa NamedDimsArray ? NamedDims.dim(data, agg_dim) : 2
+    return quantile.(Slices(data, slice_dim), [0.025 0.5 0.975])
 end
 
 include("scenarios.jl")

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -83,7 +83,7 @@ end
 
 function confint(data::NamedDimsArray, dimension::Symbol)::Vector{Vector{Float64}}
     data_slices = Slices(data, NamedDims.dim(data, dimension))
-    quantiles::Matrix{Float64} = quantile.(data_slices, [[0.025] [0.5] [0.975]])
+    quantiles::Matrix{Float64} = quantile.(data_slices, [0.025 0.5 0.975])
     return [collect(q) for q in eachcol(quantiles)]
 end
 

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -81,6 +81,18 @@ function _calc_gridsize(n_factors::Int64; max_cols::Int64=4)::Tuple{Int64,Int64}
     return n_rows, n_cols
 end
 
+function confint(
+    data::NamedDimsArray, dimension::Symbol
+)::Tuple{Vector{Float64},Vector{Float64},Vector{Float64}}
+    data_slices = Slices(data, NamedDims.dim(data, dimension))
+
+    y_lower = quantile.(data_slices, [0.025])
+    y_upper = quantile.(data_slices, [0.975])
+    y_median = median.(data_slices)
+
+    return y_lower, y_upper, y_median
+end
+
 include("scenarios.jl")
 include("sensitivity.jl")
 include("clustering.jl")

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -81,16 +81,10 @@ function _calc_gridsize(n_factors::Int64; max_cols::Int64=4)::Tuple{Int64,Int64}
     return n_rows, n_cols
 end
 
-function confint(
-    data::NamedDimsArray, dimension::Symbol
-)::Tuple{Vector{Float64},Vector{Float64},Vector{Float64}}
+function confint(data::NamedDimsArray, dimension::Symbol)::Vector{Vector{Float64}}
     data_slices = Slices(data, NamedDims.dim(data, dimension))
-
-    y_lower = quantile.(data_slices, [0.025])
-    y_upper = quantile.(data_slices, [0.975])
-    y_median = median.(data_slices)
-
-    return y_lower, y_upper, y_median
+    quantiles::Matrix{Float64} = quantile.(data_slices, [[0.025] [0.5] [0.975]])
+    return [collect(q) for q in eachcol(quantiles)]
 end
 
 include("scenarios.jl")

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -81,23 +81,6 @@ function _calc_gridsize(n_factors::Int64; max_cols::Int64=4)::Tuple{Int64,Int64}
     return n_rows, n_cols
 end
 
-"""
-    series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
-
-Computes confidence interval for series of data
-
-# Arguments
-- `data` : Matrix with series of data
-- `agg_dim` : Dimension used to aggregate data if a NamedDimsArray is passed
-
-# Returns
-Confidence interval (lower bound, median and higher bound) for each series step
-"""
-function series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
-    slice_dim = data isa NamedDimsArray ? NamedDims.dim(data, agg_dim) : 2
-    return quantile.(Slices(data, slice_dim), [0.025 0.5 0.975])
-end
-
 include("scenarios.jl")
 include("sensitivity.jl")
 include("clustering.jl")

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -1,10 +1,11 @@
 module analysis
 
-using Statistics, DataFrames
-using NamedDims, AxisKeys
 using ADRIA: ResultSet, n_locations
 using ADRIA.metrics: nds
 
+using JuliennedArrays: Slices
+using NamedDims, AxisKeys
+using Statistics, DataFrames
 
 """
     col_normalize(data::AbstractArray)::AbstractArray
@@ -80,6 +81,26 @@ function discretize_outcomes(y; S=20)
     return y_disc
 end
 
+"""
+    series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
+
+Computes confidence interval for series of data
+
+# Arguments
+- `data` : Matrix with series of data
+- `agg_dim` : Dimension used to aggregate data if a NamedDimsArray is passed
+
+# Returns
+Confidence interval (lower bound, median and higher bound) for each series step
+"""
+function series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
+    slice_dim = data isa NamedDimsArray ? NamedDims.dim(data, agg_dim) : 2
+    return quantile.(Slices(data, slice_dim), [0.025 0.5 0.975])
+end
+
+include("pareto.jl")
+include("sensitivity.jl")
+include("intervention.jl")
 include("clustering.jl")
 include("intervention.jl")
 include("pareto.jl")

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -98,9 +98,6 @@ function series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matri
     return quantile.(Slices(data, slice_dim), [0.025 0.5 0.975])
 end
 
-include("pareto.jl")
-include("sensitivity.jl")
-include("intervention.jl")
 include("clustering.jl")
 include("intervention.jl")
 include("pareto.jl")

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -84,7 +84,7 @@ end
 """
     series_confint(data::AbstractMatrix; agg_dim::Symbol=:scenarios)::Matrix{Float64}
 
-Computes confidence interval for series of data
+Computes confidence interval for series of data.
 
 # Arguments
 - `data` : Matrix with series of data


### PR DESCRIPTION
When it is `true`, `scenarios` plot the confidence intervals together with the median for each scenario type (guided, unguided and counterfactual). It defaults to `true`.

| :summarize = true | :summarize = false |
|-------------------|--------------------|
| ![tac_scenarios_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/30169704-4402-4305-93a6-b49bf8f33961) | ![tac_scenarios_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/ec8730a1-eb4f-41c6-a8e2-7dc784e524e1)|