### PR TITLE
Fix bug where cover instead of leftover space was being used in stand alone site selection

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -232,7 +232,7 @@ function n_locations(domain::Domain)::Int64
 end
 
 """
-    relative_leftover_space(loc_coral_cover::Matrix{Float64})::Matrix{Float64}
+    relative_leftover_space(loc_coral_cover::Union{Matrix{Float64},Vector{Float32}})::Union{Matrix{Float64},Vector{Float32}}
 
 Get proportion of leftover space, given site_k and proportional cover on each site, summed
 over species.
@@ -243,7 +243,9 @@ over species.
 # Returns
 Leftover space ∈ [0, 1]
 """
-function relative_leftover_space(loc_coral_cover::Matrix{Float64})::Matrix{Float64}
+function relative_leftover_space(
+    loc_coral_cover::Union{Matrix{Float64},Vector{Float32}}
+)::Union{Matrix{Float64},Vector{Float64}}
     return max.(1.0 .- loc_coral_cover, 0.0)
 end
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -232,7 +232,7 @@ function n_locations(domain::Domain)::Int64
 end
 
 """
-    relative_leftover_space(loc_coral_cover::Union{Matrix{Float64},Vector{Float32}})::Union{Matrix{Float64},Vector{Float32}}
+    relative_leftover_space(loc_coral_cover::AbstractArray)::AbstractArray
 
 Get proportion of leftover space, given site_k and proportional cover on each site, summed
 over species.
@@ -244,8 +244,8 @@ over species.
 Leftover space ∈ [0, 1]
 """
 function relative_leftover_space(
-    loc_coral_cover::Union{Matrix{Float64},Vector{Float32}}
-)::Union{Matrix{Float64},Vector{Float64}}
+    loc_coral_cover::AbstractArray,
+)::AbstractArray
     return max.(1.0 .- loc_coral_cover, 0.0)
 end
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -130,7 +130,7 @@ function rank_locations(
             scen,
             considered_sites,
             relative_leftover_space(
-                AxisKeys.keyless(NamedDims.unname(sum_cover[scen_idx, :]))
+                collect(sum_cover[scen_idx, :]),
             ) .* k_area_locs,
             area_to_seed,
             summary_stat_env(wave_scens[:, :, target_wave_scens], (:timesteps, :scenarios)),

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -10,7 +10,7 @@ MCDA method.
 
 # Arguments
 - `domain` : The geospatial domain to assess
-- `sum_cover` :  Absolute coral cover at each location
+- `sum_cover` :  Relative coral cover at each location
 - `mcda_vars` : Parameters for MCDA
 - `guided` : ID of MCDA algorithm to apply
 
@@ -66,7 +66,7 @@ Return location ranks for a given domain and scenarios.
 # Arguments
 - `domain` : The geospatial domain locations were selected from
 - `scenarios` : Scenario specification
-- `sum_cover` : Matrix[n_scenarios ⋅ n_sites] containing the total coral cover at each
+- `sum_cover` : Matrix[n_scenarios ⋅ n_sites] containing the total relative coral cover at each
     location, for each scenario
 - `area_to_seed` : Area of coral to be seeded at each time step in km²
 - `agg_func` : Aggregation function to apply, e.g `ranks_to_frequencies` or

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -116,6 +116,8 @@ function rank_locations(
         target_site_ids = collect(1:length(domain.site_ids))
     end
 
+    leftover_space_scens = relative_leftover_space(sum_cover.data) .* k_area_locs'
+
     for (scen_idx, scen) in enumerate(eachrow(scenarios))
         depth_criteria = within_depth_bounds(
             domain.site_data.depth_med,
@@ -124,14 +126,13 @@ function rank_locations(
         )
         depth_priority = findall(depth_criteria)
 
+
         considered_sites = target_site_ids[findall(in(depth_priority), target_site_ids)]
         mcda_vars_temp = DMCDA_vars(
             domain,
             scen,
             considered_sites,
-            relative_leftover_space(
-                sum_cover[scen_idx, :].data,
-            ) .* k_area_locs,
+            leftover_space_scens[scen_idx, :],
             area_to_seed,
             summary_stat_env(wave_scens[:, :, target_wave_scens], (:timesteps, :scenarios)),
             summary_stat_env(dhw_scens[:, :, target_dhw_scens], (:timesteps, :scenarios))

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -1,6 +1,6 @@
 using NamedDims, AxisKeys
 
-using ADRIA: connectivity_strength
+using ADRIA: connectivity_strength, relative_leftover_space, site_k_area
 
 """
     _location_selection(domain::Domain, sum_cover::AbstractArray, mcda_vars::DMCDA_vars, guided::Int64)::Matrix
@@ -87,6 +87,7 @@ function rank_locations(
     target_fog_sites=nothing,
 )::NamedDimsArray
     n_locs = n_locations(domain)
+    k_area_locs = site_k_area(domain)
 
     ranks_store = NamedDimsArray(
         zeros(n_locs, 2, nrow(scenarios)),
@@ -124,7 +125,12 @@ function rank_locations(
         depth_priority = findall(depth_criteria)
 
         considered_sites = target_site_ids[findall(in(depth_priority), target_site_ids)]
-        mcda_vars_temp = DMCDA_vars(domain, scen, considered_sites,  sum_cover[scen_idx, :], area_to_seed,
+        mcda_vars_temp = DMCDA_vars(
+            domain,
+            scen,
+            considered_sites,
+            relative_leftover_space(sum_cover[scen_idx, :]) .* k_area_locs,
+            area_to_seed,
             summary_stat_env(wave_scens[:, :, target_wave_scens], (:timesteps, :scenarios)),
             summary_stat_env(dhw_scens[:, :, target_dhw_scens], (:timesteps, :scenarios))
             )

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -129,7 +129,9 @@ function rank_locations(
             domain,
             scen,
             considered_sites,
-            relative_leftover_space(sum_cover[scen_idx, :]) .* k_area_locs,
+            relative_leftover_space(
+                AxisKeys.keyless(NamedDims.unname(sum_cover[scen_idx, :]))
+            ) .* k_area_locs,
             area_to_seed,
             summary_stat_env(wave_scens[:, :, target_wave_scens], (:timesteps, :scenarios)),
             summary_stat_env(dhw_scens[:, :, target_dhw_scens], (:timesteps, :scenarios))

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -130,7 +130,7 @@ function rank_locations(
             scen,
             considered_sites,
             relative_leftover_space(
-                collect(sum_cover[scen_idx, :]),
+                sum_cover[scen_idx, :].data,
             ) .* k_area_locs,
             area_to_seed,
             summary_stat_env(wave_scens[:, :, target_wave_scens], (:timesteps, :scenarios)),

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -170,7 +170,7 @@ Create in/out degree centralities for all nodes, and vector of their strongest p
 # Arguments
 - `TP_base` : Base transfer probability matrix to create Directed Graph from.
 - `area_weighted_TP` : Transfer probability matrix weighted by location `k` area
-- `cover` : Total coral cover at location
+- `cover` : Total relative coral cover at location
 - `TP_cache` : Cache matrix of same size as TP_base to hold intermediate values
 
 # Returns


### PR DESCRIPTION
Changes in MCDAvars mean leftover space in $m^2$ is now an input to MCDAvars instead of cover (introduced in #547). Cover was still being used as an input in the `MCDA_vars` usage in `rank_locations`, causing incorrect outputs in testing.