### PR TITLE
Changes to make ADRIA precompilable under Julia v1.10

### DIFF
--- a/ext/AvizExt/AvizExt.jl
+++ b/ext/AvizExt/AvizExt.jl
@@ -523,7 +523,7 @@ function ADRIA.viz.explore(rs::ResultSet)
 
     # Trigger update only after some time since last interaction
     # TODO: Add update notification (spinner animation or something...)
-    up_timer = Timer(x -> x, 0.25)
+    # up_timer = Timer(x -> x, 0.25)
     onany(time_slider.interval, tac_slider.interval,
         [t.active for t in t_toggles]...,
         [sld.interval for sld in interv_sliders]...) do time_val, tac_val, rcp45, rcp60, rcp85, c_tog, u_tog, g_tog, intervs... # i1_val, i2_val, i3_val, i4_val, i5_val, i6_val, i7_val, i8_val, i9_val, i10_val, i11_val, i12_val
@@ -534,7 +534,9 @@ function ADRIA.viz.explore(rs::ResultSet)
         tac_bot_val[] = tac_val[1]
         tac_top_val[] = tac_val[2]
 
-        close(up_timer)
+        if @isdefined up_timer
+            close(up_timer)
+        end
         up_timer = Timer(x -> update_disp(time_val, tac_val, rcp45, rcp60, rcp85, c_tog, u_tog, g_tog, intervs...), 2)
     end
 
@@ -543,6 +545,7 @@ function ADRIA.viz.explore(rs::ResultSet)
     # DataInspector()
 
     wait(gl_screen)
+    # close(up_timer)
 end
 function ADRIA.viz.explore(rs_path::String)
     return ADRIA.viz.explore(load_results(rs_path))

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -167,34 +167,34 @@ if ccall(:jl_generating_output, Cint, ()) == 1
 end
 
 
-@setup_workload begin
-    # Putting some things in `setup` can reduce the size of the
-    # precompile file and potentially make loading faster.
-    # ADRIA_DIR = pkgdir(ADRIA)
-    # EXAMPLE_DOMAIN_PATH = joinpath(ADRIA_DIR, "examples", "Example_domain")
+# @setup_workload begin
+#     # Putting some things in `setup` can reduce the size of the
+#     # precompile file and potentially make loading faster.
+#     # ADRIA_DIR = pkgdir(ADRIA)
+#     # EXAMPLE_DOMAIN_PATH = joinpath(ADRIA_DIR, "examples", "Example_domain")
 
-    @compile_workload begin
+#     @compile_workload begin
 
-        # Force precompiling of code that handles distributed infrastructure
-        addprocs(1)
-        @everywhere 1 + 1
+#         # Force precompiling of code that handles distributed infrastructure
+#         addprocs(1)
+#         @everywhere 1 + 1
 
-        # Compile progress bar
-        # f() = begin
-        #     @showprogress 1 for _ in 1:10
-        #     end
-        # end
-        # b = redirect_stdout(f, devnull)
+#         # Compile progress bar
+#         # f() = begin
+#         #     @showprogress 1 for _ in 1:10
+#         #     end
+#         # end
+#         # b = redirect_stdout(f, devnull)
 
-        # dom = ADRIA.load_domain(EXAMPLE_DOMAIN_PATH, "45")
-        # ADRIA.sample(dom, 16)
-        # ADRIA.model_spec(dom)
+#         # dom = ADRIA.load_domain(EXAMPLE_DOMAIN_PATH, "45")
+#         # ADRIA.sample(dom, 16)
+#         # ADRIA.model_spec(dom)
 
-        # ENV["ADRIA_DEBUG"] = "false"
-        # p_df = ADRIA.param_table(dom)
-        # rs1 = ADRIA.run_scenario(dom, p_df[1, :])
-        # delete!(ENV, "ADRIA_DEBUG")
-    end
-end
+#         # ENV["ADRIA_DEBUG"] = "false"
+#         # p_df = ADRIA.param_table(dom)
+#         # rs1 = ADRIA.run_scenario(dom, p_df[1, :])
+#         # delete!(ENV, "ADRIA_DEBUG")
+#     end
+# end
 
 end


### PR DESCRIPTION
Julia v1.10 has moved to an asynchronous/parallel precompilation process.

The GLMakie-based prototype UI currently included with ADRIA (invoked by calling `ADRIA.explore(rs)`) makes use of a Timer to limit the number of UI updates that can occur.

The new precompilation process seems to wait for the timer to finish or otherwise enters into some kind of wait state.

The changes in this PR:

1. Adjusts use of Timer to only become active as users interact with the UI, avoiding any active state during precompilation, and 
2. Disables the precompilation workload to avoid similar issues.

Regarding point 2, some of the errors seem to stem from dependencies rather than ADRIA itself so I've opted to simply disable the precompilation workload for now.

This PR should address and close #645.
