### PR TITLE
Update support for standalone MCDA use

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -59,12 +59,13 @@ include("ecosystem/corals/Corals.jl")
 include("ecosystem/connectivity.jl")
 
 include("Domain.jl")
+include("io/inputs.jl")  # Need to define input types before MCDA to make types available
+
 include("decision/dMCDA.jl")
 include("interventions/Interventions.jl")
 include("interventions/seeding.jl")
 include("interventions/fogging.jl")
 
-include("io/inputs.jl")
 include("io/ResultSet.jl")
 include("io/result_io.jl")
 include("io/result_post_processing.jl")
@@ -136,7 +137,7 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     Base.precompile(Tuple{typeof(bleaching_mortality!),Matrix{Float64},Matrix{Float64},Vector{Float64},Int64,Vector{Float64},Vector{Float64},Vector{Float64},Vector{Float64},Float64})   # time: 0.1940948
     Base.precompile(
         Tuple{
-            typeof(decision.create_decision_matrix),
+            typeof(decision.decision_matrix),
             Vector{Int64},
             Vector{Float64},
             Vector{Float64},

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -230,7 +230,7 @@ function pawn(
     S::Int64=10
 )::YAXArray
     # YAXrrays will raise an error if any of the masked boolean indexing in pawn is empty so
-    # vec(y) is required 
+    # vec(y) is required
 return pawn(X, vec(y), collect(X.axes[2]); S=S)
 end
 function pawn(

--- a/src/decision/Criteria/DecisionPreferences.jl
+++ b/src/decision/Criteria/DecisionPreferences.jl
@@ -1,12 +1,12 @@
 using StatsBase
-using NamedDims, YAXArrays
+using YAXArrays
 import YAXArrays.DD: At
 using ADRIA: Factor, DiscreteOrderedUniformDist, component_params
 
 abstract type DecisionPreference end
 
 struct DecisionPreferences <: DecisionPreference
-    names::Vector{Union{String,Symbol}}
+    names::Vector{Symbol}
     weights::Vector{Float64}
     directions::Vector{Function}
 end
@@ -21,22 +21,14 @@ Construct a decision matrix.
 - `loc_names` : location names
 - `criteria_names` : name of criteria being considered
 - `criteria_vals` : values for each criteria
-- `kwargs` : Preset criteria values by their names
+- `kwargs` : Preset criteria values by their names (with prefix removed)
 """
 function decision_matrix(
     loc_names::Vector{T},
     criteria_names::Vector{T2},
     criteria_vals::Matrix
 )::YAXArray where {T<:Union{String,Symbol},T2<:Union{String,Symbol}}
-    axlist = (
-        Dim{:location}(loc_names),
-        Dim{:criteria}(criteria_names),
-    )
-
-    return YAXArray(
-        axlist,
-        criteria_vals,
-    )
+    return DataCube(criteria_vals; location=loc_names, criteria=criteria_names)
 end
 function decision_matrix(
     loc_names::Vector{T},
@@ -73,7 +65,7 @@ function update_criteria_values!(dm::YAXArray, values::Matrix)::Nothing
 end
 function update_criteria_values!(dm::YAXArray; kwargs...)::Nothing
     for (criteria_name, value) in kwargs
-        dm[criteria=At(string(criteria_name))] .= value
+        dm[criteria=At(criteria_name)] .= value
     end
 
     return nothing

--- a/src/decision/Criteria/FogCriteria.jl
+++ b/src/decision/Criteria/FogCriteria.jl
@@ -93,6 +93,7 @@ function FogPreferences(
     dom, params::YAXArray
 )::DecisionPreferences
     w::DataFrame = component_params(dom.model, FogCriteriaWeights)
+    cn = Symbol[Symbol(join(split(string(cn), "_")[2:end], "_")) for cn in w.fieldname]
 
-    return DecisionPreferences(string.(w.fieldname), params[factors=At(string.(w.fieldname))], w.direction)
+    return DecisionPreferences(cn, params[factors=At(string.(w.fieldname))], w.direction)
 end

--- a/src/decision/Criteria/FogCriteria.jl
+++ b/src/decision/Criteria/FogCriteria.jl
@@ -83,13 +83,6 @@ end
 FogPreferences(names, criteria, directions) = DecisionPreferences(names, criteria, directions)
 
 function FogPreferences(
-    dom, params::NamedDimsArray
-)::DecisionPreferences
-    w::DataFrame = component_params(dom.model, FogCriteriaWeights)
-
-    return DecisionPreferences(string.(w.fieldname), params(string.(w.fieldname)), w.direction)
-end
-function FogPreferences(
     dom, params::YAXArray
 )::DecisionPreferences
     w::DataFrame = component_params(dom.model, FogCriteriaWeights)

--- a/src/decision/Criteria/SeedCriteria.jl
+++ b/src/decision/Criteria/SeedCriteria.jl
@@ -126,18 +126,21 @@ will relate to the position of the subset, not the canonical dataset.
 
 # Arguments
 - `sp` : SeedPreferences
-- `dm` : The decision matrix to assess
+- `dm` : The decision matrix to assess pertaining to the locations to be considered
 - `method` : MCDA method from JMcDM.jl
-- `cluster_ids` : Cluster membership for each considered location
+- `cluster_ids` : Cluster membership for *all* locations
 - `area_to_seed` : total area to be seeded in absolute units (n_corals * mean juvenile area)
-- `available_space` : available space for each location in absolute units (e.g., m²)
+- `available_space` : available space for *all* location in absolute units (e.g., m²)
 - `min_locs` : Minimum number of locations to consider
 - `max_members` : Maximum number of deployment locations per cluster
 
 # Example
 ```julia
 sp = SeedPreferences(rand(5), [minimum, maximum, maximum, minimum, minimum])
-dmat = build_decision_matrix([:DHW, :water_quality, :CoTS, :Conn_1, :Conn_2], Symbol.(collect(1:10)))
+
+location_names = Symbol.(collect(1:10))
+criteria_names = [:DHW, :water_quality, :CoTS, :Conn_1, :Conn_2]
+dm = decision_matrix(location_names, criteria_names)
 cluster_ids = [1,4,4,4,4,3,6,2,5,5,6]
 select_locations(sp, dmat, topsis, cluster_ids, sort(rand(10), rev=false), 3.0, 5, 2)
 ```

--- a/src/decision/Criteria/SeedCriteria.jl
+++ b/src/decision/Criteria/SeedCriteria.jl
@@ -91,16 +91,7 @@ struct SeedPreferences <: DecisionPreference
     directions::Vector{Function}
 end
 
-function SeedPreferences(
-    dom, params::NamedDimsArray
-)::SeedPreferences
-    w::DataFrame = component_params(dom.model, SeedCriteriaWeights)
-
-    return SeedPreferences(string.(w.fieldname), params(string.(w.fieldname)), w.direction)
-end
-function SeedPreferences(
-    dom, params::YAXArray
-)::SeedPreferences
+function SeedPreferences(dom, params::YAXArray)::SeedPreferences
     w::DataFrame = component_params(dom.model, SeedCriteriaWeights)
 
     return SeedPreferences(string.(w.fieldname), params[factors=At(string.(w.fieldname))], w.direction)

--- a/src/decision/Criteria/SeedCriteria.jl
+++ b/src/decision/Criteria/SeedCriteria.jl
@@ -86,15 +86,24 @@ Preference type specific for seeding interventions to allow seeding-specific rou
 be handled.
 """
 struct SeedPreferences <: DecisionPreference
-    names::Vector{Union{String,Symbol}}
+    names::Vector{Symbol}
     weights::Vector{Float64}
     directions::Vector{Function}
 end
 
 function SeedPreferences(dom, params::YAXArray)::SeedPreferences
     w::DataFrame = component_params(dom.model, SeedCriteriaWeights)
+    cn = Symbol[Symbol(join(split(string(cn), "_")[2:end], "_")) for cn in w.fieldname]
 
-    return SeedPreferences(string.(w.fieldname), params[factors=At(string.(w.fieldname))], w.direction)
+    return SeedPreferences(cn, params[factors=At(string.(w.fieldname))], w.direction)
+end
+function SeedPreferences(dom, params...)::SeedPreferences
+    w::DataFrame = component_params(dom.model, SeedCriteriaWeights)
+    for (k, v) in params
+        w[w.fieldname .== k, :val] .= v
+    end
+
+    return SeedPreferences(string.(w.fieldname), w.val, w.direction)
 end
 
 """

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -96,11 +96,12 @@ end
     within_depth_bounds(loc_depth::Vector{T}, depth_max::T, depth_min::T)::BitVector{T} where {T<:Float64}
 
 Determines whether a location is within the min/max depth bounds.
+Used to filter locations based on their depth for location selection.
+
 # Arguments
 - `loc_depth` : Depths of considered locations (typically the median depth)
 - `depth_max` : Maximum depth for each considered location
 - `depth_min` : Minimum depth for each considered location
-Used to filter locations based on their depth for location selection.
 
 # Returns
 BitVector, of logical indices indicating locations which satisfy the depth criteria.
@@ -108,6 +109,7 @@ BitVector, of logical indices indicating locations which satisfy the depth crite
 function within_depth_bounds(
     loc_depth::Vector{T}, depth_max::T, depth_min::T
 )::BitVector where {T<:Float64}
+    @assert depth_min <= depth_max "Minimum depth must be lower than maximum depth"
     return (loc_depth .<= depth_max) .& (loc_depth .>= depth_min)
 end
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -233,6 +233,7 @@ function aggregate_location_ranks(
     target_seed_locs=nothing,
     target_fog_locs=nothing,
 )::YAXArray
+    throw("Unimplemented")
     ranks = rank_locations(
         domain,
         n_corals,

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -356,3 +356,46 @@ function selection_score(
     selection_score = dropdims(sum(lowest_rank .- ranks; dims=dims); dims=dims[1])
     return selection_score ./ ((lowest_rank - 1) * prod([size(ranks, d) for d in dims]))
 end
+
+"""
+    selection_score(ranks::YAXArray{D,T,3,A}; iv_type::Symbol)
+
+Calculates score ∈ [0, 1], where 1 is the highest score possible, indicative of the relative
+desirability of each location.
+
+The score reflects the location ranking and frequency of attaining a high rank.
+
+# Example
+```julia
+ranks = ADRIA.decision.rank_locations(dom, n_corals, scens)
+
+# Identify locations that were most desirable for seeding over all scenarios
+seed_scores = ADRIA.decision.selection_score(ranks, :seed)
+
+# Identify locations that were most desirable for fogging over all scenarios
+fog_scores = ADRIA.decision.selection_score(ranks, :fog)
+
+# Selection scores can be assessed for a subset of scenarios, including a specific scenario
+ADRIA.decision.selection_score(ranks[scenarios=1:4], :seed)
+```
+
+# Arguments
+- `ranks` : Rankings of locations from `rank_locations()`
+- `iv_type` : The intervention type to assess
+
+# Returns
+Selection score
+"""
+function selection_score(
+    ranks::YAXArray,
+    iv_type::Symbol,
+)::YAXArray
+    lowest_rank = maximum(ranks)  # 1 is best rank, n_locs + 1 is worst rank
+
+    selection_score = dropdims(
+        sum(lowest_rank .- ranks, dims=:scenarios); dims=:scenarios
+    )[intervention=At(iv_type)]
+    selection_score = selection_score ./ ((lowest_rank - 1) * prod(size(ranks, :scenarios)))
+
+    return selection_score
+end

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -78,7 +78,7 @@ function rank_locations(
 
     # Set filtered locations as n_locs+1 for consistency with time dependent ranks
     ranks_store = DataCube(
-        fill(n_locs+1, n_locs, 2, nrow(scenarios));
+        fill(0.0, n_locs, 2, nrow(scenarios));
         locations=dom.site_ids,
         intervention=[:seed, :fog],
         scenarios=1:nrow(scenarios)

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -92,13 +92,21 @@ function rank_locations(
 
     seed_pref = SeedPreferences(dom, scens[1, :])
     fog_pref = FogPreferences(dom, scens[1, :])
+
+    α = 0.99
+
     site_data = dom.site_data
     coral_habitable_locs = site_data.k .> 0.0
     for (scen_idx, scen) in enumerate(eachrow(scens))
+        # Decisions should place more weight on environmental conditions
+        # closer to the decision point
+        plan_horizon = Int64(scen[At("plan_horizon")])
+        decay = α .^ (1:plan_horizon+1).^2
+
         min_depth = scen[factors=At("depth_min")].data[1]
-        depth_criteria::BitArray{1} = within_depth_bounds(
-            site_data.depth_med,
-            min_depth .+ scen[factors=At("depth_offset")].data[1],
+        depth_offset = scen[factors=At("depth_offset")].data[1]
+
+        depth_criteria = identify_within_depth_bounds(site_data.depth_med, min_depth, depth_offset)
             min_depth
         )
 

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -26,7 +26,12 @@ using ADRIA:
         target_fog_locs=nothing
     )::YAXArray
 
-Return location ranks for a given domain and scenarios.
+Determine location ranks for a given domain and intervention scenarios.
+Locations are ranked by order of their determined deployment suitability according to
+criteria weights. Values of 1 indicate highest rank.
+
+Interventions are assessed separately such that seeding locations are not influenced by
+fogging locations.
 
 # Arguments
 - `domain` : Domain dataset to assess

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -411,15 +411,28 @@ ADRIA.decision.selection_score(ranks[scenarios=1:4], :seed)
 Selection score
 """
 function selection_score(
-    ranks::YAXArray,
-    iv_type::Symbol,
-)::YAXArray
+    ranks::YAXArray{T, 3},
+    iv_type::Union{Symbol,Int64},
+)::YAXArray where {T<:Union{Int64, Float32, Float64}}
     lowest_rank = maximum(ranks)  # 1 is best rank, n_locs + 1 is worst rank
 
     selection_score = dropdims(
         sum(lowest_rank .- ranks, dims=:scenarios); dims=:scenarios
     )[intervention=At(iv_type)]
     selection_score = selection_score ./ ((lowest_rank - 1) * prod(size(ranks, :scenarios)))
+
+    return selection_score
+end
+function selection_score(
+    ranks::YAXArray{T, 4},
+    iv_type::Union{Symbol,Int64},
+)::YAXArray where {T<:Union{Int64, Float32, Float64}}
+    lowest_rank = maximum(ranks)  # 1 is best rank, n_locs + 1 is worst rank
+
+    selection_score = dropdims(
+        sum(lowest_rank .- ranks, dims=(:scenarios, :timesteps)); dims=(:timesteps, :scenarios)
+    )[intervention=At(iv_type)]
+    selection_score = selection_score ./ ((lowest_rank - 1) * prod([size(ranks, d) for d in [:scenarios, :timesteps]]))
 
     return selection_score
 end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -193,10 +193,10 @@ function sample(
 end
 
 """
-    sample_site_selection(d::Domain, n::Int64, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+    sample_selection(d::Domain, n::Int64, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
 
-Create guided samples of parameters relevant to site selection (EnvironmentalLayers, Intervention, ...).
-All other parameters are set to their default values.
+Create guided samples of factors relevant to location selection.
+Coral factors are set to their default values and are not perturbed or sampled.
 
 # Arguments
 - `d` : Domain.
@@ -206,7 +206,7 @@ All other parameters are set to their default values.
 # Returns
 Scenario specification
 """
-function sample_site_selection(d::Domain, n::Int64, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+function sample_selection(d::Domain, n::Int64, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
     subset_spec = component_params(
         d.model, [EnvironmentalLayer, Intervention, SeedCriteriaWeights, FogCriteriaWeights, DepthThresholds]
     )

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -499,7 +499,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         decision_mat = decision_matrix(
             domain.site_ids,
             seed_pref.names;
-            seed_depth=site_data.depth_med
+            depth=site_data.depth_med
         )
 
         # Unsure what to do with this because it is usually empty
@@ -629,17 +629,10 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         end
 
         if is_guided
-            # Recreate preferences, removing criteria that are constant for this timestep
-            is_const = Bool[length(x) == 1 for x in unique.(eachcol(decision_mat.data))]
-            valid_criteria = seed_pref.names[.!is_const]
-        end
-
-        if is_guided
             if fog_decision_years[tstep] && (fogging .> 0.0)
-                fp = filter_criteria(fog_pref, is_const)
                 selected_fog_ranks = select_locations(
-                    fp,
-                    decision_mat[criteria=At(valid_criteria)],
+                    fog_pref,
+                    decision_mat,
                     MCDA_approach,
                     min_iv_locs
                 )
@@ -688,10 +681,9 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
                 seed_out_connectivity=out_conn[considered_locs]
             )
 
-            sp = filter_criteria(seed_pref, is_const)
             selected_seed_ranks = select_locations(
-                sp,
-                decision_mat[criteria=At(valid_criteria)],
+                seed_pref,
+                decision_mat,
                 MCDA_approach,
                 site_data.cluster_id,
                 area_to_seed,

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -485,15 +485,9 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     # seed at a site
     area_to_seed = sum(seeded_area)
 
-    # Filter out sites outside of desired depth range
-    # Defaults to considering all sites if depth cannot be considered.
-    depth_criteria = BitVector(fill(true, n_locs))
-    if .!all(site_data.depth_med .== 0)
-        max_depth::Float64 = param_set[At("depth_min")] + param_set[At("depth_offset")]
-        depth_criteria::BitArray{1} = within_depth_bounds(
-            site_data.depth_med, max_depth, param_set[At("depth_min")]
-        )
-    end
+    depth_criteria = identify_within_depth_bounds(
+        site_data.depth_med, param_set[At("depth_min")], param_set[At("depth_offset")]
+    )
 
     coral_habitable_locs = site_data.k .> 0.0
     if is_guided

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -425,7 +425,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     # Lower values are higher importance/ranks.
     # Values of n_locs+1 indicate locations that were not considered in rankings.
     log_location_ranks = DataCube(
-        fill(n_locs + 1, tf, n_locs, 2);  # log seeding/fogging ranks
+        fill(0.0, tf, n_locs, 2);  # log seeding/fogging ranks
         timesteps=1:tf,
         locations=domain.site_ids,
         intervention=[:seed, :fog]

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -674,11 +674,11 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
             update_criteria_values!(
                 decision_mat;
-                seed_heat_stress=dhw_projection[considered_locs],
-                seed_wave_stress=wave_projection[considered_locs],
-                seed_coral_cover=loc_coral_cover[considered_locs],  # Coral cover relative to `k`
-                seed_in_connectivity=in_conn[considered_locs],  # area weighted connectivities for time `t`
-                seed_out_connectivity=out_conn[considered_locs]
+                heat_stress=dhw_projection[considered_locs],
+                wave_stress=wave_projection[considered_locs],
+                coral_cover=loc_coral_cover[considered_locs],  # Coral cover relative to `k`
+                in_connectivity=in_conn[considered_locs],  # area weighted connectivities for time `t`
+                out_connectivity=out_conn[considered_locs]
             )
 
             selected_seed_ranks = select_locations(

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -238,14 +238,11 @@ function run_scenario(
     vals[vals.<threshold] .= 0.0
     data_store.relative_cover[:, :, idx] .= vals
 
-    # This is temporary while we are migrating to YAXArray
-    scenario_nda::NamedDimsArray = yaxarray2nameddimsarray(scenario)
-
-    vals .= absolute_shelter_volume(rs_raw, site_k_area(domain), scenario_nda)
+    vals .= absolute_shelter_volume(rs_raw, site_k_area(domain), scenario)
     vals[vals.<threshold] .= 0.0
     data_store.absolute_shelter_volume[:, :, idx] .= vals
 
-    vals .= relative_shelter_volume(rs_raw, site_k_area(domain), scenario_nda)
+    vals .= relative_shelter_volume(rs_raw, site_k_area(domain), scenario)
     vals[vals.<threshold] .= 0.0
     data_store.relative_shelter_volume[:, :, idx] .= vals
 
@@ -369,7 +366,6 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
     tspan::Tuple = (0.0, 1.0)
     solver::Euler = Euler()
-    MCDA_approach::Int64 = param_set[At("guided")]
 
     # Environment variables are stored as strings, so convert to bool for use
     in_debug_mode = parse(Bool, ENV["ADRIA_DEBUG"]) == true

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -117,7 +117,7 @@ end
     @testset "Site selection sampling" begin
         dom = ADRIA.load_domain(TEST_DOMAIN_PATH)
         num_samples = 32
-        scens = ADRIA.sample_site_selection(dom, num_samples)
+        scens = ADRIA.sample_selection(dom, num_samples)
 
         @test all(scens.guided .> 0) || "Intervention or counterfactual scenarios found"
 
@@ -194,7 +194,7 @@ end
         @testset "Discrete factor is sampled within specified range and is discrete" begin
             bnds = rand(0.0:1000000.0, 2)
             dom = ADRIA.set_factor_bounds(dom, :N_seed_TA, (minimum(bnds), maximum(bnds)))
-            scens = ADRIA.sample_site_selection(dom, num_samples)
+            scens = ADRIA.sample_selection(dom, num_samples)
             @test (maximum(scens[:, "N_seed_TA"]) <= maximum(bnds)) ||
                 "Sampled discrete factor is outside of specified new bounds."
             @test (minimum(scens[:, "N_seed_TA"]) >= minimum(bnds)) ||
@@ -223,7 +223,7 @@ end
                 @test factor_params.dist_params[1] == factor_params.default_dist_params[1]
                 @test factor_params.dist_params[2] == factor_params.default_dist_params[2]
 
-                scens = ADRIA.sample_site_selection(dom, num_samples)
+                scens = ADRIA.sample_selection(dom, num_samples)
                 discrete_factor_scens = scens[:, string(discrete_factor_name)]
                 @test (maximum(discrete_factor_scens) <= maximum(new_bounds))
                 @test (minimum(discrete_factor_scens) >= minimum(new_bounds))

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -75,7 +75,7 @@ end
 @testset "Guided site selection without ADRIA ecological model" begin
     dom = ADRIA.load_domain(TEST_DOMAIN_PATH, 45)
     N = 2^3
-    scens = ADRIA.sample_site_selection(dom, N)  # get scenario dataframe
+    scens = ADRIA.sample_selection(dom, N)  # get scenario dataframe
 
     area_to_seed = 962.11  # Area of seeded corals in m^2.
 


### PR DESCRIPTION
Changes to allow standalone use of MCDA.

This was the original usage for standalone assessment:

```julia
using ADRIA

dom = ADRIA.load_domain("path to domain", "45")
scens = ADRIA.sample_site_selection(dom, 8)

# Area of seeded corals in m^2
area_to_seed = 962.11

# Initial coral cover matching number of criteria samples (size = (no. criteria scens, no. of sites)).
sum_cover = repeat(sum(dom.init_coral_cover; dims=1), size(scens, 1))

# Use rank_locations to get ranks
ranks = ADRIA.decision.rank_locations(dom, scens, sum_cover, area_to_seed)

# Get measure of magnitude and frequency of selection and a high rank
sel_score = ADRIA.decision.selection_score(ranks[intervention=1])

# With scenario runs
scens = ADRIA.sample(dom, 8)
rs = ADRIA.run_scenarios(dom, scens, "45")

sel_score = selection_score(rs.ranks[intervention=1])
```

Note the user is expected to determine the area to be seeded and manually create initial cover data.
Note also the use of indices to specify dimensions

This is the new usage:

```julia
using ADRIA

dom = ADRIA.load_domain("path to domain", "45")
scens = ADRIA.sample_selection(dom, 8)

# Use rank_locations to get ranks
n_corals = 1_000_000  # number of corals to deploy
ranks = ADRIA.decision.rank_locations(dom, n_corals, scens)
scores = ADRIA.decision.selection_score(ranks, :seed)

# With scenario runs
scens = ADRIA.sample(dom, 16)
rs = ADRIA.run_scenarios(dom, scens, "45")

# Have to use index number for now until YAXArray migration is complete
# This currently returns the aggregate score across all time steps.
sel_score = ADRIA.decision.selection_score(rs.ranks, 1)

# Analysis includes the time dimension by default where scenario runs are being assessed
# such that the score for each location is returned
rs = ADRIA.scenario_runs(dom, scens, "45")
ADRIA.decision.selection_score(rs.ranks, 1; keep_time=false)
# 216-element YAXArray{Float32,1} with dimensions:
#   Dim{:sites} Sampled{Int64} 1:216 ForwardOrdered Regular Points
# Total size: 864.0 bytes

# Change to true to keep the time dimension (to get the score per time step)
ADRIA.decision.selection_score(rs.ranks, 1; keep_time=true)
# 75×216 YAXArray{Float32,2} with dimensions:
#   Dim{:timesteps} Sampled{Int64} 1:75 ForwardOrdered Regular Points,
#   Dim{:sites} Sampled{Int64} 1:216 ForwardOrdered Regular Points
# Total size: 63.28 KB
```

Further changes to update assessment methods are incoming.

The MCDA processes inside the standalone and scenario runs are still separate. They use the same underlying methods to a larger degree now, but they still represent different implementations. Care still needs to be taken - if one approach is updated, the other should be examined and updated as well, as appropriate.

Work to further align these two should be considered in future.