### PR TITLE
Fix bleaching mortality 

### DIFF
--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -299,7 +299,7 @@ function load_connectivity(
 
     # Mean over all years
     conn_data::Matrix{Float64} = dropdims(mean(tmp_mat; dims=3); dims=3)
-    return NamedDimsArray(conn_data; source=loc_ids, sinks=loc_ids)
+    return NamedDimsArray(conn_data; Source=loc_ids, Sink=loc_ids)
 end
 
 """

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -51,7 +51,7 @@ end
     truncated_standard_normal_mean(lb::Float64, ub::Float64)::Float64
 
 Calculates the mean of the truncated standard normal distribution. Implementation taken
-from Distributions.jl [1] excluding unused error checks. 
+from Distributions.jl [1] excluding unused error checks.
 
 # Arguments
 - `lb` : lower bound of the truncated distribution
@@ -86,11 +86,11 @@ end
 
 """
     truncated_normal_mean(
-        normal_mean::Float64, 
-        normal_stdev::Float64, 
-        lower_bound::Float64, 
+        normal_mean::Float64,
+        normal_stdev::Float64,
+        lower_bound::Float64,
         upper_bound::Float64
-    )::Float64   
+    )::Float64
 
 Calculates the mean of the truncated normal distribution.
 
@@ -152,8 +152,8 @@ function truncated_normal_cdf(
             $(alpha) and $(beta) standard deviations from the normal mean respectively."
     end
 
-    logcdf::Float64 = 
-        logerf(alpha * StatsFuns.invsqrt2, zeta * StatsFuns.invsqrt2) - 
+    logcdf::Float64 =
+        logerf(alpha * StatsFuns.invsqrt2, zeta * StatsFuns.invsqrt2) -
         logerf(alpha * StatsFuns.invsqrt2, beta * StatsFuns.invsqrt2)
 
     return exp(logcdf)

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -133,7 +133,7 @@ function site_connectivity(
     end
 
     TP_base = NamedDimsArray(
-        extracted_TP; Source=unique_site_ids, Receiving=unique_site_ids
+        extracted_TP; Source=unique_site_ids, Sink=unique_site_ids
     )
     @assert all(0.0 .<= TP_base .<= 1.0) "Connectivity data not scaled between 0 - 1"
 

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -67,7 +67,7 @@ function load_mat_data(
     # Attach site names to each dimension
     try
         site_order = Vector{String}(vec(data["reef_siteid"]))
-        loaded = NamedDimsArray(data[attr]; Source=site_order, Receiving=site_order)
+        loaded = NamedDimsArray(data[attr]; Source=site_order, Sink=site_order)
     catch err
         if isa(err, KeyError)
             @warn "Provided file $(data_fn) did not have reef_siteid! There may be a mismatch in sites."
@@ -76,7 +76,7 @@ function load_mat_data(
 
                 # Subset down to number of sites
                 tmp = selectdim(data[attr], 2, 1:nrow(site_data))
-                loaded = NamedDimsArray(tmp; Source=site_order, Receiving=site_order)
+                loaded = NamedDimsArray(tmp; Source=site_order, Sink=site_order)
             end
         else
             rethrow(err)

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -92,7 +92,7 @@ function store_env_summary(
 end
 
 """
-    store_conn(conn_data::NamedDimsArray, file_loc::String, rcp::String, 
+    store_conn(conn_data::NamedDimsArray, file_loc::String, rcp::String,
         compressor::Zarr.Compressor)::ZArray
 
 Retrieve connectivity matrices from Domain for storage.
@@ -119,9 +119,9 @@ function store_conn(
         fill_value = nothing, fill_as_missing = false,
         path = joinpath(file_loc, rcp),
         attrs = Dict(
-            :structure => ("Source", "Receiving"),
+            :structure => ("Source", "Sink"),
             :Source => conn_data.Source,
-            :Receiving => conn_data.Receiving,
+            :Sink => conn_data.Sink,
             :rcp => rcp),
         compressor = compressor)
 
@@ -561,10 +561,10 @@ function _recreate_conn_from_store(zarr_store_path::String)::Dict{String, Abstra
 
         dim_names = Symbol.(store.attrs["structure"])
         source_ids = string.(store.attrs["Source"])
-        recieving_ids = string.(store.attrs["Receiving"])
+        sink_ids = string.(store.attrs["Sink"])
         conn_set = NamedDimsArray(
             store[:, :];
-            zip(dim_names, [source_ids, recieving_ids])...
+            zip(dim_names, [source_ids, sink_ids])...
         )
 
         conn_d[rcp_dirs[i]] = conn_set
@@ -625,7 +625,7 @@ function load_results(result_loc::String)::ResultSet
         msg = """Results were produced with a different version of ADRIA ($(r_vers_id)).
         The version of ADRIA in use is $(t_vers_id).\n
         Errors may occur when analyzing data.
-        
+
         ADRIA v0.8 store results relative to absolute location area, where as v0.9+ now
         stores results relative to available area.
         """

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -69,7 +69,8 @@ end
     run_scenarios(dom::Domain, scens::DataFrame, RCP::Vector{String}; show_progress=true, remove_workers=true)
 
 Run scenarios defined by the parameter table storing results to disk.
-Scenarios are run in parallel where the number of scenarios > 256.
+Scenarios are run in parallel where the number of scenarios > 256 for base Domain data
+packages and > 4 for GBR-scale datasets.
 
 # Notes
 - Returned `Domain` holds scenario invoke time used as unique result set identifier.
@@ -130,7 +131,8 @@ function run_scenarios(
         factors=names(scenarios_df)
     )
 
-    parallel = (nrow(scens) >= 256) && (parse(Bool, ENV["ADRIA_DEBUG"]) == false)
+    para_threshold = typeof(dom) == ReefModDomain ? 8 : 256
+    parallel = (parse(Bool, ENV["ADRIA_DEBUG"]) == false) && (nrow(scens) >= para_threshold)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin


### PR DESCRIPTION
Previous implementation was erroneously looping over all size classes for all functional groups, skipping only size classes 1 and 2 for the first functional group.

We now loop over all non-juvenile size classes for all functional groups as expected.