### PR TITLE
Allow user to set whatever bounds they wish

### DIFF
--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -57,7 +57,7 @@ function _check_has_required_info(kwargs::NT) where {NT <: NamedTuple}
     @assert haskey(kwargs, :description) "Missing factor field `description`"
 
     param_dist_types = [
-        "continuous", "ordered categorical", "unordered categorical", "discrete"
+        "continuous", "ordered categorical", "unordered categorical", "ordered discrete", "discrete"
     ]
     @assert any(occursin.(kwargs[:ptype], param_dist_types)) "`ptype` field is not one of $(param_dist_types)"
 end

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -1,7 +1,7 @@
-Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
+Base.@kwdef struct Intervention <: EcoModel
     # Intervention Factors
     # Bounds are defined as floats to maintain type stability
-    guided::DU = Factor(
+    guided::Param = Factor(
         0;
         ptype="unordered categorical",
         dist=DiscreteUniform,
@@ -9,7 +9,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Guided",
         description="Choice of MCDA approach.",
     )
-    N_seed_TA::DU = Factor(
+    N_seed_TA::Param = Factor(
         0;
         ptype="ordered discrete",
         dist=DiscreteOrderedUniformDist,
@@ -17,7 +17,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Seeded Tabular Acropora",
         description="Number of Tabular Acropora to seed per deployment year.",
     )
-    N_seed_CA::DU = Factor(
+    N_seed_CA::Param = Factor(
         0;
         ptype="ordered discrete",
         dist=DiscreteOrderedUniformDist,
@@ -25,7 +25,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Seeded Corymbose Acropora",
         description="Number of Corymbose Acropora to seed per deployment year.",
     )
-    N_seed_SM::DU = Factor(
+    N_seed_SM::Param = Factor(
         0;
         ptype="ordered discrete",
         dist=DiscreteOrderedUniformDist,
@@ -33,7 +33,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Seeded Small Massives",
         description="Number of small massives/encrusting to seed per deployment year.",
     )
-    fogging::T = Factor(
+    fogging::Param = Factor(
         0.16;
         ptype="continuous",
         dist=TriangularDist,
@@ -41,7 +41,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Fogging",
         description="Assumed reduction in bleaching mortality.",
     )
-    SRM::T = Factor(
+    SRM::Param = Factor(
         0.0;
         ptype="continuous",
         dist=TriangularDist,
@@ -49,7 +49,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="SRM",
         description="Reduction in DHWs due to shading.",
     )
-    a_adapt::T = Factor(
+    a_adapt::Param = Factor(
         0.0;
         ptype="continuous",
         dist=TriangularDist,
@@ -57,7 +57,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Assisted Adaptation",
         description="Assisted adaptation in terms of DHW resistance.",
     )
-    seed_years::DT = Factor(
+    seed_years::Param = Factor(
         10;
         ptype="ordered categorical",
         dist=DiscreteTriangularDist,
@@ -65,7 +65,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Years to Seed",
         description="Number of years to seed for.",
     )
-    shade_years::DT = Factor(
+    shade_years::Param = Factor(
         10;
         ptype="ordered categorical",
         dist=DiscreteTriangularDist,
@@ -73,7 +73,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Years to Shade",
         description="Number of years to shade for.",
     )
-    fog_years::DT = Factor(
+    fog_years::Param = Factor(
         10;
         ptype="ordered categorical",
         dist=DiscreteTriangularDist,
@@ -81,7 +81,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Years to fog",
         description="Number of years to fog for.",
     )
-    plan_horizon::DU = Factor(
+    plan_horizon::Param = Factor(
         5;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -89,7 +89,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Planning Horizon",
         description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current deployment year).",
     )
-    seed_freq::DU = Factor(
+    seed_freq::Param = Factor(
         5;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -97,7 +97,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Seeding Frequency",
         description="Frequency of seeding site selection (0 is set and forget).",
     )
-    shade_freq::DU = Factor(
+    shade_freq::Param = Factor(
         1;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -105,7 +105,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Shading Frequency",
         description="Frequency of shading site selection (0 is set and forget).",
     )
-    fog_freq::DU = Factor(
+    fog_freq::Param = Factor(
         1;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -113,7 +113,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Fogging Frequency",
         description="Frequency of fogging site selection (0 is set and forget).",
     )
-    seed_year_start::DU = Factor(
+    seed_year_start::Param = Factor(
         2;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -121,7 +121,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Seeding Start Year",
         description="Start seeding deployments after this number of years has elapsed.",
     )
-    shade_year_start::DU = Factor(
+    shade_year_start::Param = Factor(
         2;
         ptype="ordered categorical",
         dist=DiscreteUniform,
@@ -129,7 +129,7 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
         name="Shading Start Year",
         description="Start of shading deployments after this number of years has elapsed.",
     )
-    fog_year_start::DU = Factor(
+    fog_year_start::Param = Factor(
         2;
         ptype="ordered categorical",
         dist=DiscreteUniform,

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -11,25 +11,25 @@ Base.@kwdef struct Intervention{DU,T,DT} <: EcoModel
     )
     N_seed_TA::DU = Factor(
         0;
-        ptype="ordered categorical",
-        dist=DiscreteUniform,
-        dist_params=(0.0, 1000000.0),
+        ptype="ordered discrete",
+        dist=DiscreteOrderedUniformDist,
+        dist_params=(0.0, 1000000.0, 50000.0),  # increase in steps of 50K
         name="Seeded Tabular Acropora",
         description="Number of Tabular Acropora to seed per deployment year.",
     )
     N_seed_CA::DU = Factor(
         0;
-        ptype="ordered categorical",
-        dist=DiscreteUniform,
-        dist_params=(0.0, 1000000.0),
+        ptype="ordered discrete",
+        dist=DiscreteOrderedUniformDist,
+        dist_params=(0.0, 1000000.0, 50000.0),  # increase in steps of 50K
         name="Seeded Corymbose Acropora",
         description="Number of Corymbose Acropora to seed per deployment year.",
     )
     N_seed_SM::DU = Factor(
         0;
-        ptype="ordered categorical",
-        dist=DiscreteUniform,
-        dist_params=(0.0, 1000000.0),
+        ptype="ordered discrete",
+        dist=DiscreteOrderedUniformDist,
+        dist_params=(0.0, 1000000.0, 50000.0),  # increase in steps of 50K
         name="Seeded Small Massives",
         description="Number of small massives/encrusting to seed per deployment year.",
     )

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -127,7 +127,7 @@ end
             string.(
                 ADRIA.component_params(
                     ms,
-                    [ADRIA.EnvironmentalLayer, ADRIA.Intervention, ADRIA.CriteriaWeights],
+                    [ADRIA.EnvironmentalLayer, ADRIA.Intervention, ADRIA.CriteriaWeights]
                 ).fieldname
             )
 
@@ -228,6 +228,18 @@ end
                 @test (maximum(discrete_factor_scens) <= maximum(new_bounds))
                 @test (minimum(discrete_factor_scens) >= minimum(new_bounds))
                 @test all(mod.(discrete_factor_scens, 1.0) .== 0.0)
+            end
+
+            @testset "Set distribution bounds with new step sizes or peaks" begin
+                # The below should not raise an error
+                dom = ADRIA.set_factor_bounds(
+                    dom;
+                    N_seed_TA=(Int(1e6), Int(5e10), Int(1e6)),
+                    N_seed_CA=(Int(1e6), Int(5e10), Int(1e6)),
+                    N_seed_SM=(Int(1e6), Int(5e10), Int(1e6)),
+                    a_adapt=(0.0, 30.0, 0.0),
+                    seed_freq=(1, 5)
+                )
             end
         end
     end


### PR DESCRIPTION
Recently, when trying to do some scenario runs to sweep through larger factor bounds, I ran into an issue where certain distributions cannot be set.

This PR allows the user to set whatever bounds they wish, so long as they specify the necessary distribution parameters.

Factor types and their expected parameters are:

- `DiscreteOrderedUniformDist` : `(min, max, step)`, 
- `TriangularDist` : `(min, max, peak)`


```julia
dom = ADRIA.load_domain(some_domain)
dom = ADRIA.set_factor_bounds(
    dom,
    N_seed_TA=(Int(1e6), Int(5e10), Int(1e6)),
    N_seed_CA=(Int(1e6), Int(5e10), Int(1e6)),
    N_seed_SM=(Int(1e6), Int(5e10), Int(1e6)),
    a_adapt=(0.0, 30.0, 0.0),
    seed_freq=(1, 5)
)
```