### PR TITLE
Truncated normal changes

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -48,6 +48,62 @@ function EnvironmentalLayer(
 end
 
 """
+    rational_erf(x::Float64)::Float64
+
+Rational approximation of the error function only using elementary functions [1].
+Maximum error of 1.5 × 10^{-7}.
+
+# References
+1. Abramowitz, Milton; Stegun, Irene Ann, eds. (1983) [June 1964]. "Chapter 7". 
+   Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical Tables. 
+   Applied Mathematics Series. Vol. 55 (Ninth reprint with additional corrections of 
+   tenth original printing with corrections (December 1972); first ed.). Washington D.C.; 
+   New York: United States Department of Commerce, National Bureau of Standards; 
+   Dover Publications. p. 297
+"""
+function rational_erf(x::Float64)::Float64
+    coef::Float64 = 1.0
+    if (x < 0)
+        x *= -1
+        coef = -1
+    end
+
+    # Use multiplication to avoid slow power function (x^n)
+    x2::Float64 = x * x
+    x3::Float64 = x2 * x
+    x4::Float64 = x3 * x
+    x5::Float64 = x4 * x
+    x6::Float64 = x5 * x
+
+    a1::Float64 = 0.0705230784
+    a2::Float64 = 0.0422820123
+    a3::Float64 = 0.0092705272
+    a4::Float64 = 0.0001520143
+    a5::Float64 = 0.0002765672
+    a6::Float64 = 0.0000430638
+
+    denom = 1.0 + a1 * x + a2 * x2 + a3 * x3 + a4 * x4 + a5 * x5 + a6 * x6
+
+    denom = denom * denom # power 2
+    denom = denom * denom # power 4
+    denom = denom * denom # power 8
+    denom = denom * denom # power 16
+
+    return coef * (1 - 1.0 / denom)
+end
+
+"""
+    rational_erfcx(x::Float64)::Float64
+
+Approximation of erfcx using a rational approximation of the error function. 
+
+erfcx(x) = e^{x^2} ⋅ (1 - erf(x))
+"""
+function rational_erfcx(x::Float64)::Float64
+    return exp(x * x) * (1 - erf(x))
+end
+
+"""
     truncated_standard_normal_mean(lb::Float64, ub::Float64)::Float64
 
 Calculates the mean of the truncated standard normal distribution. Implementation taken
@@ -81,9 +137,9 @@ function truncated_standard_normal_mean(lb::Float64, ub::Float64)::Float64
 
     m = ub
     if lb ≤ 0 ≤ ub
-        m = expm1(-Δ) * exp(-lb^2 / 2) / erf(ub′, lb′)
+        m = expm1(-Δ) * exp(-lb^2 / 2) / (rational_erf(lb′) - rational_erf(ub′))# erf(ub′, lb′)
     elseif 0 < lb < ub
-        z = exp(-Δ) * erfcx(ub′) - erfcx(lb′)
+        z = exp(-Δ) * rational_erfcx(ub′) - rational_erfcx(lb′)
         iszero(z) && return mid
         m = expm1(-Δ) / z
     end
@@ -141,7 +197,6 @@ function truncated_normal_cdf(
     lower_bound::Float64,
     upper_bound::Float64
 )::Float64
-
     if x <= lower_bound
         return 0.0
     elseif x >= upper_bound
@@ -159,9 +214,9 @@ function truncated_normal_cdf(
             $(alpha) and $(beta) standard deviations from the normal mean respectively."
     end
 
-    logcdf::Float64 =
-        logerf(alpha * StatsFuns.invsqrt2, zeta * StatsFuns.invsqrt2) -
-        logerf(alpha * StatsFuns.invsqrt2, beta * StatsFuns.invsqrt2)
+    # Store error function of alpha to avoid calculating twice
+    erf_alpha = rational_erf(alpha * StatsFuns.invsqrt2)
 
-    return exp(logcdf)
+    return (rational_erf(zeta * StatsFuns.invsqrt2) - erf_alpha) /
+           (rational_erf(beta * StatsFuns.invsqrt2) - erf_alpha)
 end

--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -137,7 +137,7 @@ function truncated_standard_normal_mean(lb::Float64, ub::Float64)::Float64
 
     m = ub
     if lb ≤ 0 ≤ ub
-        m = expm1(-Δ) * exp(-lb^2 / 2) / (rational_erf(lb′) - rational_erf(ub′))# erf(ub′, lb′)
+        m = expm1(-Δ) * exp(-lb^2 / 2) / (rational_erf(lb′) - rational_erf(ub′))
     elseif 0 < lb < ub
         z = exp(-Δ) * rational_erfcx(ub′) - rational_erfcx(lb′)
         iszero(z) && return mid

--- a/test/Ecosystem.jl
+++ b/test/Ecosystem.jl
@@ -28,8 +28,8 @@ using ADRIA.Random
     for i in 1:n_checks
         mu = rand(Uniform(0, 10))
         stdev = rand(Uniform(0.01, 10))
-        lb = rand(Uniform(mu - 15 * stdev, mu + 15 * stdev))
-        ub = rand(Uniform(lb, lb + 15 * stdev))
+        lb = rand(Uniform(mu - 6.0 * stdev, mu + 3.0 * stdev))
+        ub = rand(Uniform(lb, lb + 3.0 * stdev))
         
         calculated = ADRIA.truncated_normal_mean(
             mu, stdev, lb, ub
@@ -38,7 +38,7 @@ using ADRIA.Random
         mean_diffs[i] = abs(expected - calculated)
     end
 
-    @test all(mean_diffs .< 1e-7) ||
+    @test all(mean_diffs .< 1e-4) ||
         "calculated truncated normal mean differs signficantly from Distributions.jl"
 end
 
@@ -76,8 +76,8 @@ end
     for i in 1:n_checks
         mu = rand(Uniform(0, 10))
         stdev = rand(Uniform(0.01, 10))
-        lb = rand(Uniform(mu - stdev * 10, mu + stdev * 5))
-        ub = rand(Uniform(lb, lb + stdev * 5))
+        lb = rand(Uniform(mu - stdev * 6.0, mu + stdev * 3.0))
+        ub = rand(Uniform(lb, lb + stdev * 3.0))
 
         x = rand(Uniform(lb, ub))
 
@@ -88,8 +88,12 @@ end
             truncated(Normal(mu, stdev), lb, ub), x
         )
         cdf_diffs[i] = abs(expected - calculated)
+        if (cdf_diffs[i] > 1e-4)
+            println("diff: $(cdf_diffs[i])")
+            println("mu: $(mu), stdev: $(stdev), lb: $(lb), ub: $(ub)")
+        end
     end
 
-    @test all(cdf_diffs .< 1e-7) ||
+    @test all(cdf_diffs .< 1e-4) ||
         "Implemented truncated normal cdf differs significantly from built-in cdf"
 end


### PR DESCRIPTION
Added truncated normal changes to speedup calculation of truncated normal mean and cdf.

The test cases are more relaxed to account for the loss of accuracy resulting from the approximation. 

The if statement warning about accuracy is now more specific in what it detects requiring both truncated bounds be on the same side of the mean as this was the source of cancellation errors. During the test runs done bellow, the warning was not encoutnered

The following plot is **without changes** contained in this pull request.
<img width="604" alt="no_changes_plot" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/3491af6a-4d70-4898-b765-b9be85f6179a">

The following plot is **with changes** contained in this pull request.
<img width="608" alt="with_changes_plot" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/f7175771-8d19-42e6-8c34-c17122eab194">

closes #572 
