### PR TITLE
Avoid assuming where the RCP column is when adjusting scenario spec

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -51,7 +51,7 @@ Length of `u` (the upper bounds) is expected to match number of columns in `df`.
 """
 function map_to_discrete!(
     df::Union{DataFrame,SubDataFrame},
-    u::Union{AbstractVector{Union{Int64,Float64}},Tuple}
+    u::Union{AbstractVector{<:Union{Int64,Float64}},Tuple}
 )::Nothing
     for (idx, b) in enumerate(u)
         df[!, idx] .= map_to_discrete.(df[!, idx], b)

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -44,12 +44,15 @@ function map_to_discrete(v::Union{Int64,Float64}, u::Union{Int64,Float64})::Int6
 end
 
 """
-    map_to_discrete!(df::DataFrame, u::AbstractArray)::Nothing
+    map_to_discrete!(df::Union{DataFrame,SubDataFrame}, u::Union{AbstractVector{Union{Int64,Float64}},Tuple})::Nothing
 
 Update a dataframe of parameters.
-Length of `u` is expected to match number of columns in `df`.
+Length of `u` (the upper bounds) is expected to match number of columns in `df`.
 """
-function map_to_discrete!(df::DataFrame, u::Union{AbstractVector{Union{Int64,Float64}},Tuple})::Nothing
+function map_to_discrete!(
+    df::Union{DataFrame,SubDataFrame},
+    u::Union{AbstractVector{Union{Int64,Float64}},Tuple}
+)::Nothing
     for (idx, b) in enumerate(u)
         df[!, idx] .= map_to_discrete.(df[!, idx], b)
     end


### PR DESCRIPTION
The column indicating the RCP was originally the first entry but can be the first or last column depending on how/who the scenario spec was generated (and what version of ADRIA).

Remove the assumption that the RCP column is before any other discrete-valued parameter.

Fixed a bug where values set as constants by the user were being floored as well.

Closes #518 
