### PR TITLE
Fix integer dims reference in location_selection_frequency()

### DIFF
--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -246,7 +246,7 @@ function location_selection_frequencies(
     n_iv_locs::Int64=5,
 )::NamedDimsArray
     ranks_frequencies = ranks_to_frequencies(ranks; n_ranks=n_iv_locs)
-    loc_count = sum(ranks_frequencies[ranks=1:n_iv_locs], dims=2)[ranks=1]
+    loc_count = sum(ranks_frequencies[ranks=1:n_iv_locs]; dims=:ranks)[ranks=1]
 
     return loc_count
 end


### PR DESCRIPTION
Closes #562

A dims reference in `location_selection_frequency()` was incorrect. This has been changed to a symbol to avoid any future issues.