### PR TITLE
Clean up scenario running methods

### DIFF
--- a/docs/src/usage/scenario_generation.md
+++ b/docs/src/usage/scenario_generation.md
@@ -128,16 +128,16 @@ dom = ADRIA.load_domain()
 
 # Adjust seeding bounds. Note only lower and upper bounds are needed because the factors in
 # question have a uniform distribution.
-ADRIA.set_factor_bounds!(dom, :N_seed_TA, (500000.0, 1000000.0))
-ADRIA.set_factor_bounds!(dom, :N_seed_CA, (500000.0, 1000000.0))
-ADRIA.set_factor_bounds!(dom, :N_seed_SA, (500000.0, 1000000.0))
+dom = ADRIA.set_factor_bounds(dom, :N_seed_TA, (500000.0, 1000000.0))
+dom = ADRIA.set_factor_bounds(dom, :N_seed_CA, (500000.0, 1000000.0))
+dom = ADRIA.set_factor_bounds(dom, :N_seed_SA, (500000.0, 1000000.0))
 
 # Adjust fogging bounds. Note lower, upper and mode parameters are needed because it
 # is a triangular distribution.
-ADRIA.set_factor_bounds!(dom, :fogging, (0.2, 0.3, 0.1))
+dom = ADRIA.set_factor_bounds(dom, :fogging, (0.2, 0.3, 0.1))
 
 # Adjust multiple factors simultaneously.
-ADRIA.set_factor_bounds!(dom;
+dom = ADRIA.set_factor_bounds(dom;
     heat_stress=(0.3, 0.7),
     N_seed_TA=(500000.0, 1000000.0),
     N_seed_CA=(500000.0, 1000000.0))

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -483,7 +483,7 @@ must be a 2-element Tuple, with `(new_lower, new_upper)` values.
 set_factor_bounds!(dom, :wave_stress, (0.1, 0.2))
 ```
 """
-function set_factor_bounds!(dom::Domain, factor::Symbol, new_bounds::Tuple)::Nothing
+function set_factor_bounds(dom::Domain, factor::Symbol, new_bounds::Tuple)::Domain
     _check_bounds_range(dom, factor, new_bounds)
 
     new_bounds, new_val = if _is_discrete_factor(dom, factor)
@@ -496,16 +496,16 @@ function set_factor_bounds!(dom::Domain, factor::Symbol, new_bounds::Tuple)::Not
     params[params.fieldname .== factor, :dist_params] .= [new_bounds]
     params[params.fieldname .== factor, :val] .= new_val
 
-    update!(dom, params)
+    dom = update!(dom, params)
 
-    return nothing
+    return dom
 end
-function set_factor_bounds!(d::Domain; factors...)::Nothing
+function set_factor_bounds(dom::Domain; factors...)::Domain
     for (factor, bounds) in factors
-        set_factor_bounds!(d, factor, bounds)
+        dom = set_factor_bounds(dom, factor, bounds)
     end
 
-    return nothing
+    return dom
 end
 
 function _continuous_bounds(dom::Domain, factor::Symbol, new_bounds::Tuple)::Tuple
@@ -545,10 +545,10 @@ function _check_bounds_range(dom::Domain, factor::Symbol, new_bounds::Tuple)::No
         )
     end
 
-    if (_distribution_type(dom, factor) == "triang") && (length(new_bounds) !== 3)
-        error("Triangular dist requires three parameters (minimum, maximum, peak).")
-    elseif (_distribution_type(dom, factor) == "unif") && (length(new_bounds) !== 2)
-        error("Uniform dist requires two parameters (minimum, maximum).")
+    if contains(string(_distribution_type(dom, factor)), "Triang") && (length(new_bounds) !== 3)
+        error("Triangular type distributions requires three parameters (minimum, maximum, peak).")
+    elseif contains(string(_distribution_type(dom, factor)), "Unif") && (length(new_bounds) !== 2)
+        error("Uniform distributions requires two parameters (minimum, maximum).")
     end
 
     return nothing

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -460,8 +460,8 @@ function get_default_dist_params(dom::Domain, factor::Symbol)::Tuple
 end
 
 """
-    set_factor_bounds!(dom::Domain, factor::Symbol, new_bounds::Tuple)::Nothing
-    set_factor_bounds!(dom::Domain; factors...)::Nothing
+    set_factor_bounds(dom::Domain, factor::Symbol, new_bounds::Tuple)::Nothing
+    set_factor_bounds(dom::Domain; factors...)::Nothing
 
 Set new bound values for a given parameter. Sampled values for a parameter will lie
 within the range `lower_bound ≤ s ≤ upper_bound`, for every sample value `s`.
@@ -480,7 +480,7 @@ must be a 2-element Tuple, with `(new_lower, new_upper)` values.
 
 # Examples
 ```julia
-set_factor_bounds!(dom, :wave_stress, (0.1, 0.2))
+set_factor_bounds(dom, :wave_stress, (0.1, 0.2))
 ```
 """
 function set_factor_bounds(dom::Domain, factor::Symbol, new_bounds::Tuple)::Domain
@@ -496,7 +496,7 @@ function set_factor_bounds(dom::Domain, factor::Symbol, new_bounds::Tuple)::Doma
     params[params.fieldname .== factor, :dist_params] .= [new_bounds]
     params[params.fieldname .== factor, :val] .= new_val
 
-    dom = update!(dom, params)
+    update!(dom, params)
 
     return dom
 end
@@ -536,14 +536,6 @@ Check new parameter bounds are within default parameter bounds
 function _check_bounds_range(dom::Domain, factor::Symbol, new_bounds::Tuple)::Nothing
     default_lower, default_upper = get_default_dist_params(dom, factor)
     new_lower, new_upper = new_bounds
-
-    # Check if new bounds are within the default range
-    out_of_bounds::Bool = (new_lower < default_lower) || (new_upper > default_upper)
-    if out_of_bounds
-        error(
-            "Bounds should be within ($default_lower, $default_upper), received: ($new_lower, $new_upper).",
-        )
-    end
 
     if contains(string(_distribution_type(dom, factor)), "Triang") && (length(new_bounds) !== 3)
         error("Triangular type distributions requires three parameters (minimum, maximum, peak).")

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -337,9 +337,9 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
 end
 
 """
-    fix_factor(d::Domain, factor::Symbol)
-    fix_factor(d::Domain, factor::Symbol, val::Real)
-    fix_factor(d::Domain, factors...)
+    fix_factor!(d::Domain, factor::Symbol)
+    fix_factor!(d::Domain, factor::Symbol, val::Real)
+    fix_factor!(d::Domain, factors...)
 
 Fix a factor so it gets ignored for the purpose of constructing samples.
 If no value is provided, the default is used.

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -584,6 +584,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray)::NamedTuple
 
         # Reset potential settlers to zero
         potential_settlers .= 0.0
+        recruitment .= 0.0
 
         # Recruitment represents additional cover, relative to total site area
         # Recruitment/settlement occurs after the full moon in October/November
@@ -608,7 +609,7 @@ function run_model(domain::Domain, param_set::NamedDimsArray)::NamedTuple
         )
 
         # Add recruits to current cover
-        C_t[p.small, :] .+= recruitment
+        C_t[p.small, :] .= recruitment
 
         # Check whether current timestep is in deployment period for each intervention
         in_fog_timeframe = fog_start_year <= tstep <= (fog_start_year + fog_years - 1)

--- a/test/Ecosystem.jl
+++ b/test/Ecosystem.jl
@@ -6,7 +6,7 @@ using ADRIA.Random
 @testset "Truncated normal mean" begin
     n_checks = 1000
     mean_diffs::Vector{Float64} = zeros(n_checks)
-    
+
     # The truncted normal mean should agree with the normal mean for symmetrical bound about mean
     for i in 1:n_checks
         mu = rand(Uniform(0, 10))
@@ -37,7 +37,7 @@ using ADRIA.Random
         expected = mean(truncated(Normal(mu, stdev), lb, ub))
         mean_diffs[i] = abs(expected - calculated)
     end
-    
+
     @test all(mean_diffs .< 1e-7) ||
         "calculated truncated normal mean differs signficantly from Distributions.jl"
 end
@@ -45,7 +45,7 @@ end
 @testset "Truncated normal cdf" begin
     n_checks::Int = 1000
     cdf_diffs::Vector{Float64} = zeros(3 * n_checks)
-    
+
     # The truncated normal cdf should return 0.0, 0.5, and 1.0 when evaluated at the lower
     # bound, median and upper bound respectively.
     for i in 1:n_checks
@@ -71,14 +71,14 @@ end
         "truncated normal cdf not equal to 0.0, 0.5, 1.0 at lower bound, mean, upper bound"
 
     n_checks = 3000
-   
+
     # The truncated normal cdf should agree with the Distributions.jl implementation
     for i in 1:n_checks
         mu = rand(Uniform(0, 10))
         stdev = rand(Uniform(0.01, 10))
         lb = rand(Uniform(mu - stdev * 10, mu + stdev * 5))
         ub = rand(Uniform(lb, lb + stdev * 5))
-    
+
         x = rand(Uniform(lb, ub))
 
         calculated = ADRIA.truncated_normal_cdf(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,7 +273,7 @@ function test_rs_w_fig()
     scenarios_iv = scens[:, fields_iv]
 
     # Use SIRUS algorithm to extract rules
-    max_rules = 10
+    max_rules = 4
     rules_iv = ADRIA.analysis.cluster_rules(target_clusters, scenarios_iv, max_rules)
 
     # Plot scatters for each rule highlighting the area selected them

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -181,7 +181,7 @@ end
 
         @testset "Continuous factor is sampled within specified range" begin
             bnds = rand(2)
-            ADRIA.set_factor_bounds!(
+            dom = ADRIA.set_factor_bounds(
                 dom, :deployed_coral_risk_tol, (minimum(bnds), maximum(bnds))
             )
             scens = ADRIA.sample_guided(dom, num_samples)
@@ -193,7 +193,7 @@ end
 
         @testset "Discrete factor is sampled within specified range and is discrete" begin
             bnds = rand(0.0:1000000.0, 2)
-            ADRIA.set_factor_bounds!(dom, :N_seed_TA, (minimum(bnds), maximum(bnds)))
+            dom = ADRIA.set_factor_bounds(dom, :N_seed_TA, (minimum(bnds), maximum(bnds)))
             scens = ADRIA.sample_site_selection(dom, num_samples)
             @test (maximum(scens[:, "N_seed_TA"]) <= maximum(bnds)) ||
                 "Sampled discrete factor is outside of specified new bounds."
@@ -217,7 +217,7 @@ end
 
             @testset "New and old bounds are the same" begin
                 new_bounds = ADRIA.get_default_dist_params(dom, discrete_factor_name)
-                ADRIA.set_factor_bounds!(dom, discrete_factor_name, new_bounds)
+                dom = ADRIA.set_factor_bounds(dom, discrete_factor_name, new_bounds)
 
                 factor_params = dom.model[ms.fieldname .== discrete_factor_name][1]
                 @test factor_params.dist_params[1] == factor_params.default_dist_params[1]


### PR DESCRIPTION
Clean up model run process for simplicity and conceptual validity.

Removes deprecated interface functions as well.

Addresses issue with NaN poisoning. 
RME datasets where empty wave datasets inadvertently resolves to NaN (due to max normalization with 0 values).
This has a flow-on effect to DHWs, resulting in DHW data being NaNs as well.

I've also corrected `set_factor_bounds!()` as it implies an in-place update will occur but this is only true if the function is called directly from the "main"/top-level module. If called from within another function, the updated `Domain` is not returned.
