### PR TITLE
Add support series and map binary clusters plots

### DIFF
--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -181,7 +181,7 @@ end
 function cluster_labels(
     clusters::Vector{Int64}, data::AbstractVector{<:Real}
 )::Vector{String}
-    cluster_names::Vector{String} = ["Cluster $(cluster)" for cluster in clusters]
+    cluster_names::Vector{String} = "Cluster " .* string.(clusters)
     return cluster_labels(cluster_names, data)
 end
 function cluster_labels(clusters::BitVector, data::AbstractVector{<:Real})::Vector{String}

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -142,8 +142,8 @@ Get color alphas for each cluster weighted by number of scenarios.
 # Returns
 Vector with one color alpha for each cluster.
 """
-function cluster_alphas(clusters::Vector{Int64})::Vector{Float64}
-    alphas::Vector{Float64} = zeros(Float64, length(unique(clusters)))
+function cluster_alphas(clusters::Vector{Int64})::Dict{Int64,Float64}
+    alphas::Dict{Int64,Float64} = Dict()
 
     for (i, cluster) in enumerate((unique(clusters)))
         n_scens::Int64 = count(clusters .== cluster)
@@ -153,7 +153,7 @@ function cluster_alphas(clusters::Vector{Int64})::Vector{Float64}
 
     return alphas
 end
-function cluster_alphas(clusters::BitVector)::Vector{Float64}
+function cluster_alphas(clusters::BitVector)::Dict{Int64,RGBA{Float32}}
     return cluster_alphas(Int64.(clusters))
 end
 

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -82,4 +82,52 @@ function scenario_colors!(obs_color::Observable, color_map::Vector, scen_types::
 
     color_map[hide] .= ((:white, 0.0),)
     obs_color[] = color_map
+
+"""
+    cluster_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}
+
+Computes the colors for each clustered scenario
+
+# Arguments
+- `clusters` : Vector with scenario cluster numbers
+
+# Returns
+Vector with one color for each clustered scenario
+"""
+function cluster_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}
+    unique_clusters = unique(clusters)
+    unique_colors = categorical_colors(:seaborn_bright, length(unique_clusters))
+
+    colors_map::Dict{Int64,RGBA{Float32}} = Dict(
+        c => unique_colors[i] for (i, c) in enumerate(unique_clusters)
+    )
+
+    colors::Vector{RGBA{Float32}} = Vector{RGBA{Float32}}(undef, length(clusters))
+    for (idx_c, cluster) in enumerate(clusters)
+        colors[idx_c] = colors_map[cluster]
+    end
+    return colors
+end
+
+"""
+    cluster_alphas(clusters::Vector{Int64})::Vector{Float64}
+
+Vector of color alphas for each clusters weighted by number of scenarios
+
+# Arguments
+- `clusters` : Vector with scenario cluster numbers
+
+# Returns
+Vector with one color alpha for each cluster
+"""
+function cluster_alphas(clusters::Vector{Int64})::Vector{Float64}
+    alphas::Vector{Float64} = zeros(Float64, length(unique(clusters)))
+
+    for (i, cluster) in enumerate((unique(clusters)))
+        n_scens = count(clusters .== cluster)
+        base_alpha = 1.0 / (n_scens * 0.05)
+        alphas[i] = max(min(base_alpha, 0.6), 0.1)
+    end
+
+    return alphas
 end

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -84,8 +84,8 @@ function scenario_colors!(obs_color::Observable, color_map::Vector, scen_types::
     end
 
     color_map[hide] .= ((:white, 0.0),)
-    obs_color[] = color_map
-
+    return obs_color[] = color_map
+end
 """
     cluster_colors(clusters::Vector{Int64}, unique_colors::Vector{RGBA{Float32}})::Vector{RGBA{Float32}}
     cluster_colors(clusters::Vector{Int64})::Vector{RGBA{Float32}}

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -177,3 +177,15 @@ function cluster_labels(clusters::BitVector)::Vector{String}
     end
     return ["Non-target", "Target"]
 end
+function cluster_labels(
+    clusters::Vector{Int64}, data::AbstractVector{<:Real}
+)::Vector{String}
+    legend_labels = Vector{String}(undef, length(unique(clusters)))
+    for (idx, cluster) in enumerate(unique(clusters))
+        # TODO Extract to external function and accept as argument
+        cluster_agg = mean(data[cluster .== clusters])
+        cluster_agg_formatted = @sprintf "%.1e" cluster_agg
+        legend_labels[idx] = "Cluster $(cluster): $cluster_agg_formatted"
+    end
+    return legend_labels
+end

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -1,3 +1,5 @@
+using Printf: @sprintf
+
 const COLORS::Dict{Symbol,Symbol} = Dict(
     :RCP45 => :darkblue,
     :RCP60 => :seagreen,

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -153,7 +153,7 @@ function cluster_alphas(clusters::Vector{Int64})::Dict{Int64,Float64}
 
     return alphas
 end
-function cluster_alphas(clusters::BitVector)::Dict{Int64,RGBA{Float32}}
+function cluster_alphas(clusters::BitVector)::Dict{Int64,Float64}
     return cluster_alphas(Int64.(clusters))
 end
 

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -137,7 +137,7 @@ end
 Get color alphas for each cluster weighted by number of scenarios.
 
 # Arguments
-- `clusters` : Vector with scenario cluster numbers
+- `clusters` : Vector with scenario cluster ids
 
 # Returns
 Vector with one color alpha for each cluster.

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -65,7 +65,7 @@ function _plot_clusters_series!(
         series!(ax, data[:, clusters .== cluster]'; solid_color=(colors[idx], alphas[idx]))
     end
 
-    _render_clustered_scenarios_legend(g, cluster_labels(clusters), colors)
+    _render_clustered_scenarios_legend(g, cluster_labels(sorted_clusters), colors)
 
     return nothing
 end
@@ -105,7 +105,7 @@ function _plot_clusters_confint!(
 
     series!(ax, confints[:, :, 2]'; solid_color=colors)
 
-    _render_clustered_scenarios_legend(g, cluster_labels(clusters), colors)
+    _render_clustered_scenarios_legend(g, cluster_labels(sorted_clusters), colors)
     return nothing
 end
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -84,6 +84,8 @@ function _plot_clusters_confint!(
     end
 
     sorted_clusters = sort(clusters)
+    cluster_ids = unique(sorted_clusters)
+
     colors = unique(cluster_colors(sorted_clusters))
     alpha = get(opts, :alpha, 0.4)
 
@@ -92,14 +94,14 @@ function _plot_clusters_confint!(
     data_dims = dimnames(data)
     slice_dimension = data_dims[findfirst(data_dims .!= :timesteps)]
 
-    confints = zeros(n_timesteps, length(unique(sorted_clusters)), 3)
-    for (idx_c, cluster) in enumerate(unique(sorted_clusters))
+    confints = zeros(n_timesteps, length(cluster_ids), 3)
+    for (idx_c, cluster) in enumerate(cluster_ids)
         confints[:, idx_c, :] = ADRIA.analysis.series_confint(
             data[:, clusters .== cluster]; agg_dim=slice_dimension
         )
     end
 
-    for idx in eachindex(unique(sorted_clusters))
+    for idx in eachindex(cluster_ids)
         y_lower, y_upper = confints[:, idx, 1], confints[:, idx, 3]
         band!(ax, x_timesteps, y_lower, y_upper; color=(colors[idx], alpha))
     end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -139,7 +139,7 @@ Figure
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
     data::AbstractArray{<:Real},
-    clusters::Vector{Int64};
+    clusters::Union{BitVector,Vector{Int64}};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
@@ -154,7 +154,7 @@ function ADRIA.viz.map!(
     g::Union{GridLayout,GridPosition},
     rs::Union{Domain,ResultSet},
     data::AbstractVector{<:Real},
-    clusters::Vector{Int64};
+    clusters::Union{BitVector,Vector{Int64}};
     opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
 )::Union{GridLayout,GridPosition}
@@ -168,32 +168,25 @@ function ADRIA.viz.map!(
 
     return g
 end
-function ADRIA.viz.map!(
-    g::Union{GridLayout,GridPosition},
-    rs::Union{Domain,ResultSet},
-    data::AbstractVector{<:Real},
-    clusters::BitVector;
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
-)::Union{GridLayout,GridPosition}
-    return ADRIA.viz.map!(g, rs, data, clusters; opts=opts, axis_opts=axis_opts)
-end
 
 """
     _cluster_legend_params(clusters::Vector{Int64}, clusters_colors::Vector{RGBA{Float32}}, data_statistics::Vector{Float32})
 
-Color parameter for current cluster weighted by number of scenarios
+Color parameter for current cluster weighted by number of scenarios.
 
 # Arguments
 - `clusters` : Vector of numbers corresponding to clusters
-- `cluster_colors` : Vector of all cluster options that are being used
+- `colors` : Vector of all cluster options that are being used
 - `data` : Vector of some metric outcome for each site
 
 # Returns
-Tuple{RGBA{Float32}, Float64}
+Tuple of legend params to be passed to map! containing legend_entries, legend_labels and
+legend_title (in that order).
 """
 function _cluster_legend_params(
-    clusters::Vector{Int64}, colors::Vector, data::AbstractVector{<:Real}
+    clusters::Union{BitVector,Vector{Int64}},
+    colors::Vector{RGBA{Float32}},
+    data::AbstractVector{<:Real},
 )::Tuple
     legend_entries = [PolyElement(; color=c, strokecolor=:transparent) for c in colors]
     legend_labels = cluster_labels(clusters, data)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -85,6 +85,7 @@ function _plot_clusters_confint!(
 
     sorted_clusters = sort(clusters)
     colors = unique(cluster_colors(sorted_clusters))
+    alpha = get(opts, :alpha, 0.4)
 
     n_timesteps = length(timesteps(data))
     x_timesteps::UnitRange{Int64} = 1:n_timesteps
@@ -100,7 +101,7 @@ function _plot_clusters_confint!(
 
     for idx in eachindex(unique(sorted_clusters))
         y_lower, y_upper = confints[:, idx, 1], confints[:, idx, 3]
-        band!(ax, x_timesteps, y_lower, y_upper; color=(colors[idx], 0.5))
+        band!(ax, x_timesteps, y_lower, y_upper; color=(colors[idx], alpha))
     end
 
     series!(ax, confints[:, :, 2]'; solid_color=colors)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -59,14 +59,14 @@ function _plot_clusters_series!(
 )::Nothing
     unique_clusters = sort(unique(clusters))
     alphas = _get_alphas(clusters)
-    clusters_colors = unique(_get_colors(clusters, alphas))
+    colors = unique(_get_colors(clusters))
 
-    leg_entry::Vector{Any} = [
-        series!(ax, data[:, clusters .== cluster]'; solid_color=clusters_colors[idx_c]) for
-        (idx_c, cluster) in enumerate(unique_clusters)
-    ]
+    for (idx, cluster) in enumerate(unique_clusters)
+        series!(ax, data[:, clusters .== cluster]'; solid_color=(colors[idx], alphas[idx]))
+    end
 
-    Legend(g[1, 2], leg_entry, "Cluster " .* string.(unique_clusters); framevisible=false)
+    labels = "Cluster " .* string.(unique_clusters)
+    _render_clustered_scenarios_legend(g, colors, labels)
 
     return nothing
 end
@@ -105,12 +105,21 @@ function _plot_clusters_confint!(
         )
 
         band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
-        legend_entry[idx_c] = scatterlines!(ax, y_median; color=line_color, markersize=5)
+        scatterlines!(ax, y_median; color=line_color, markersize=5)
     end
 
-    Legend(
-        g[1, 2], legend_entry, "Cluster " .* string.(unique_clusters); framevisible=false
-    )
+    labels = "Cluster " .* string.(unique_clusters)
+    _render_clustered_scenarios_legend(g, line_colors, labels)
+
+    return nothing
+end
+
+function _render_clustered_scenarios_legend(
+    g::Union{GridLayout,GridPosition}, colors::Vector, labels::Vector{String}
+)::Nothing
+    line_elems = [LineElement(; color=c, linestyle=nothing) for c in colors]
+
+    Legend(g[1, 2], line_elems, labels; framevisible=false)
 
     return nothing
 end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -168,6 +168,16 @@ function ADRIA.viz.map!(
 
     return g
 end
+function ADRIA.viz.map!(
+    g::Union{GridLayout,GridPosition},
+    rs::Union{Domain,ResultSet},
+    data::AbstractVector{<:Real},
+    clusters::BitVector;
+    opts::Dict=Dict(),
+    axis_opts::Dict=Dict(),
+)::Union{GridLayout,GridPosition}
+    return ADRIA.viz.map!(g, rs, data, clusters; opts=opts, axis_opts=axis_opts)
+end
 
 """
     _cluster_legend_params(clusters::Vector{Int64}, clusters_colors::Vector{RGBA{Float32}}, data_statistics::Vector{Float32})
@@ -177,33 +187,17 @@ Color parameter for current cluster weighted by number of scenarios
 # Arguments
 - `clusters` : Vector of numbers corresponding to clusters
 - `cluster_colors` : Vector of all cluster options that are being used
-- `data_statistics` : Vector of statistics for each site (default is mean)
+- `data` : Vector of some metric outcome for each site
 
 # Returns
 Tuple{RGBA{Float32}, Float64}
 """
 function _cluster_legend_params(
-    clusters::Vector{Int64}, clusters_colors::Vector, data::AbstractArray
+    clusters::Vector{Int64}, colors::Vector, data::AbstractVector{<:Real}
 )::Tuple
-    # Filter non-zero clusters from clusters, colors and data
-    non_zero_clusters = clusters .!= 0
-    clusters_filtered = clusters[non_zero_clusters]
-    statistics_filtered = data[non_zero_clusters]
-
-    # Fill legend entries colors
-    legend_entries = [
-        PolyElement(; color=color, strokecolor=:transparent) for color in clusters_colors
-    ]
-
-    # Fill legend labels
-    legend_labels = String[]
-    clusters_numbers = unique(clusters_filtered)
-    for cluster in clusters_numbers
-        stat_mean = mean(statistics_filtered[cluster .== clusters_filtered])
-        stat_mean_formatted = @sprintf "%.1e" stat_mean
-        push!(legend_labels, "Cluster $(cluster): $stat_mean_formatted")
-    end
-
+    legend_entries = [PolyElement(; color=c, strokecolor=:transparent) for c in colors]
+    legend_labels = cluster_labels(clusters, data)
     legend_title = "Clusters mean value"
+
     return (legend_entries, legend_labels, legend_title)
 end


### PR DESCRIPTION
These were partially supported before, but this implements a few improvements like:

- Allow passing a BitVector of clusters
- Move some common functions to theme.jl
- When plotting a BitVector cluster, use "Target" and "Non-Target" as legend labels

Close #494 