### PR TITLE
Fix mcda method bugs 

### DIFF
--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -58,7 +58,6 @@ function supported_jmcdm_methods()
         JMcDM.MOORA.MooraMethod,
         JMcDM.PIV.PIVMethod,
         JMcDM.PSI.PSIMethod,
-        JMcDM.ROV.ROVMethod,
         JMcDM.SAW.SawMethod,
         JMcDM.WASPAS.WaspasMethod,
         JMcDM.WPM.WPMMethod

--- a/src/decision/mcda_methods.jl
+++ b/src/decision/mcda_methods.jl
@@ -106,7 +106,7 @@ Details of this aggregation method in, for example [1]
 """
 function adria_vikor(S::Array{Float64,2}; v::Float64=0.5)::Array{Float64}
 
-    # Remove zero columns as these will return NaNs in the Q score 
+    # Remove columns with constant values. Zero-valued columns will return NaNs in the Q score.
     S = S[:, .!vec((all(S .== maximum(S; dims=1); dims=1)))]
     F_s = maximum(S)
 

--- a/src/decision/mcda_methods.jl
+++ b/src/decision/mcda_methods.jl
@@ -106,8 +106,8 @@ Details of this aggregation method in, for example [1]
 """
 function adria_vikor(S::Array{Float64,2}; v::Float64=0.5)::Array{Float64}
 
-    # Remove zero columns as these will return NaNs in the Q score
-    S = S[:, vec(sum(S .> 0.0; dims=1) .!= 0)]
+    # Remove zero columns as these will return NaNs in the Q score 
+    S = S[:, .!vec((all(S .== maximum(S; dims=1); dims=1)))]
     F_s = maximum(S)
 
     # Compute utility of the majority Sr (Manhatten Distance)

--- a/src/decision/mcda_methods.jl
+++ b/src/decision/mcda_methods.jl
@@ -106,6 +106,8 @@ Details of this aggregation method in, for example [1]
 """
 function adria_vikor(S::Array{Float64,2}; v::Float64=0.5)::Array{Float64}
 
+    # Remove zero columns as these will return NaNs in the Q score
+    S = S[:, vec(sum(S .> 0.0; dims=1) .!= 0)]
     F_s = maximum(S)
 
     # Compute utility of the majority Sr (Manhatten Distance)


### PR DESCRIPTION
This PR fixes a couple of bugs found in mcda methods during testing.

VIKOR method has been returning NaNs in the case where some weights are zero. This is due to the formulation of the Q score, which requires division by (column max - column min). This has been fixed by adding a line in the VIKOR method which removes any zero columns.

ROV method was found to be incorrectly reversing site ranks. An example of this is :
```julia
results.scores =
 0.6371641507442964
 0.6941436816327351
 0.877935879420678
 1.0066403672998092
 1.033670846678704
 1.5902842580982375
 1.7501562536882735
 0.5729368306847074
 0.4478149807103405
 0.4484346568894094

results.bestIndex =2
```

In this case, site 2 is neither the highest nor lowest score. This suggests either a bug in JMcDM, or that the method searches for something other than a max/min score in ranking alternatives. Either way, for now it is best to remove ROV.