### PR TITLE
Change approach to listing supported MCDA methods

### DIFF
--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -573,7 +573,7 @@ function ADRIA.viz.outcome_map!(
     b_slices = parse.(Float64, bin_slices)
 
     if any(f_names .== :guided)
-        fv_labels = ["unguided", "cf", last.(split.(string.(ADRIA.methods_mcda), "."))...]
+        fv_labels = ["unguided", "cf", last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...]
     end
     curr::Int64 = 1
     axs = Axis[]

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -54,10 +54,34 @@ jmcdm_ignore = [
     JMcDM.VIKOR.VikorMethod,
 ]
 
-const jmcdm_methods = subtypes(MCDMMethod)
-const methods_mcda = [
-    order_ranking, adria_vikor, adria_topsis, setdiff(jmcdm_methods, jmcdm_ignore)...
-]
+function supported_jmcdm_methods()
+    return [
+        JMcDM.ARAS.ArasMethod,
+        JMcDM.COCOSO.CocosoMethod,
+        JMcDM.CODAS.CodasMethod,
+        JMcDM.EDAS.EdasMethod,
+        JMcDM.GREY.GreyMethod,
+        JMcDM.MABAC.MabacMethod,
+        JMcDM.MAIRCA.MaircaMethod,
+        JMcDM.MARCOS.MarcosMethod,
+        JMcDM.MOORA.MooraMethod,
+        JMcDM.PIV.PIVMethod,
+        JMcDM.PSI.PSIMethod,
+        JMcDM.ROV.ROVMethod,
+        JMcDM.SAW.SawMethod,
+        JMcDM.WASPAS.WaspasMethod,
+        JMcDM.WPM.WPMMethod
+    ]
+end
+
+function mcda_methods()
+    return [
+        order_ranking,
+        adria_vikor,
+        adria_topsis,
+        supported_jmcdm_methods()...
+    ]
+end
 
 """
     DMCDA_vars(domain::Domain, criteria::NamedDimsArray,
@@ -555,7 +579,7 @@ function guided_site_selection(
     in_conn::Vector{Float64},
     out_conn::Vector{Float64},
     strong_pred::Vector{Int64};
-    methods_mcda=methods_mcda
+    methods_mcda=mcda_methods()
 )::Tuple{Vector{T}, Vector{T}, Matrix{T}} where {
     T<:Int64,IA<:AbstractArray{<:Int64},IB<:AbstractArray{<:Int64},B<:Bool
 }

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -6,8 +6,8 @@ Base.@kwdef struct Intervention{N,P,P2} <: EcoModel
     guided::N = Param(
         0;
         ptype="categorical",
-        bounds=(-1.0, length(decision.methods_mcda) + 1.0),
-        default_bounds=(-1.0, length(decision.methods_mcda) + 1.0),
+        bounds=(-1.0, length(decision.mcda_methods()) + 1.0),
+        default_bounds=(-1.0, length(decision.mcda_methods()) + 1.0),
         dists="unif",
         name="Guided",
         description="Choice of MCDA approach.",

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -92,7 +92,8 @@ end
 end
 
 @testset "Test ranks line up with ordering" begin
-    mcda_func = ADRIA.decision.methods_mcda[rand(1:length(ADRIA.decision.methods_mcda))]
+    supported_methods = ADRIA.decision.mcda_methods()
+    mcda_func = supported_methods[rand(1:length(supported_methods))]
     n_sites = 20
 
     S = ADRIA.decision.mcda_normalize(rand(Uniform(0, 1), n_sites, 6))


### PR DESCRIPTION
Replace consts with a function to allow flexibility. Previously modifying the list of supported methods required Julia to be restarted as the method list was assigned to a const.

Rather than listing out methods to ignore, we now explicitly list out the methods to include. This avoids situations where new (unsupported) methods are added to JMcDM.

Tests pass locally but visualizations fail (this is fixed in #589).