### PR TITLE
Resolve Out-of-Memory issues when working with larger spatial areas

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -44,7 +44,7 @@ function site_distances(site_data::DataFrame)::Tuple{Matrix{Float64},Float64}
                 continue
             end
 
-            @inbounds dist[ii, jj] = haversine((longitudes[ii], latitudes[ii]), (longitudes[jj], latitudes[jj]))
+            @views dist[ii, jj] = haversine((longitudes[ii], latitudes[ii]), (longitudes[jj], latitudes[jj]))
         end
     end
 

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -79,8 +79,8 @@ function load_domain(::Type{ReefModDomain}, fn_path::String, RCP::String)::ReefM
 
     conn_data = load_connectivity(ReefModDomain, data_files, loc_ids)
     in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(
-        conn_data, 
-        vec(site_data.area .* site_data.k), 
+        conn_data,
+        vec(site_data.area .* site_data.k),
         similar(conn_data)
     )
 
@@ -250,7 +250,7 @@ function load_connectivity(::Type{ReefModDomain}, data_path::String, loc_ids::Ve
     end
 
     # Mean over all years
-    conn_data::SparseMatrixCSC = sparse(dropdims(mean(tmp_mat, dims=3), dims=3))
+    conn_data::Matrix{Float64} = dropdims(mean(tmp_mat, dims=3), dims=3)
     return NamedDimsArray(conn_data, source=loc_ids, sinks=loc_ids)
 end
 

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -1,5 +1,6 @@
 using NamedDims, AxisKeys, CSV
-using CSV, DataFrames, Statistics, Distributions
+using DataFrames, Statistics, Distributions
+using SparseArrays
 import GeoDataFrames as GDF
 
 using ModelParameters
@@ -71,7 +72,7 @@ function load_domain(::Type{ReefModDomain}, fn_path::String, RCP::String)::ReefM
     @assert isempty(findall(site_data.LABEL_ID .!= id_list[:, 1]))
 
     # Convert area in km² to m²
-    site_data[:, :area] .= id_list[:, 2] * 1e6
+    site_data[:, :area] .= id_list[:, 2] .* 1e6
 
     # Calculate `k` area (1.0 - "ungrazable" area)
     site_data[:, :k] .= 1.0 .- id_list[:, 3]
@@ -249,7 +250,7 @@ function load_connectivity(::Type{ReefModDomain}, data_path::String, loc_ids::Ve
     end
 
     # Mean over all years
-    conn_data = dropdims(mean(tmp_mat, dims=3), dims=3)
+    conn_data::SparseMatrixCSC = sparse(dropdims(mean(tmp_mat, dims=3), dims=3))
     return NamedDimsArray(conn_data, source=loc_ids, sinks=loc_ids)
 end
 

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -77,7 +77,11 @@ function load_domain(::Type{ReefModDomain}, fn_path::String, RCP::String)::ReefM
     site_data[:, :k] .= 1.0 .- id_list[:, 3]
 
     conn_data = load_connectivity(ReefModDomain, data_files, loc_ids)
-    in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(conn_data, vec(site_data.area .* site_data.k))
+    in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(
+        conn_data, 
+        vec(site_data.area .* site_data.k), 
+        similar(conn_data)
+    )
 
     # Set all site depths to 6m below sea level
     # (ReefMod does not account for depth)

--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -1,9 +1,18 @@
-using NamedDims, AxisKeys, CSV
-using DataFrames, Statistics, Distributions
-using SparseArrays
+using
+    AxisKeys,
+    NamedDims
+
+using
+    CSV,
+    DataFrames,
+    ModelParameters
+
+using
+    Distributions,
+    Statistics
+
 import GeoDataFrames as GDF
 
-using ModelParameters
 using ADRIA: SimConstants, Domain, site_distances
 
 

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -105,7 +105,7 @@ function site_connectivity(file_loc::String, unique_site_ids::Vector{String};
         extracted_TP[extracted_TP.<con_cutoff] .= 0.0
     end
 
-    TP_base = NamedDimsArray(sparse(extracted_TP), Source=unique_site_ids, Receiving=unique_site_ids)
+    TP_base = NamedDimsArray(extracted_TP, Source=unique_site_ids, Receiving=unique_site_ids)
     @assert all(0.0 .<= TP_base .<= 1.0) "Connectivity data not scaled between 0 - 1"
 
     return (TP_base=TP_base, truncated=invalid_ids, site_ids=unique_site_ids)
@@ -174,8 +174,8 @@ function connectivity_strength(TP_base::AbstractMatrix{Float64})::NamedTuple
     return (in_conn=C1, out_conn=C2, strongest_predecessor=strong_pred)
 end
 function connectivity_strength(
-    area_weighted_TP::AbstractMatrix{Float64}, 
-    cover::Vector{Float64}, 
+    area_weighted_TP::AbstractMatrix{Float64},
+    cover::Vector{Float64},
     TP_cache::AbstractMatrix{Float64}
 )::NamedTuple
 

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -128,7 +128,7 @@ end
 
 """
     connectivity_strength(TP_base::AbstractArray)::NamedTuple
-    connectivity_strength(area_weighted_TP::AbstractMatrix{Float64}, cover::Vector{Float64})::NamedTuple
+    connectivity_strength(area_weighted_TP::AbstractMatrix{Float64}, cover::Vector{Float64}, TP_cache::AbstractMatrix{Float64})::NamedTuple
 
 Create in/out degree centralities for all nodes, and vector of their strongest predecessors.
 
@@ -173,7 +173,11 @@ function connectivity_strength(TP_base::AbstractMatrix{Float64})::NamedTuple
 
     return (in_conn=C1, out_conn=C2, strongest_predecessor=strong_pred)
 end
-function connectivity_strength(area_weighted_TP::AbstractMatrix{Float64}, cover::Vector{Float64}, TP_cache::AbstractMatrix{Float64})::NamedTuple
+function connectivity_strength(
+    area_weighted_TP::AbstractMatrix{Float64}, 
+    cover::Vector{Float64}, 
+    TP_cache::AbstractMatrix{Float64}
+)::NamedTuple
 
     # Accounts for cases where there is no coral cover
     TP_cache .= (area_weighted_TP .* cover)

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -173,12 +173,11 @@ function connectivity_strength(TP_base::AbstractMatrix{Float64})::NamedTuple
 
     return (in_conn=C1, out_conn=C2, strongest_predecessor=strong_pred)
 end
-function connectivity_strength(
-    area_weighted_TP::NamedDimsArray, cover::Vector{<:Union{Float32, Float64}}
-)::NamedTuple
-    # Accounts for cases where there is no coral cover
-    tp = (area_weighted_TP .* cover)
-    tp .= tp ./ maximum(tp)
+function connectivity_strength(area_weighted_TP::AbstractMatrix{Float64}, cover::Vector{Float64}, TP_cache::AbstractMatrix{Float64})::NamedTuple
 
-    return connectivity_strength(tp)
+    # Accounts for cases where there is no coral cover
+    TP_cache .= (area_weighted_TP .* cover)
+    TP_cache .= TP_cache ./ maximum(TP_cache)
+
+    return connectivity_strength(TP_cache)
 end

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -398,7 +398,7 @@ function settler_DHW_tolerance!(
 
     settler_sc::StepRange = 1:6:36
     for sink_loc in sink_loc_ids
-        if sum(settlers[:, sink_loc]) .== 0.0
+        if sum(@views(settlers[:, sink_loc])) .== 0.0
             # Only update locations where recruitment occurred
             continue
         end
@@ -424,7 +424,7 @@ function settler_DHW_tolerance!(
             # Determine weights based on contribution to recruitment.
             # This weights the recruited corals by the size classes and source locations
             # which contributed to recruitment.
-            if sum(w_per_group[:, sp]) > 0.0
+            if sum(@view(w_per_group[:, sp])) > 0.0
                 ew = @views repeat(w_per_group[:, sp], inner=count(reproductive_sc))
                 weights::Weights = Weights(ew ./ sum(ew))
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -641,10 +641,7 @@ function settler_cover(
     valid_locs::BitVector = sum.(eachcol(TP_data)) .> 0.0
 
     # Send larvae out into the world (reuse fec_scope to reduce allocations)
-    # fec_scope .= (fec_scope .* sf)
-    # fec_scope .= (fec_scope * TP_data) .* (1.0 .- Mwater)  # larval pool for each site (in larvae/m²)
-
-    # As above, but more performant, less readable.
+    # [Larval pool for each location in larvae/m²] * [survival rate]
     Mwater::Float64 = 0.95  # in water mortality
     @views fec_scope[:, valid_locs] .= (
         fec_scope[:, valid_locs]

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -618,7 +618,5 @@ function settler_cover(
     # Larvae have landed, work out how many are recruited
     # Determine area covered by recruited larvae (settler cover) per m^2
     # recruits per m^2 per site multiplied by area per settler
-    fec_scope .= recruitment_rate(fec_scope, leftover_k_m²; α=α, β=β) .* basal_area_per_settler
-
-    return fec_scope
+    return recruitment_rate(fec_scope, leftover_k_m²; α=α, β=β) .* basal_area_per_settler
 end

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -365,7 +365,7 @@ locations.
 
 # Arguments
 - `cover` : Area covered by coral
-- `c_dist_t_1` : DHW tolerance distribution for previous timestep (t  - 1)
+- `c_dist_t_1` : DHW tolerance distribution for previous timestep (t - 1)
 - `c_dist_t` : DHW tolerance distribution for current timestep (t)
 - `k_area` : Absolute coral habitable area
 - `tp` : Transition Probability matrix indicating the proportion of larvae that reaches a

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -80,7 +80,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
 
         # Truncated normal distributions for deployed corals
         # Assume same stdev and bounds as original
-        tn::Vector{Float64} = mean.(truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti)))
+        tn::Vector{Float64} = mean.(truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), 0.0, a_adapt[seed_sc] .+ HEAT_UB))
 
         # If seeding an empty location, no need to do any further calculations
         if all(isapprox.(w_taxa[:, i], 1.0))

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -55,7 +55,7 @@ Note: Units for all areas are expected to be identical, and are assumed to be in
 """
 function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_space::V,
     seed_locs::Vector{Int64}, seeded_area::NamedDimsArray, seed_sc::BitVector, a_adapt::V,
-    Yseed::SubArray, stdev::V, c_dist_t::Matrix{<:Truncated})::Nothing where {V<:Vector{Float64}}
+    Yseed::SubArray, stdev::V, c_dist_t::Matrix{Float64})::Nothing where {V<:Vector{Float64}}
 
     # Calculate proportion to seed based on current available space
     scaled_seed = distribute_seeded_corals(total_location_area[seed_locs], leftover_space[seed_locs], seeded_area)
@@ -80,7 +80,7 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
 
         # Truncated normal distributions for deployed corals
         # Assume same stdev and bounds as original
-        tn::Vector{Truncated} = truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti))
+        tn::Vector{Float64} = mean.(truncated.(Normal.(a_adapt[seed_sc], stdev[seed_sc]), minimum.(c_dist_ti), maximum.(c_dist_ti)))
 
         # If seeding an empty location, no need to do any further calculations
         if all(isapprox.(w_taxa[:, i], 1.0))
@@ -91,8 +91,8 @@ function seed_corals!(cover::Matrix{Float64}, total_location_area::V, leftover_s
         # Create new distributions by mixing previous and current distributions using
         # proportional cover as the priors/weights
         # Priors (weights based on cover for each species)
-        tx::Vector{MixtureModel} = MixtureModel[MixtureModel([t, t1], Float64[w, 1.0-w]) for ((t, t1), w) in zip(zip(c_dist_ti, tn), w_taxa[:, i])]
-        c_dist_t[seed_sc, loc] .= truncated.(Normal.(mean.(tx), stdev[seed_sc]), minimum.(tx), maximum.(tx))
+        tx::Vector{Weights} = Weights.(eachcol(vcat(w_taxa[:, i]', 1.0 .- w_taxa[:, i]')))
+        c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
     end
 
     return nothing

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -171,16 +171,16 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
 
     # Log for coral DHW thresholds
     attrs = Dict(
-        :structure => ("timesteps", "species", "sites", "stat", "scenarios"),
+        :structure => ("timesteps", "species", "sites", "scenarios"),
         :unique_site_ids => unique_sites,
     )
 
     # 36 is the number of species/groups represented
     local coral_dhw_log
     if parse(Bool, ENV["ADRIA_DEBUG"]) == true
-        coral_dhw_log = zcreate(Float32, tf, 36, n_sites, 2, n_scens; name="coral_dhw_log", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(tf, 36, n_sites, 2, 1), attrs=attrs)
+        coral_dhw_log = zcreate(Float32, tf, 36, n_sites, n_scens; name="coral_dhw_log", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(tf, 36, n_sites, 1), attrs=attrs)
     else
-        coral_dhw_log = zcreate(Float32, tf, 36, 1, 2, n_scens; name="coral_dhw_log", fill_value=0.0, fill_as_missing=false, path=log_fn, chunks=(tf, 36, 1, 2, 1), attrs=attrs)
+        coral_dhw_log = zcreate(Float32, tf, 36, 1, n_scens; name="coral_dhw_log", fill_value=0.0, fill_as_missing=false, path=log_fn, chunks=(tf, 36, 1, 1), attrs=attrs)
     end
 
     return ranks, seed_log, fog_log, shade_log, coral_dhw_log

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -440,7 +440,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     fec_params_per_m²::Vector{Float64} = corals.fecundity  # number of larvae produced per m²
 
     # Caches
-    TP_data = Matrix(domain.TP_data)
+    TP_data = domain.TP_data
     # sf = cache.sf  # unused as it is currently deactivated
     fec_all = cache.fec_all
     fec_scope = cache.fec_scope
@@ -595,7 +595,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     growth::ODEProblem = ODEProblem{true}(growthODE, ode_u, tspan, p)
     tmp::Matrix{Float64} = zeros(size(Y_cover[1, :, :]))  # temporary array to hold intermediate covers
 
-    area_weighted_TP = domain.TP_data .* site_k_area(domain)
+    area_weighted_TP = TP_data .* site_k_area(domain)
     TP_cache = similar(area_weighted_TP)
 
     # basal_area_per_settler is the area in m^2 of a size class one coral

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -595,6 +595,9 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
     growth::ODEProblem = ODEProblem{true}(growthODE, ode_u, tspan, p)
     tmp::Matrix{Float64} = zeros(size(Y_cover[1, :, :]))  # temporary array to hold intermediate covers
 
+    area_weighted_TP = domain.TP_data .* site_k_area(domain)
+    TP_cache = similar(area_weighted_TP)
+
     # basal_area_per_settler is the area in m^2 of a size class one coral
     basal_area_per_settler = colony_mean_area(corals.mean_colony_diameter_m[corals.class_id.==1])
     for tstep::Int64 in 2:tf
@@ -648,7 +651,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
 
             # Determine connectivity strength
             # Account for cases where there is no coral cover
-            in_conn, out_conn, strong_pred = connectivity_strength(domain.TP_data .* site_k_area(domain), vec(site_coral_cover))
+            in_conn, out_conn, strong_pred = connectivity_strength(area_weighted_TP, vec(site_coral_cover), TP_cache)
             (seed_locs, shade_locs, rankings) = guided_site_selection(mcda_vars, MCDA_approach,
                 seed_decision_years[tstep], shade_decision_years[tstep],
                 seed_locs, shade_locs, rankings, in_conn[mcda_vars.site_ids], out_conn[mcda_vars.site_ids], strong_pred[mcda_vars.site_ids])

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -671,7 +671,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray, corals::DataFrame,
         #    attempts to account for the cooling effect of storms / high wave activity
         # `wave_scen` is normalized to the maximum value found for the given wave scenario
         # so what causes 100% mortality can differ between runs.
-        bleaching_mortality!(Y_pstep, collect(dhw_t .* (1.0 .- @view(wave_scen[tstep, :]))), depth_coeff, corals.dist_std, c_mean_t_1, c_mean_t, @view(bleaching_mort[tstep, :, :]))
+        bleaching_mortality!(Y_pstep, collect(dhw_t .* (1.0 .- @view(wave_scen[tstep, :]))), depth_coeff, corals.dist_std, c_mean_t_1, c_mean_t, @view(bleaching_mort[tstep-1:tstep, :, :]))
 
         # Apply seeding
         if seed_corals && in_seed_years && has_seed_sites

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -69,7 +69,7 @@ using ADRIA: distribute_seeded_corals, site_k, seed_corals!
 
     @testset "DHW distribution priors" begin
         Y_pstep = rand(36, 10)  # size class, locations
-        a_adapt = rand(2.0:6.0, 36)
+        a_adapt = rand(3.0:6.0, 36)
         total_location_area = fill(5000.0, 10)
 
         seed_locs = rand(1:10, 5)  # Pick 5 random locations
@@ -81,7 +81,8 @@ using ADRIA: distribute_seeded_corals, site_k, seed_corals!
         seed_sc = BitVector([i ∈ [2, 8, 15] for i in 1:36])
 
         # Initial distributions
-        c_dist_t = fill(truncated(Normal(1.0, 0.1), 0.0, 2.0), 36, 10)
+        d = truncated(Normal(1.0, 0.15), 0.0, 3.0)
+        c_dist_t = rand(d, 36, 10)
         orig_dist = copy(c_dist_t)
 
         dist_std = rand(36)
@@ -93,7 +94,7 @@ using ADRIA: distribute_seeded_corals, site_k, seed_corals!
             for (i, sc) in enumerate(findall(seed_sc))
                 prior1 = Yseed[1, i, loc] ./ Y_pstep[sc, loc]
                 expected = [prior1, 1.0 - prior1]
-                @test mean(c_dist_t[sc, loc]) > mean(orig_dist[sc, loc]) || "Expected mean of distribution to shift | SC: $sc ; Location: $loc"
+                @test c_dist_t[sc, loc] > orig_dist[sc, loc] || "Expected mean of distribution to shift | SC: $sc ; Location: $loc"
             end
         end
     end


### PR DESCRIPTION
Attempt to reduce high number of memory allocations to a more manageable level 
(recalling that memory allocations are not the same as memory use - although a small reduction is a nice side-effect here).

Much of the effort is in streamlining the `settler_DHW_tolerance!()` function.

High memory use is somewhat expected in GBR-scale simulations (3806 reefs).
Currently, `settler_DHW_tolerance!()` is doing a naive check for any locations with $k$ > 0 - and it turns out all represented reefs have $k$ > 0.

Note: Please ignore changes to `settler_cover()` - I had to cherry pick some changes from another branch (for turning all calculations to be relative to $k$ area) and these were brought over by accident. The changes there don't affect anything.

