### PR TITLE
Fix bug causing Domain loading with RCP to error

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -44,7 +44,7 @@ struct EnvironmentalLayer{P<:Param} <: EcoModel
     wave_scenario::P
 end
 
-function EnvironmentalLayer(dhw::AbstractArray{T}, wave::AbstractArray{T2})::EnvironmentalLayer where {T<:Union{Float32,Float64},T2<:Union{Float32,Float64}}
+function EnvironmentalLayer(dhw::AbstractArray{T}, wave::AbstractArray{T2})::EnvironmentalLayer where {T<:Union{Missing,Float32,Float64},T2<:Union{Missing,Float32,Float64}}
     return EnvironmentalLayer(
         Param(1, bounds=(1.0, Float64(size(dhw, 3)) + 1.0), ptype="integer", dists="unif", name="DHW Scenario", description="DHW scenario member identifier."),
         Param(1, bounds=(1.0, Float64(size(wave, 3)) + 1.0), ptype="integer", dists="unif", name="Wave Scenario", description="Wave scenario member identifier.")


### PR DESCRIPTION
Error occurs due to incorrect input type for EnvironmentalLayer. This PR adds Missing to possible input types in EnvironmentalLayer

Resolves issue #510 .