### PR TITLE
Add back commented lines for defining spatial plot limits

### DIFF
--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -44,14 +44,14 @@ function create_map!(
 
     spatial = GeoAxis(
         f[1, 1];
-        dest="+proj=latlong +datum=WGS84",
+        dest = "+proj=latlong +datum=WGS84",
         axis_opts...,
     )
-    # lon = first.(centroids)
-    # lat = last.(centroids)
-    # map_buffer = 0.025
-    # xlims!(spatial, minimum(lon) - map_buffer, maximum(lon) + map_buffer)
-    # ylims!(spatial, minimum(lat) - map_buffer, maximum(lat) + map_buffer)
+    lon = first.(centroids)
+    lat = last.(centroids)
+    map_buffer = 0.025
+    xlims!(spatial, minimum(lon) - map_buffer, maximum(lon) + map_buffer)
+    ylims!(spatial, minimum(lat) - map_buffer, maximum(lat) + map_buffer)
 
     spatial.xticklabelsize = 14
     spatial.yticklabelsize = 14


### PR DESCRIPTION
Lines in `spatial.jl` which defined the x and y limits for spatial plotting had been left commented out, so that spatial plots are excessively zoomed out:

![plot_cover_without_bounds](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/767f892d-bb01-47f0-a53f-31601b42b480)

Adding the lines back in means plots can be seen without additional manual zooming in:
![plot_cover_bounds](https://github.com/open-AIMS/ADRIA.jl/assets/56939532/bb87a2e2-776c-496f-b416-73a57521e337)

