### PR TITLE
Update use of progress meter to resolve deprecation warning

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -166,7 +166,7 @@ function run_scenarios(
             rep_doms = Iterators.repeated(dom, length(target_rows))
             scenario_args = zip(rep_doms, target_rows, eachrow(scenarios_matrix[target_rows, :]))
             if show_progress
-                @showprogress run_msg 4 pmap(func, CachingPool(workers()), scenario_args)
+                @showprogress desc=run_msg dt=4 pmap(func, CachingPool(workers()), scenario_args)
             else
                 pmap(func, CachingPool(workers()), scenario_args)
             end
@@ -187,7 +187,7 @@ function run_scenarios(
             rep_doms = Iterators.repeated(dom, size(scenarios_matrix, 1))
             scenario_args = zip(rep_doms, target_rows, eachrow(scenarios_matrix[target_rows, :]))
             if show_progress
-                @showprogress run_msg 4 map(func, scenario_args)
+                @showprogress desc=run_msg dt=4 map(func, scenario_args)
             else
                 map(func, scenario_args)
             end


### PR DESCRIPTION
Recent version requires use of named arguments:

```julia
@showprogress desc=run_msg dt=4 ...
```

Otherwise a deprecation warning is thrown:

```julia
┌ Warning: `Progress(n::Integer, desc::AbstractString, offset::Integer = 0; kwargs...)` is deprecated, use `Progress(n; desc = desc, offset = offset, kwargs...)` instead.
│   caller = ip:0x0
└ @ Core :-1
```