### PR TITLE
Visualizations to be agnostic to Makie backend

### DIFF
--- a/Aviz/build/precompile_script.jl
+++ b/Aviz/build/precompile_script.jl
@@ -1,7 +1,7 @@
 using CSV, DataFrames, GeoDataFrames, GeoInterface
 using Statistics, Distributions
-using GLMakie.GeometryBasics
-using ADRIA, GLMakie
+using Makie.GeometryBasics
+using ADRIA, Makie
 
 
 precompile(CSV.read, (String, DataFrame))

--- a/Project.toml
+++ b/Project.toml
@@ -64,12 +64,12 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [weakdeps]
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
 
 [extensions]
-AvizExt = ["GLMakie", "GeoMakie", "GraphMakie"]
+AvizExt = ["Makie", "GeoMakie", "GraphMakie"]
 
 [compat]
 ArchGDAL = "0.9, 0.10"

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -11,18 +11,25 @@ The Makie.jl ecosystem is used to produce figures.
 Install additional packages if necessary
 
 ```julia
-]add GLMakie GeoMakie GraphMakie
+]add Makie GeoMakie GraphMakie
+```
+
+Install a Makie [backend](https://docs.makie.org/stable/explanations/backends/) of your
+choice. WGLMakie is more flexible for our workflows, but GLMakie is a good choice too.
+
+```julia
+]add WGLMakie
 ```
 
 Import additional packages and the visualization extension will compile.
 
 ```julia
-using GLMakie, GeoMakie, GraphMakie
+using WGLMakie, GeoMakie, GraphMakie
 using ADRIA
 ```
 
-If using VS Code, you may need to deactivate the inline plotting feature to make figures
-appear.
+Plots will appear in the VS Code plots pane.
+You may need to deactivate the inline plotting feature when displaying plots elsewhere.
 
 ```julia
 Makie.inline!(false)

--- a/ext/AvizExt/AvizExt.jl
+++ b/ext/AvizExt/AvizExt.jl
@@ -4,7 +4,7 @@ using Base.Iterators
 using Reexport
 
 using RelocatableFolders
-using GLMakie
+using Makie
 @reexport using GeoMakie
 
 using Statistics, Distributions, FLoops, Random

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -28,7 +28,7 @@ See: https://docs.makie.org/v0.19/api/index.html#Figure
 See: https://docs.makie.org/v0.19/api/index.html#Axis
 
 # Returns
-GLMakie figure
+Makie figure
 """
 function ADRIA.viz.pawn!(g::Union{GridLayout,GridPosition}, Si::NamedDimsArray; opts::Dict=Dict(), axis_opts::Dict=Dict())
     xtick_rot = get(axis_opts, :xticklabelrotation, 2.0 / π)
@@ -86,7 +86,7 @@ Display temporal sensitivity analysis
   See: https://docs.makie.org/v0.19/api/index.html#Axis
 
 # Returns
-GLMakie figure
+Makie figure
 """
 function ADRIA.viz.tsa!(g::Union{GridLayout,GridPosition}, rs::ResultSet, si::NamedDimsArray; opts, axis_opts)
     stat = get(opts, :stat, :median)
@@ -155,7 +155,7 @@ Plot regional sensitivities of up to 30 factors.
   See: https://docs.makie.org/v0.19/api/index.html#Axis
 
 # Returns
-GLMakie figure
+Makie figure
 """
 function ADRIA.viz.rsa!(g::Union{GridLayout,GridPosition}, rs::ResultSet, si::NamedDimsArray, factors::Vector{String}; opts, axis_opts)
     n_factors::Int64 = length(factors)
@@ -262,7 +262,7 @@ Plot outcomes mapped to factor regions for up to 30 factors.
   See: https://docs.makie.org/v0.19/api/index.html#Axis
 
 # Returns
-GLMakie figure
+Makie figure
 """
 function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::NamedDimsArray, factors::Vector{String}; opts::Dict=Dict(), axis_opts::Dict=Dict())
     # TODO: Clean up and compartmentalize as a lot of code here are duplicates of those
@@ -313,7 +313,7 @@ function ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet
         for c in 1:n_cols
             f_name = Symbol(factors[curr])
             f_vals = rs.inputs[:, f_name]
-            
+
             if f_name == :guided
                 fv_s = collect(1:length(fv_labels))
             else

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -14,7 +14,7 @@ Base.getindex(fc::AbstractFeatureCollection, i::Vector) = features(fc)[i]
 Create a spatial choropleth figure.
 
 # Arguments
-- `f` : GLMakie figure to create plot in
+- `f` : Makie figure to create plot in
 - `geodata` : FeatureCollection, Geospatial data to display
 - `data` : Values to use for choropleth
 - `highlight` : Stroke colors for each location

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -1,9 +1,9 @@
-using GLMakie, DataFrames
+using Makie, DataFrames
 
 using ADRIA: ResultSet, metrics.metric_label, analysis.col_normalize, model_spec
 using NamedDims, AxisKeys
 using .AvizExt
-using GLMakie.Colors
+using Makie.Colors
 
 """
     _time_labels(labels)


### PR DESCRIPTION
GLMakie may be preferred when creating visualizations locally, but allows WGLMakie to be installed instead for web/browser-based plots.

By default, figures will appear in the VS Code plot pane:

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/9f824c88-c09e-42b2-accf-eb6fed667d9a)


To switch backends, either:

```julia
] remove GLMakie
] add WGLMakie
```

or have both installed and activate the desired backend:

```julia
using WGLMakie
WGLMakie.activate!()

# or

using GLMakie
GLMakie.activate!()
```

https://docs.makie.org/stable/explanations/backends/