### PR TITLE
Only load up relevant RME SSP datasets

### DIFF
--- a/src/ExtInterface/ReefMod/Domain.jl
+++ b/src/ExtInterface/ReefMod/Domain.jl
@@ -203,6 +203,7 @@ function load_DHW(
 )::NamedDimsArray
     dhw_path = joinpath(data_path, "dhw")
     rcp_files = _get_relevant_files(dhw_path, rcp)
+    rcp_files = filter(x -> occursin("SSP", x), rcp_files)
     if isempty(rcp_files)
         ArgumentError("No DHW data files found in: $(dhw_path)")
     end


### PR DESCRIPTION
ReefModDomain type loads up DHW datasets by pattern matching the relevant RCP code ("26", "45", "85", etc).

The RME dataset includes a file that holds historic data from 1985, which inadvertently gets included in the file list.

This change avoids this situation by also requiring the identified files have an "SSP" prefix.