### PR TITLE
Fix scenarios subsetting now working

### DIFF
--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -192,3 +192,12 @@ function cluster_labels(
     end
     return legend_labels
 end
+
+function alphas(scenario_types::Dict{Symbol,BitVector})::Dict{Symbol,Float64}
+    return Dict(k => alpha(v) for (k, v) in scenario_types)
+end
+
+function alpha(scenario_types::BitVector)::Float64
+    base_alpha = (1 - count(scenario_types) / length(scenario_types))
+    return max(min(base_alpha, 0.3), 0.1)
+end

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -23,21 +23,11 @@ function scenario_type(rs::ResultSet; scenarios=(:))
         unguided=ADRIA.analysis.unguided(rs_input)[scenarios],
         guided=ADRIA.analysis.guided(rs_input)[scenarios],
     )
-end
-
-function scenario_colors(rs::ResultSet, weight::Float64)
-    scen_type = scenario_type(rs)
-    counterfactual = scen_type.counterfactual
-    unguided = scen_type.unguided
-
-    color_map = fill((COLORS[:guided], weight), size(rs.inputs, 1))
-    color_map[counterfactual] .= ((COLORS[:counterfactual], weight),)
-    color_map[unguided] .= ((COLORS[:unguided], weight),)
-
-    return color_map
+function scenario_colors(rs::ResultSet, weight::Float64)::Vector{Tuple{Symbol,Float64}}
+    return [(c, weight) for c in scenario_colors(rs)]
 end
 function scenario_colors(rs::ResultSet, weight::Float64, hide::BitVector)
-    color_map = scenario_colors(rs, weight)
+    color_map::Vector{Tuple{Symbol,Float64}} = scenario_colors(rs, weight)
 
     if length(hide) > 0
         color_map[hide] .= ((:white, 0.0),)
@@ -45,8 +35,18 @@ function scenario_colors(rs::ResultSet, weight::Float64, hide::BitVector)
 
     return color_map
 end
-function scenario_colors(rs::ResultSet)
-    return scenario_colors(rs, 0.1)
+function scenario_colors(rs::ResultSet)::Vector{Symbol}
+    return scenario_colors(rs.inputs)
+end
+function scenario_colors(rs_inputs::DataFrame)::Vector{Symbol}
+    scen_types::Dict{Symbol,BitVector} = ADRIA.analysis.scenario_types(rs_inputs)
+    colors = Vector{Symbol}(undef, size(rs_inputs, 1))
+
+    for (key, value) in scen_types
+        colors[value] .= COLORS[key]
+    end
+
+    return colors
 end
 
 """

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -13,23 +13,16 @@ const COLORS::Dict{Symbol,Symbol} = Dict(
 )
 
 const BINARY_LABELS::Dict{Bool,String} = Dict(0 => "Non-Target", 1 => "Target")
+function scenario_type(rs::ResultSet; scenarios=(:))
+    counterfactual = ADRIA.analysis.counterfactual(rs)
+    unguided = ADRIA.analysis.unguided(rs)
+    guided = ADRIA.analysis.guided(rs)
 
-function scenario_type(rs; scenarios=(:))
-    inputs = rs.inputs
-
-    no_seed = (inputs.N_seed_TA .== 0) .& (inputs.N_seed_CA .== 0) .& (inputs.N_seed_SM .== 0)
-    no_fog = inputs.fogging .== 0
-    no_SRM = inputs.SRM .== 0
-    counterfactual = no_seed .& no_fog .& no_SRM
-
-    has_seed = (inputs.N_seed_TA .> 0) .| (inputs.N_seed_CA .> 0) .| (inputs.N_seed_SM .> 0)
-    has_shade = (inputs.fogging .> 0) .| (inputs.SRM .> 0)
-    unguided = (inputs.guided .== 0) .& (has_seed .| has_shade)
-
-    # Guided scenarios must be the inverse of unguided/counterfactual scenarios
-    guided = Bool.(ones(Int64, size(inputs, 1)) .⊻ (counterfactual .| unguided))
-
-    return (counterfactual=counterfactual[scenarios], unguided=unguided[scenarios], guided=guided[scenarios])
+    return (
+        counterfactual=counterfactual[scenarios],
+        unguided=unguided[scenarios],
+        guided=guided[scenarios],
+    )
 end
 
 function scenario_colors(rs, weight::Float64, hide::BitVector)

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -72,7 +72,7 @@ function scenario_colors!(
         display_weight = t.active[] ? weight : 0.05
 
         scen_t = getfield(scen_types, Symbol(lowercase(l)))
-        color_map[scen_t.&.!hide] .= ((display_color, display_weight),)
+        color_map[scen_t .& .!hide] .= ((display_color, display_weight),)
     end
 
     color_map[hide] .= ((:white, 0.0),)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -44,7 +44,7 @@ function ADRIA.viz.scenarios!(
     ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
 
     scen_groups = ADRIA.analysis.scenario_clusters(clusters)
-    opts::Dict{Symbol,Any} = Dict(:histogram => false)
+    opts[:histogram] = false
     return ADRIA.viz.scenarios!(
         g,
         ax,

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -26,9 +26,7 @@ function ADRIA.viz.scenarios(
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
-    ADRIA.viz.scenarios!(
-        g, outcomes, clusters; opts=opts, axis_opts=axis_opts, series_opts=series_opts
-    )
+    ADRIA.viz.scenarios!(g, outcomes, clusters; opts=opts, axis_opts=axis_opts)
 
     return f
 end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,6 +1,21 @@
 using JuliennedArrays: Slices
 using Statistics
 
+"""
+    scenarios(outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    scenarios!(g::Union{GridLayout,GridPosition}, outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), axis_opts::Dict=Dict())
+
+Visualize clustered time series of scenarios.
+
+# Arguments
+- `outcomes` : Matrix of outcomes for several scenarios or sites
+- `clusters` : Vector of numbers corresponding to clusters
+- `opts` : Aviz options
+    - `summarize` : plot confidence interval. Defaults to true
+
+# Returns
+Figure
+"""
 function ADRIA.viz.scenarios(
     outcomes::NamedDimsArray,
     clusters::Union{BitVector,Vector{Int64}};
@@ -65,12 +80,9 @@ function ADRIA.viz.clustered_scenarios(
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
 )::Figure
-    f = Figure(; fig_opts...)
-    g = f[1, 1] = GridLayout()
-
-    ADRIA.viz.scenarios!(g, outcomes, clusters; axis_opts=axis_opts, opts=opts)
-
-    return f
+    return ADRIA.viz.scenarios(
+        outcomes, clusters; opts=opts, fig_opts=fig_opts, axis_opts=axis_opts
+    )
 end
 function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -93,6 +93,25 @@ function ADRIA.viz.scenarios!(
         ADRIA.analysis.scenario_types(_rs_inputs)
     end
 
+    return ADRIA.viz.scenarios!(
+        g,
+        ax,
+        outcomes,
+        scen_groups;
+        opts=opts,
+        axis_opts::Dict=Dict(),
+        series_opts=series_opts,
+    )
+end
+function ADRIA.viz.scenarios!(
+    g::Union{GridLayout,GridPosition},
+    ax::Axis,
+    outcomes::NamedDimsArray,
+    scen_groups::Dict{Symbol,BitVector};
+    opts::Dict=Dict(),
+    axis_opts::Dict=Dict(),
+    series_opts::Dict=Dict(),
+)::Union{GridLayout,GridPosition}
     if get(opts, :summarize, true)
         scenarios_confint!(ax, outcomes, scen_groups)
     else

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -99,7 +99,7 @@ function ADRIA.viz.scenarios!(
         outcomes,
         scen_groups;
         opts=opts,
-        axis_opts::Dict=Dict(),
+        axis_opts=axis_opts,
         series_opts=series_opts,
     )
 end

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -241,6 +241,6 @@ function _sort_keys(
             scen_types; by=type -> size(outcomes[:, scenario_types[type]], 2), rev=true
         )
     else
-        throw(ArgumentError("Invalid value of 'by' kwarg"))
+        throw(ArgumentError("Invalid 'by' option. Must be one of: [:variance, :size]"))
     end
 end

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -1,8 +1,10 @@
 using JuliennedArrays: Slices
+using ADRIA.analysis: series_confint
 
 """
-    ADRIA.viz.scenarios(rs::ADRIA.ResultSet, y::NamedDimsArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
-    ADRIA.viz.scenarios!(g::Union{GridLayout,GridPosition}, rs::ADRIA.ResultSet, y::NamedDimsArray; opts=Dict(by_RCP => false), axis_opts=Dict(), series_opts=Dict())
+    ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::NamedDimsArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
+    ADRIA.viz.scenarios(rs_inputs::DataFrame, outcomes::NamedDimsArray; opts::Dict=Dict(:by_RCP => false), fig_opts::Dict=Dict(), axis_opts::Dict=Dict(), series_opts::Dict=Dict())::Figure
+    ADRIA.viz.scenarios!(g::Union{GridLayout,GridPosition}, rs_inputs::DataFrame, outcomes::NamedDimsArray; opts=Dict(by_RCP => false), axis_opts=Dict(), series_opts=Dict())
 
 Plot scenario outcomes over time.
 
@@ -15,15 +17,15 @@ scens = ADRIA.sample(dom, 64)
 s_tac = ADRIA.metrics.scenario_total_cover(rs)
 
 # Plot scenario outcomes
-ADRIA.viz.scenarios(rs, s_tac)
+ADRIA.viz.scenarios(rs.inputs, s_tac)
 
 # Plot outcomes of scenarios where SRM < 1.0
-ADRIA.viz.scenarios(rs, s_tac[:, scens.SRM .< 1.0])
+ADRIA.viz.scenarios(rs.inputs, s_tac[:, scens.SRM .< 1.0])
 ```
 
 # Arguments
-- `rs` : ResultSet
-- `data` : results of scenario metric
+- `rs_input` : DataFrame with ResultSet inputs
+- `outcomes` : Results of scenario metric
 - `opts` : Aviz options
     - `by_RCP` : color by RCP otherwise color by scenario type. Defaults to false.
     - `legend` : show legend. Defaults to true.
@@ -34,11 +36,28 @@ ADRIA.viz.scenarios(rs, s_tac[:, scens.SRM .< 1.0])
   See: https://docs.makie.org/v0.19/api/index.html#series!
 
 # Returns
-GridPosition
+Figure or GridPosition
 """
 function ADRIA.viz.scenarios(
     rs::ResultSet,
-    data::NamedDimsArray;
+    outcomes::NamedDimsArray;
+    opts::Dict=Dict(:by_RCP => false),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict(),
+    series_opts::Dict=Dict(),
+)::Figure
+    return ADRIA.viz.scenarios(
+        rs.inputs,
+        outcomes;
+        opts=opts,
+        fig_opts=fig_opts,
+        axis_opts=axis_opts,
+        series_opts=series_opts,
+    )
+end
+function ADRIA.viz.scenarios(
+    rs_inputs::DataFrame,
+    outcomes::NamedDimsArray;
     opts::Dict=Dict(:by_RCP => false),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
@@ -46,44 +65,44 @@ function ADRIA.viz.scenarios(
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
-    ADRIA.viz.scenarios!(g, rs, data; opts, axis_opts, series_opts)
+    ADRIA.viz.scenarios!(
+        g, rs_inputs, outcomes; opts=opts, axis_opts=axis_opts, series_opts=series_opts
+    )
 
     return f
 end
 function ADRIA.viz.scenarios!(
     g::Union{GridLayout,GridPosition},
-    rs::ResultSet,
-    data::NamedDimsArray;
+    rs_inputs::DataFrame,
+    outcomes::NamedDimsArray;
     opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
     series_opts::Dict=Dict(),
 )::Union{GridLayout,GridPosition}
     # Ensure last year is always shown in x-axis
-    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(data)))
+    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
-
     ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
 
-    rs_inputs = copy(rs.inputs)
-    keepat!(rs_inputs, data.scenarios)
-
-    # Set series colors
-    by_rcp = get(opts, :by_RCP, false)
-    colors = by_rcp ? _RCP_colors(rs_inputs, data) : _type_colors(rs_inputs)
-    merge!(series_opts, colors)
-
-    if get(opts, :summarize, true)
-        _plot_scenarios_confint!(ax, rs_inputs, data)
+    _rs_inputs = copy(rs_inputs[1:end .== outcomes.scenarios, :])
+    scen_groups = if get(opts, :by_RCP, false)
+        ADRIA.analysis.scenario_rcps(_rs_inputs)
     else
-        _plot_scenarios_series!(ax, rs_inputs, data, series_opts)
+        ADRIA.analysis.scenario_types(_rs_inputs)
     end
 
-    # Plot Histograms when opts[:histogram] is true
-    get(opts, :histogram, true) ? _plot_scenarios_hist(g, rs, data) : nothing
+    if get(opts, :summarize, true)
+        _plot_scenarios_confint!(ax, outcomes, scen_groups)
+    else
+        _plot_scenarios_series!(ax, outcomes, scen_groups, series_opts)
+    end
 
-    # Render legend
-    legend_position = get(opts, :histogram, true) ? (1, 3) : (1, 2)
-    _render_scenarios_legend(g, rs, legend_position, opts)
+    get(opts, :histogram, true) ? _plot_scenarios_hist(g, outcomes, scen_groups) : nothing
+
+    if get(opts, :legend, true)
+        legend_position = get(opts, :histogram, true) ? (1, 3) : (1, 2)
+        _render_legend(g, scen_groups, legend_position)
+    end
 
     ax.xlabel = "Year"
     # ax.ylabel = metric_label(metric)
@@ -92,73 +111,63 @@ function ADRIA.viz.scenarios!(
 end
 
 function _plot_scenarios_confint!(
-    ax::Axis, rs_inputs::DataFrame, data::NamedDimsArray
+    ax::Axis, outcomes::NamedDimsArray, scen_groups::Dict{Symbol,BitVector}
 )::Nothing
-    n_timesteps = size(data, 1)
-    x_timesteps::UnitRange{Int64} = 1:n_timesteps
-    scenario_types = ADRIA.analysis.scenario_types(rs_inputs)
-    ordered_types = _sort(scenario_types, data)
+    ordered_groups::Vector{Symbol} = _sort_keys(scen_groups, outcomes)
+    n_timesteps::Int64 = size(outcomes, 1)
+    n_scens::Int64 = length(ordered_groups)
 
-    selected_scenarios = [scenario_types[type] for type in ordered_types]
-    colors = [COLORS[scenario] for scenario in keys(scenario_types)]
-
-    confints = zeros(n_timesteps, length(scenario_types), 3)
-    for (idx_s, scenario) in enumerate(selected_scenarios)
-        confints[:, idx_s, :] = ADRIA.analysis.series_confint(
-            data[:, scenario]; agg_dim=:scenarios
-        )
+    # Compute confints
+    confints::Array{Float64} = zeros(n_timesteps, n_scens, 3)
+    for (idx, group) in enumerate(ordered_groups)
+        confints[:, idx, :] = series_confint(outcomes[:, scen_groups[group]])
     end
 
-    for idx in eachindex(ordered_types)
-        band_alpha = max(0.7 - idx * 0.1, 0.4)
-        band_color = (colors[idx], band_alpha)
+    _colors::Dict{Symbol,Symbol} = colors(scen_groups)
+
+    for idx in eachindex(ordered_groups)
+        band_color = (_colors[ordered_groups[idx]], 0.4)
         y_lower, y_upper = confints[:, idx, 1], confints[:, idx, 3]
-        band!(ax, x_timesteps, y_lower, y_upper; color=band_color)
+        band!(ax, 1:n_timesteps, y_lower, y_upper; color=band_color)
     end
 
-    series!(ax, confints[:, :, 2]'; solid_color=colors)
+    series_colors = [_colors[group] for group in keys(scen_groups)]
+    series!(ax, confints[:, :, 2]'; solid_color=series_colors)
 
     return nothing
 end
 
 function _plot_scenarios_series!(
-    ax::Axis, rs_inputs::DataFrame, data::NamedDimsArray, series_opts::Dict
+    ax::Axis,
+    outcomes::NamedDimsArray,
+    scen_groups::Dict{Symbol,BitVector},
+    series_opts::Dict,
 )::Nothing
-    scenario_types = ADRIA.analysis.scenario_types(rs_inputs)
+    _colors = colors(scen_groups)
+    _alphas = alphas(scen_groups)
 
-    colors = pop!(series_opts, :color)
-    _alphas = alphas(scenario_types)
-
-    for type in _sort(scenario_types, data)
-        selected_scenarios = scenario_types[type]
-        color = (colors[selected_scenarios][1], _alphas[type])
-
-        series!(ax, data[:, selected_scenarios]'; solid_color=color, series_opts...)
+    for group in _sort_keys(scen_groups, outcomes)
+        color = (_colors[group], _alphas[group])
+        scens = outcomes[:, scen_groups[group]]'
+        series!(ax, scens; solid_color=color, series_opts...)
     end
+
     return nothing
 end
 
 function _plot_scenarios_hist(
-    g::Union{GridLayout,GridPosition}, rs::ResultSet, data::NamedDimsArray
+    g::Union{GridLayout,GridPosition},
+    outcomes::NamedDimsArray,
+    scen_groups::Dict{<:Any,BitVector},
 )::Nothing
-    scen_match = 1:nrow(rs.inputs) .∈ [_dimkeys(data).scenarios]
-    scen_types = ADRIA.analysis.scenario_types(rs; scenarios=scen_match)
-    scen_dist = dropdims(mean(data; dims=:timesteps); dims=:timesteps)
-
-    hist_color_weights = (counterfactual=0.8, unguided=0.7, guided=0.6)
-
+    scen_dist = dropdims(mean(outcomes; dims=:timesteps); dims=:timesteps)
     ax_hist = Axis(g[1, 2]; width=100)
-    for type in keys(scen_types)
-        if !isempty(scen_types[type])
-            hist!(
-                ax_hist,
-                scen_dist[scen_types[type]];
-                direction=:x,
-                color=(COLORS[type], hist_color_weights[type]),
-                bins=30,
-                normalization=:pdf,
-            )
-        end
+    _colors = colors(scen_groups)
+
+    for group in _sort_keys(scen_groups, outcomes)
+        color = (_colors[group], 0.7)
+        dist = scen_dist[scen_groups[group]]
+        hist!(ax_hist, dist; direction=:x, color=color, bins=30, normalization=:pdf)
     end
 
     hidedecorations!(ax_hist)
@@ -172,59 +181,33 @@ function _plot_scenarios_hist(
     return nothing
 end
 
-# TODO Move these two to theme.jl
-function _RCP_colors(rs_input::DataFrame, data::NamedDimsArray)
-    rcp::Vector{Symbol} = Symbol.(:RCP, Int64.(rs_input[:, :RCP]))
-    return Dict(:color => map(x -> (COLORS[x], _color_weight(data)), rcp))
-end
-
-function _type_colors(rs_input::DataFrame)
-    return Dict(:color => scenario_colors(rs_input))
-end
-
-function _render_scenarios_legend(
+function _render_legend(
     g::Union{GridLayout,GridPosition},
-    rs::ResultSet,
+    scen_groups::Dict{<:Any,BitVector},
     legend_position::Tuple{Int64,Int64},
-    opts::Dict,
 )::Nothing
-    labels::Vector{String} = Vector{String}(undef, 0)
-    line_elements::Vector{LineElement} = Vector{LineElement}(undef, 0)
+    _colors = colors(scen_groups)
+    line_els::Vector{LineElement} = [
+        LineElement(; color=_colors[group]) for group in keys(scen_groups)
+    ]
+    labels::Vector{String} = string.(keys(scen_groups))
 
-    if get(opts, :by_RCP, false)
-        rcp::Vector{Symbol} = sort((unique(Symbol.(:RCP, Int64.(rs.inputs[:, :RCP])))))
-
-        rcp_colors = [COLORS[r] for r in rcp]
-        line_elements = [LineElement(; color=c, linestyle=nothing) for c in rcp_colors]
-        labels = String.(rcp)
-    else
-        cf::LineElement = LineElement(; color=COLORS[:counterfactual], linestyle=nothing)
-        ug::LineElement = LineElement(; color=COLORS[:unguided], linestyle=nothing)
-        gu::LineElement = LineElement(; color=COLORS[:guided], linestyle=nothing)
-
-        line_elements = [cf, ug, gu]
-        labels = ["No Intervention", "Unguided", "Guided"]
-    end
-
-    # Add legend
-    if get(opts, :legend, true)
-        Legend(
-            g[legend_position...],
-            line_elements,
-            labels;
-            halign=:left,
-            valign=:top,
-            margin=(5, 5, 5, 5),
-        )
-    end
+    Legend(
+        g[legend_position...],
+        line_els,
+        labels;
+        halign=:left,
+        valign=:top,
+        margin=(5, 5, 5, 5),
+    )
 
     return nothing
 end
 
 """
-    _sort(scenario_types::Dict{Symbol, BitVector}, data::NamedDimsArray)::Vector{Symbol}
+    _sort_keys(scenario_types::Dict{Symbol, BitVector}, data::NamedDimsArray)::Vector{Symbol}
 
-Sort types by variance in reverse order to plot highest variances first
+Sort types by variance in reverse order.
 
 # Arguments
 - `data` : Results of scenario metric
@@ -233,7 +216,9 @@ Sort types by variance in reverse order to plot highest variances first
     - :unguided
     - :counterfactual
 """
-function _sort(scenario_types::Dict{Symbol,BitVector}, data::NamedDimsArray)::Vector{Symbol}
+function _sort_keys(
+    scenario_types::Dict{Symbol,BitVector}, data::NamedDimsArray
+)::Vector{Symbol}
     scen_types::Vector{Symbol} = collect(keys(scenario_types))
     return sort(
         scen_types; by=type -> sum(var(data[:, scenario_types[type]]; dims=2)), rev=true

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -93,7 +93,7 @@ function _plot_scenarios_confint!(ax::Axis, rs::ResultSet, data::NamedDimsArray)
     ordered_types = _order_by_variance(data, scenario_types)
 
     selected_scenarios = [scenario_types[type] for type in ordered_types]
-    colors = [scenario_colors(rs)[scenario][1][1] for scenario in selected_scenarios]
+    colors = [COLORS[scenario] for scenario in keys(scenario_types)]
 
     confints = zeros(n_timesteps, length(scenario_types), 3)
     for (idx_s, scenario) in enumerate(selected_scenarios)

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -1,8 +1,6 @@
 using JuliennedArrays: Slices
 using ADRIA.analysis: series_confint
 
-include("../../../src/utils/text_display.jl")
-
 """
     ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::NamedDimsArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
     ADRIA.viz.scenarios(rs_inputs::DataFrame, outcomes::NamedDimsArray; opts::Dict=Dict(:by_RCP => false), fig_opts::Dict=Dict(), axis_opts::Dict=Dict(), series_opts::Dict=Dict())::Figure

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -2,7 +2,7 @@ using GLMakie, DataFrames
 
 using ADRIA: ResultSet, metrics.metric_label, analysis.col_normalize, model_spec
 using NamedDims, AxisKeys
-using .AvizExt: scenario_type, scenario_colors, COLORS
+using .AvizExt
 using GLMakie.Colors
 
 """

--- a/src/analysis/analysis.jl
+++ b/src/analysis/analysis.jl
@@ -102,6 +102,7 @@ include("clustering.jl")
 include("intervention.jl")
 include("pareto.jl")
 include("rule_extraction.jl")
+include("scenario.jl")
 include("sensitivity.jl")
 
 end

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,12 +1,31 @@
-SCEN_TYPES = [:counterfactual, :unguided, :guided]
+SCENARIO_TYPES = [:counterfactual, :unguided, :guided]
 
-function scenario_types(rs::ResultSet; scenarios=(:))::Dict{Symbol,BitVector}
+"""
+# Example
+```
+# It returns something like:
+Dict(:RCP40 => [1,1,0], :)
+```
+"""
+function scenario_rcps(
+    rs_inputs::DataFrame; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
+)::Dict{Symbol,BitVector}
+    rs_rcps::Vector{Symbol} = Symbol.(:RCP, Int64.(rs_inputs[scenarios, :RCP]))
+    unique_rcps = unique(rs_rcps)
+    return Dict(rcp => rs_rcps .== rcp for rcp in unique_rcps)
+end
+
+function scenario_types(
+    rs::ResultSet; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
+)::Dict{Symbol,BitVector}
     return scenario_types(rs.inputs; scenarios=scenarios)
 end
-function scenario_types(rs_input::DataFrame; scenarios=(:))::Dict{Symbol,BitVector}
+function scenario_types(
+    rs_inputs::DataFrame; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
+)::Dict{Symbol,BitVector}
     return Dict(
-        type => eval(type)(rs_input)[scenarios] for
-        type in SCEN_TYPES if sum(eval(type)(rs_input)[scenarios]) != 0
+        type => eval(type)(rs_inputs[scenarios, :]) for
+        type in SCENARIO_TYPES if count(eval(type)(rs_inputs[scenarios, :])) != 0
     )
 end
 

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,4 +1,4 @@
-SCENARIO_TYPES = [:counterfactual, :unguided, :guided]
+const SCENARIO_TYPES = [:counterfactual, :unguided, :guided]
 
 function scenario_clusters(clusters::BitVector)::Dict{Symbol,BitVector}
     return Dict(:target => clusters, :non_target => .!clusters)

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,3 +1,15 @@
+SCEN_TYPES = [:counterfactual, :unguided, :guided]
+
+function scenario_types(rs::ResultSet; scenarios=(:))::Dict{Symbol,BitVector}
+    return scenario_types(rs.inputs; scenarios=scenarios)
+end
+function scenario_types(rs_input::DataFrame; scenarios=(:))::Dict{Symbol,BitVector}
+    return Dict(
+        type => eval(type)(rs_input)[scenarios] for
+        type in SCEN_TYPES if sum(eval(type)(rs_input)[scenarios]) != 0
+    )
+end
+
 function counterfactual(rs_inputs::DataFrame)::BitVector
     no_seed = _no_seed(rs_inputs)
     no_fog = rs_inputs.fogging .== 0

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,20 +1,22 @@
-function counterfactual(rs::ResultSet)::BitVector
-    inputs = rs.inputs
-    no_seed =
-        (inputs.N_seed_TA .== 0) .& (inputs.N_seed_CA .== 0) .& (inputs.N_seed_SM .== 0)
-    no_fog = inputs.fogging .== 0
-    no_SRM = inputs.SRM .== 0
+function counterfactual(rs_inputs::DataFrame)::BitVector
+    no_seed = _no_seed(rs_inputs)
+    no_fog = rs_inputs.fogging .== 0
+    no_SRM = rs_inputs.SRM .== 0
     return no_seed .& no_fog .& no_SRM
 end
 
-function unguided(rs::ResultSet)::BitVector
-    inputs = rs.inputs
-    has_seed = (inputs.N_seed_TA .> 0) .| (inputs.N_seed_CA .> 0) .| (inputs.N_seed_SM .> 0)
-    has_shade = (inputs.fogging .> 0) .| (inputs.SRM .> 0)
-    return (inputs.guided .== 0) .& (has_seed .| has_shade)
+function unguided(rs_inputs::DataFrame)::BitVector
+    has_seed = .!_no_seed(rs_inputs)
+    has_shade = (rs_inputs.fogging .> 0) .| (rs_inputs.SRM .> 0)
+    return (rs_inputs.guided .== 0) .& (has_seed .| has_shade)
 end
 
-function guided(rs::ResultSet)::BitVector
-    inputs = rs.inputs
-    return Bool.(ones(Int64, size(inputs, 1)) .⊻ (counterfactual(rs) .| unguided(rs)))
+function guided(rs_inputs::DataFrame)::BitVector
+    return .!(counterfactual(rs_inputs) .| unguided(rs_inputs))
+end
+
+function _no_seed(rs_inputs::DataFrame)::BitVector
+    return (rs_inputs.N_seed_TA .== 0) .&
+           (rs_inputs.N_seed_CA .== 0) .&
+           (rs_inputs.N_seed_SM .== 0)
 end

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,12 +1,14 @@
 SCENARIO_TYPES = [:counterfactual, :unguided, :guided]
 
-"""
-# Example
-```
-# It returns something like:
-Dict(:RCP40 => [1,1,0], :)
-```
-"""
+function scenario_clusters(clusters::BitVector)::Dict{Symbol,BitVector}
+    return Dict(:target => clusters, :non_target => .!clusters)
+end
+function scenario_clusters(clusters::Vector{Int64})::Dict{Symbol,BitVector}
+    return Dict(
+        Symbol("Cluster_$(cluster)") => clusters .== cluster for cluster in unique(clusters)
+    )
+end
+
 function scenario_rcps(
     rs_inputs::DataFrame; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
 )::Dict{Symbol,BitVector}
@@ -15,11 +17,6 @@ function scenario_rcps(
     return Dict(rcp => rs_rcps .== rcp for rcp in unique_rcps)
 end
 
-function scenario_types(
-    rs::ResultSet; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
-)::Dict{Symbol,BitVector}
-    return scenario_types(rs.inputs; scenarios=scenarios)
-end
 function scenario_types(
     rs_inputs::DataFrame; scenarios::Union{UnitRange,Colon,Vector{Int64},BitVector}=(:)
 )::Dict{Symbol,BitVector}

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -1,0 +1,20 @@
+function counterfactual(rs::ResultSet)::BitVector
+    inputs = rs.inputs
+    no_seed =
+        (inputs.N_seed_TA .== 0) .& (inputs.N_seed_CA .== 0) .& (inputs.N_seed_SM .== 0)
+    no_fog = inputs.fogging .== 0
+    no_SRM = inputs.SRM .== 0
+    return no_seed .& no_fog .& no_SRM
+end
+
+function unguided(rs::ResultSet)::BitVector
+    inputs = rs.inputs
+    has_seed = (inputs.N_seed_TA .> 0) .| (inputs.N_seed_CA .> 0) .| (inputs.N_seed_SM .> 0)
+    has_shade = (inputs.fogging .> 0) .| (inputs.SRM .> 0)
+    return (inputs.guided .== 0) .& (has_seed .| has_shade)
+end
+
+function guided(rs::ResultSet)::BitVector
+    inputs = rs.inputs
+    return Bool.(ones(Int64, size(inputs, 1)) .⊻ (counterfactual(rs) .| unguided(rs)))
+end


### PR DESCRIPTION
As in title.

Because this issue involved changing viz.scenarios code, that had a lot code duplicated from viz.clustered_scenarios, also refactored both to re-use the same functions.

Following are some plotting results: 

- scenario_total_cover

| scenario_total_cover :summarized = true | scenario_total_cover :summarized = false|
|--|--|
|![scenarios__summarize_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/52c37ad5-fea7-469c-89cc-f6607a590c35)|![scenarios__summarize_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/8face8b0-1930-4b98-b94f-06c07da65185)|

- scenario_total_cover with the filter `target_scens = (rs.inputs.guided .== 0) .& (rs.inputs.SRM .< 1.0)`

| :summarized = true | :summarized = false|
|--|--|
|![scenarios_filtered__summarize_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/98915df1-73bb-420e-94cd-89431ee2ed01)|![scenarios_filtered__summarize_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/723e316e-351e-4644-8088-9db8b98a8f21)|

- scenario_total_cover clustered with 4 clusters

| :summarized = true | :summarized = false|
|--|--|
|![clusters_summarize_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/4f73dd68-0e7f-48d4-a5d0-98b24f87344d)| ![clusters_summarize_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/1cc3dde0-a7d9-45ed-a328-57cd6ac8a3e2)|

- scenario_total_cover targeting the best cluster

| :summarized = true | :summarized = false|
|--|--|
|![target__summarize_true](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/bd5c60a9-a74a-4945-b442-2144a19ddfc3)|![target__summarize_false](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/cc7097f5-2ed7-4bbb-a298-f52cc265624d)|




Closes #522.