### PR TITLE
Add a default size for scenario plots

### DIFF
--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -42,7 +42,7 @@ function ADRIA.viz.scenarios(
     rs::ResultSet,
     outcomes::NamedDimsArray;
     opts::Dict=Dict(:by_RCP => false),
-    fig_opts::Dict=Dict(),
+    fig_opts::Dict=Dict(:size=>(800, 300)),
     axis_opts::Dict=Dict(),
     series_opts::Dict=Dict(),
 )::Figure
@@ -78,7 +78,7 @@ function ADRIA.viz.scenarios(
     scenarios::DataFrame,
     outcomes::NamedDimsArray;
     opts::Dict=Dict(:by_RCP => false),
-    fig_opts::Dict=Dict(),
+    fig_opts::Dict=Dict(:size=>(800, 300)),
     axis_opts::Dict=Dict(),
     series_opts::Dict=Dict(),
 )::Figure


### PR DESCRIPTION
Specify a default figure size to make it look nicer "out of the box".

![cf_stac_fig](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/47585944-70db-431c-9613-c1a42517d1fd)
