### PR TITLE
Address MCDA error for single locations

### DIFF
--- a/src/decision/mcda_methods.jl
+++ b/src/decision/mcda_methods.jl
@@ -118,7 +118,7 @@ function adria_vikor(S::Matrix{Float64}; v::Float64=0.5)::Array{Float64}
     R = maximum(sr_arg, dims=2)
 
     # Compute the VIKOR compromise Q
-    S_s, S_h = extrema(Sr)
+    S_h, S_s = extrema(Sr)
     R_h, R_s = extrema(R)
     Q = @. v * (Sr - S_h) / (S_s - S_h) + (1 - v) * (R - R_h) / (R_s - R_h)
     Q .= 1.0 .- Q  # Invert rankings so higher values = higher rank

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -460,7 +460,7 @@ function Base.show(io::IO, mime::MIME"text/plain", rs::ResultSet)
     Results stored at: $(result_location(rs))
 
     RCP(s) represented: $(rcps)
-    Intervention scenarios run: $(scens)
+    Scenarios run: $(scens)
     Number of sites: $(sites)
     Timesteps: $(tf)
 


### PR DESCRIPTION
A bug was introduced in the previous fix #629, as it does not handle cases where only a single location is viable, resulting in an empty decision matrix.