### PR TITLE
Update use of Makie/GeoMakie to address deprecation errors

### DIFF
--- a/ext/AvizExt/AvizExt.jl
+++ b/ext/AvizExt/AvizExt.jl
@@ -152,7 +152,7 @@ Display GUI for quick visualization and analysis of results.
 """
 function ADRIA.viz.explore(rs::ResultSet)
     @info "Creating display"
-    layout = comms_layout(resolution=(1920, 1080))
+    layout = comms_layout(size=(1920, 1080))
 
     f = layout.figure
     traj_display = layout.trajectory.temporal
@@ -553,7 +553,7 @@ end
 
 
 # function explore(rs::ADRIA.ResultSet)
-#     layout = modeler_layout(resolution=(1920, 1080))
+#     layout = modeler_layout(size=(1920, 1080))
 
 #     f = layout.figure
 #     # controls = layout.controls

--- a/ext/AvizExt/layout.jl
+++ b/ext/AvizExt/layout.jl
@@ -21,8 +21,8 @@
 │     │ │                │ │         Message                        │
 └─────┘ └────────────────┘ └────────────────────────────────────────┘
 """
-function comms_layout(; resolution=(1920, 1080))
-    f = Figure(resolution=resolution)
+function comms_layout(; size=(1920, 1080))
+    f = Figure(size=size)
 
     main = f[1:6, 1:9] = GridLayout()
 
@@ -118,8 +118,8 @@ end
      │                            │  │                   │
      └────────────────────────────┘  └───────────────────┘
 """
-function modeler_layout(; resolution=(1920, 1080))
-    f = Figure(resolution=resolution)
+function modeler_layout(; size=(1920, 1080))
+    f = Figure(size=size)
 
     # controls = f[1:3, 1] = GridLayout()
     main = f[1:3, 1:6] = GridLayout()
@@ -189,8 +189,8 @@ end
 # │             │  │              │ │   Histogram   │
 # └─────────────┘  └──────────────┘ └───────────────┘
 # """
-# function create_layout(; resolution=(1600, 900))
-#     f = Figure(resolution=resolution)
+# function create_layout(; size=(1600, 900))
+#     f = Figure(size=size)
 
 #     controls = f[1:3, 1] = GridLayout()
 #     main = f[1:3, 2] = GridLayout()

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -21,7 +21,7 @@ Create a spatial choropleth figure.
 - `centroids` : Vector{Tuple}, of lon and lats
 - `show_colorbar` : Whether to show a colorbar (true) or not (false)
 - `colorbar_label` : Label to use for color bar
-- `color_map` : Type of colormap to use, 
+- `color_map` : Type of colormap to use,
     See: https://docs.makie.org/stable/documentation/colors/#colormaps
 - `legend_params` : Legend parameters
 - `axis_opts` : Additional options to pass to adjust Axis attributes
@@ -36,28 +36,26 @@ function create_map!(
     show_colorbar::Bool=true,
     colorbar_label::String="",
     color_map::Union{Symbol,Vector{Symbol},RGBA{Float32},Vector{RGBA{Float32}}}=:grayC,
-    legend_params::Union{Tuple,Nothing}=nothing, 
+    legend_params::Union{Tuple,Nothing}=nothing,
     axis_opts::Dict=Dict(),
 )
-    lon = first.(centroids)
-    lat = last.(centroids)
-
     axis_opts[:title] = get(axis_opts, :title, "Study Area")
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Longitude")
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "Latitude")
 
-    map_buffer = 0.025
     spatial = GeoAxis(
         f[1, 1];
-        lonlims=(minimum(lon) - map_buffer, maximum(lon) + map_buffer),
-        latlims=(minimum(lat) - map_buffer, maximum(lat) + map_buffer),
         dest="+proj=latlong +datum=WGS84",
         axis_opts...
     )
+    # lon = first.(centroids)
+    # lat = last.(centroids)
+    # map_buffer = 0.025
+    # xlims!(spatial, minimum(lon) - map_buffer, maximum(lon) + map_buffer)
+    # ylims!(spatial, minimum(lat) - map_buffer, maximum(lat) + map_buffer)
+
     spatial.xticklabelsize = 14
     spatial.yticklabelsize = 14
-    # spatial.xticklabelsvisible = false
-    # spatial.yticklabelsvisible = false
 
     spatial.yticklabelpad = 50
     spatial.ytickalign = 10
@@ -124,7 +122,6 @@ function create_map!(
             Legend(f[1, 3], legend_params..., framevisible=false)
         end
     end
-    # datalims!(spatial)  # auto-adjust limits (doesn't work if there are Infs...)
 
     return f
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ function test_rs_w_fig()
 	## Visualization
 
 	# Some shared options for the example plots below
-	fig_opts = Dict(:resolution => (1600, 800))
+	fig_opts = Dict(:size => (1600, 800))
 
 	# Factors of Interest
 	opts = Dict(
@@ -92,7 +92,7 @@ function test_rs_w_fig()
 	# save("scenarios_tac.png", fig_s_tac)
 
 
-	tf = Figure(resolution = (1600, 600))  # resolution in pixels
+	tf = Figure(size = (1600, 600))  # resolution in pixels
 
 	# Implicitly create a single figure with 2 columns
 	ADRIA.viz.scenarios!(
@@ -122,12 +122,12 @@ function test_rs_w_fig()
 	)
 
 	# Plot 1st rank frequencies as a colormap
-	rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, 1; fig_opts = Dict(:resolution => (1200, 800)))
+	rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, 1; fig_opts = Dict(:size => (1200, 800)))
 
 	# save("single_rank_plot.png", rank_fig)
 
 	# Plot 1st, 2nd and 3rd rank frequencies as an overlayed colormap
-	rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, [1, 2, 3]; fig_opts = Dict(:resolution => (1200, 800)))
+	rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, [1, 2, 3]; fig_opts = Dict(:size => (1200, 800)))
 
 	# save("ranks_plot.png", rank_fig)
 
@@ -307,7 +307,7 @@ function test_rs_w_fig()
 
 	### Outcome mapping
 
-	tf = Figure(resolution = (1600, 1200))  # resolution in pixels
+	tf = Figure(size = (1600, 1200))  # resolution in pixels
 
 	# Indicate factor values that are in the top 50 percentile
 	tac_om_50 = ADRIA.sensitivity.outcome_map(rs, mean_s_tac, x -> any(x .>= 0.5), foi; S = 20)


### PR DESCRIPTION
Addresses errors due to use of now fully deprecated keywords for Makie (v0.20.4) / GeoMakie (v0.6.0).

GeoMakie has updated (but the docs have not). The previous approach to setting lon/lat limits and associated tick labels does not work anymore.

The figure looks cleaner perhaps, but it would still be nice to see where we're looking at. In any case, I've opted to leave these off by default for later investigation.

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/359c654f-cdd6-4f71-881c-0bbb967612f6)
