### PR TITLE
Remove list of ignored JMcDM methods

### DIFF
--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -45,18 +45,6 @@ end
 include("mcda_methods.jl")
 include("location_selection.jl")
 
-jmcdm_ignore = [
-    JMcDM.LOPCOW.LOPCOWMethod,
-    JMcDM.CRITIC.CriticMethod,
-    JMcDM.COPRAS.CoprasMethod,
-    JMcDM.MOOSRA.MoosraMethod,
-    JMcDM.MEREC.MERECMethod,
-    JMcDM.ELECTRE.ElectreMethod,
-    JMcDM.PROMETHEE.PrometheeMethod,
-    JMcDM.Topsis.TopsisMethod,
-    JMcDM.VIKOR.VikorMethod,
-]
-
 function supported_jmcdm_methods()
     return [
         JMcDM.ARAS.ArasMethod,


### PR DESCRIPTION
This seems to have been reintroduced by an inappropriate rebase in #571
