### PR TITLE
Fix error in bin size for `sensitivity.outcome_map`

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -441,7 +441,7 @@ tac_rs = ADRIA.sensitivity.rsa(rs, mean_s_tac; S=10)
 rsa_fig = ADRIA.viz.rsa(
     rs,
     tac_rs,
-    ["dhw_scenario", "wave_scenario", "N_seed_TA", "N_seed_CA", "fogging", "SRM"];
+    [:dhw_scenario, :wave_scenario, :N_seed_TA, :N_seed_CA, :fogging, :SRM];
     opts,
     fig_opts
 )

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -228,7 +228,6 @@ save("tsa.png", tsa_fig)
 
 ![Plots of Temporal Sensitivities](../assets/imgs/analysis/tsa.png)
 
-
 ### Convergence Analysis
 
 When undertaking sensitivity analysis it is important to have a sufficient number of samples

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -437,6 +437,8 @@ in identifying which (group of) factors drive model outputs and their active are
 factor space.
 
 ```julia
+mean_s_tac = dropdims(mean(s_tac), dims=1)
+
 tac_rs = ADRIA.sensitivity.rsa(rs, mean_s_tac; S=10)
 rsa_fig = ADRIA.viz.rsa(
     rs,
@@ -458,6 +460,9 @@ As the name implies, outcome mapping aids in identifying the relationship betwee
 outputs and the region of factor space that led to those outputs.
 
 ```julia
+
+mean_s_tac = dropdims(mean(s_tac), dims=1)
+
 tf = Figure(size=(1600, 1200))  # size of figure
 
 # Indicate factor values that are in the top 50 percentile

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -222,7 +222,7 @@ function ADRIA.viz.rsa!(
     f_names = ms[foi, :fieldname]
     h_names = ms[foi, :name]
     dist_params = ms[foi, :dist_params]
-    f_types = ms[foi, :ptype]
+    f_types::Vector{String} = ms[foi, :ptype]
 
     if any(f_names .== :guided)
         fv_labels = _get_guided_labels()
@@ -247,7 +247,7 @@ function ADRIA.viz.rsa!(
             f_type = f_types[curr]
             f_vals = rs.inputs[:, f_name]
 
-            if f_type == "unordered categorical"
+            if _is_discrete_factor(f_type)
                 fv_s = _get_cat_quantile(
                     ms[ms.fieldname .== f_name, :], f_name, collect(si[f_name].axes[1])
                 )
@@ -355,7 +355,7 @@ function ADRIA.viz.outcome_map!(
     f_names = ms[foi, :fieldname]
     h_names = ms[foi, :name]
     dist_params = ms[foi, :dist_params]
-    f_types = ms[foi, :ptype]
+    f_types::Vector{String} = ms[foi, :ptype]
 
     # Hacky special case handling for SSP/RCP
     if :RCP in factors || :SSP in factors
@@ -380,7 +380,7 @@ function ADRIA.viz.outcome_map!(
             f_type = f_types[curr]
             f_vals = rs.inputs[:, f_name]
 
-            if f_type == "unordered categorical"
+            if _is_discrete_factor(f_type)
                 fv_s = _get_cat_quantile(
                     ms[ms.fieldname .== f_name, :], f_name,
                     collect(outcomes[f_name].axes[1]),

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -574,13 +574,16 @@ function ADRIA.viz.outcome_map!(
         title_val = ms_factor.name[1]
     end
 
-    ax::Axis = Axis(g[1, 1]; title=title_val,
+    ax::Axis = Axis(
+        g[1, 1];
+        title=title_val,
         titlesize=38,
         xlabel=xlabel,
         ylabel=ylabel,
         xlabelsize=32,
         ylabelsize=32,
-        ylabelrotation=π / 2.0, axis_opts...)
+        ylabelrotation=π / 2.0,
+        axis_opts...)
     ADRIA.viz.outcome_map!(ax, outcomes, ms_factor, f_vals)
 
     return g

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -3,7 +3,6 @@ using Printf
 using ADRIA.sensitivity: _get_cat_quantile
 using ADRIA: _is_discrete_factor
 
-
 """
     _get_guided_labels()::Vector{String}
 

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -289,14 +289,15 @@ function ADRIA.viz.rsa!(
         fv_s = round.(quantile(f_vals, collect(si.axes[1])), digits=2)
     end
 
-    scatterlines!(ax, fv_s, collect(si[si=At("Si")]); markersize=15)
+    if .!all(si[si=At("Si")] .== 0.0)
+        scatterlines!(ax, fv_s, collect(si[si=At("Si")]); markersize=15)
 
-    if f_name == :guided
-        fv_labels = _get_guided_labels()
-        ax.xticks = (fv_s, fv_labels)
-        ax.xticklabelrotation = pi / 4
+        if f_name == :guided
+            fv_labels = _get_guided_labels()
+            ax.xticks = (fv_s, fv_labels)
+            ax.xticklabelrotation = pi / 4
+        end
     end
-
     return ax
 end
 function ADRIA.viz.rsa(
@@ -523,20 +524,21 @@ function ADRIA.viz.outcome_map!(
         fv_s = round.(quantile(f_vals, collect(outcomes.axes[1])), digits=2)
     end
 
-    band!(
-        ax,
-        fv_s[.!ismissing.(outcomes[CI=At("lower")])],
-        collect(skipmissing(outcomes[CI=At("lower")])),
-        collect(skipmissing(outcomes[CI=At("upper")])),
-    )
-    scatterlines!(ax, fv_s, outcomes[CI=At("mean")]; markersize=15)
+    if .!all(outcomes[CI=At("mean")] .== 0.0)
+        band!(
+            ax,
+            fv_s[.!ismissing.(outcomes[CI=At("lower")])],
+            collect(skipmissing(outcomes[CI=At("lower")])),
+            collect(skipmissing(outcomes[CI=At("upper")]))
+        )
+        scatterlines!(ax, fv_s, outcomes[CI=At("mean")]; markersize=15)
 
-    if f_name == :guided
-        fv_labels = _get_guided_labels()
-        ax.xticks = (fv_s, fv_labels)
-        ax.xticklabelrotation = pi / 4
+        if f_name == :guided
+            fv_labels = _get_guided_labels()
+            ax.xticks = (fv_s, fv_labels)
+            ax.xticklabelrotation = pi / 4
+        end
     end
-
     return ax
 end
 function ADRIA.viz.outcome_map(

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -345,6 +345,7 @@ function ADRIA.viz.outcome_map!(
     f_names = ms[foi, :fieldname]
     h_names = ms[foi, :name]
     dist_params = ms[foi, :dist_params]
+    f_types = ms[foi, :ptype]
 
     # Hacky special case handling for SSP/RCP
     if :RCP in factors || :SSP in factors
@@ -367,15 +368,18 @@ function ADRIA.viz.outcome_map!(
     axs = Axis[]
     for r in 1:n_rows
         for c in 1:n_cols
-            f_name = Symbol(factors[curr])
+            f_name = factors[curr]
+            f_type = f_types[curr]
             f_vals = rs.inputs[:, f_name]
 
-            if f_name == :guided
-                fv_s = collect(1:length(fv_labels))
+            if f_type == "unordered categorical"
+                fv_s = _get_cat_quantile(
+                    ms[ms.fieldname .== f_name, :], f_name,
+                    collect(outcomes[f_name].axes[1]),
+                )
             else
-                fv_s = round.(quantile(f_vals, b_slices), digits=2)
+                fv_s = round.(quantile(f_vals, collect(outcomes[f_name].axes[1])), digits=2)
             end
-
             ax::Axis = Axis(
                 g[r, c]; title=h_names[f_names .== factors[curr]][1], axis_opts...
             )

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -1,6 +1,18 @@
 using Statistics
 using Printf
 using ADRIA.sensitivity: _get_cat_quantile
+using ADRIA: _is_discrete_factor
+
+"""
+    _get_guided_labels()::Vector{String}
+
+    Returns labels for categories of the `guided` factor.
+"""
+function _get_guided_labels()::Vector{String}
+    return [
+        "cf", "unguided", last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...
+    ]
+end
 
 """
     ADRIA.viz.pawn(Si::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
@@ -213,9 +225,7 @@ function ADRIA.viz.rsa!(
     f_types = ms[foi, :ptype]
 
     if any(f_names .== :guided)
-        fv_labels = [
-            "unguided", "cf", last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...
-        ]
+        fv_labels = _get_guided_labels()
     end
 
     # Hacky special case handling for SSP/RCP
@@ -360,9 +370,7 @@ function ADRIA.viz.outcome_map!(
     b_slices = parse.(Float64, bin_slices)
 
     if any(f_names .== :guided)
-        fv_labels = [
-            "unguided", "cf", last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...
-        ]
+        fv_labels = _get_guided_labels()
     end
     curr::Int64 = 1
     axs = Axis[]

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -395,7 +395,6 @@ end
     ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
     ADRIA.viz.outcome_map!(ax::Axis, outcomes::YAXArray, ms_factor::DataFrame, f_vals::Vector{Float64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
-
 Plot outcomes mapped to factor regions for up to 30 factors.
 
 # Arguments
@@ -552,7 +551,7 @@ function ADRIA.viz.outcome_map!(
 end
 function ADRIA.viz.outcome_map(
     rs::ResultSet,
-    si::Dataset,
+    outcomes::Dataset,
     factors::Vector{Symbol};
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
@@ -587,7 +586,7 @@ end
         opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(:plot_overlay => true), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot sensitivity values for an increasing number of scenarios as a series, with each member
-    of the series representing a factor or model component.
+of the series representing a factor or model component.
 
 # Arguments
 - `Si_conv` : Produced using ADRIA.analysis.convergence()
@@ -701,6 +700,7 @@ function _series_convergence(
             end
         end
     end
+
     return g
 end
 
@@ -709,7 +709,7 @@ end
         opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot sensitivity values for an increasing number of scenarios as a heatmap, with each row
-    of the heatmap representing a factor or model component.
+of the heatmap representing a factor or model component.
 
 # Arguments
 - `Si_conv` : Produced using ADRIA.analysis.convergence()

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -320,7 +320,7 @@ function ADRIA.viz.rsa(
     factor::Symbol;
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -334,7 +334,7 @@ function ADRIA.viz.rsa!(
     si::YAXArray,
     factor::Symbol;
     opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
 )
     xlabel = get(axis_opts, :xlabel, "Factor Value")
     ylabel = get(axis_opts, :ylabel, L"\text{Relative } S_{i}")
@@ -359,7 +359,7 @@ function ADRIA.viz.rsa!(
         xlabelsize=32,
         ylabelsize=32,
         ylabelrotation=π / 2.0,
-        axis_opts...,
+        axis_opts...
     )
     ADRIA.viz.rsa!(ax, si, ms_factor, f_vals)
 
@@ -507,7 +507,7 @@ function ADRIA.viz.outcome_map!(
     ms_factor::DataFrame,
     f_vals::Vector{Float64};
     opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
 )
     f_name = ms_factor.fieldname[1]
     f_type::String = ms_factor.ptype[1]
@@ -516,7 +516,7 @@ function ADRIA.viz.outcome_map!(
         # If categorical/discrete get categorical quantile
         fv_s = _get_cat_quantile(
             ms_factor, f_name,
-            collect(outcomes.axes[1]),
+            collect(outcomes.axes[1])
         )
 
     else
@@ -531,7 +531,7 @@ function ADRIA.viz.outcome_map!(
             collect(skipmissing(outcomes[CI=At("lower")])),
             collect(skipmissing(outcomes[CI=At("upper")]))
         )
-        scatterlines!(ax, fv_s, outcomes[CI=At("mean")]; markersize=15)
+        scatterlines!(ax, fv_s, collect(outcomes[CI=At("mean")]); markersize=15)
 
         if f_name == :guided
             fv_labels = _get_guided_labels()
@@ -547,7 +547,7 @@ function ADRIA.viz.outcome_map(
     factor::Symbol;
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -561,7 +561,7 @@ function ADRIA.viz.outcome_map!(
     outcomes::YAXArray,
     factor::Symbol;
     opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
 )
     xlabel = pop!(axis_opts, :xlabel, "Factor Value")
     ylabel = pop!(axis_opts, :ylabel, "Outcome")

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -566,6 +566,9 @@ function rsa(
         if ptype == "unordered categorical"
             seq = seq_store[fact_t]
             X_q = _get_cat_quantile(foi_spec, fact_t, seq)
+        elseif ptype == ("ordered categorical") || (ptype == "ordered discrete")
+            seq = seq_store[:default]
+            X_q = _get_cat_quantile(foi_spec, fact_t, seq)
         else
             seq = seq_store[:default]
             X_q = quantile(X_i, seq)
@@ -694,9 +697,11 @@ function outcome_map(
     for fact_t in target_factors
         X_f = X[:, fact_t]
         ptype = model_spec.ptype[model_spec.fieldname .== fact_t][1]
-
         if ptype == "unordered categorical"
             seq = seq_store[fact_t]
+            X_q = _get_cat_quantile(foi_spec, fact_t, seq)
+        elseif ptype == "ordered categorical" || ptype == "ordered discrete"
+            seq = seq_store[:default]
             X_q = _get_cat_quantile(foi_spec, fact_t, seq)
         else
             seq = seq_store[:default]

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -594,7 +594,7 @@ function rsa(
         r_s[fact_t] .= normalize!(r_s[fact_t])
     end
 
-    return Dataset(; r_s...)
+    return r_s
 end
 function rsa(
     rs::ResultSet, y::AbstractVector{<:Real}; S::Int64=10
@@ -726,7 +726,7 @@ function outcome_map(
         end
     end
 
-    return Dataset(; p...)
+    return p
 end
 function outcome_map(
     X::DataFrame,

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -622,7 +622,7 @@ function rsa(
     seq_store = _create_seq_store(foi_spec, unordered_cat, S)
 
     # Create storage for sensitivities.
-    r_s::Dataset = _foi_data_stores(seq_store, foi_spec, unordered_cat, (Si=["Si"], ))
+    r_s::Dataset = _foi_data_stores(seq_store, foi_spec, unordered_cat, (Si=["Si"],))
 
     for fact_t in factors
         X_i .= X[:, fact_t]
@@ -836,7 +836,7 @@ function outcome_map(
 
     # Create storage for sensitivities.
     pawn_results::Dataset = _foi_data_stores(
-        seq_store, foi_spec, unordered_cat, (CI=["mean", "lower", "upper"], )
+        seq_store, foi_spec, unordered_cat, (CI=["mean", "lower", "upper"],)
     )
 
     all_p_rule = _map_outcomes(y, rule)

--- a/src/io/datacubes.jl
+++ b/src/io/datacubes.jl
@@ -31,7 +31,9 @@ are passed, all axes labels will be ranges.
 function ZeroDataCube(; T::Type{D}=Float64, kwargs...)::YAXArray where {D}
     return DataCube(zeros(T, [length(val) for (name, val) in kwargs]...); kwargs...)
 end
-function ZeroDataCube(axes_names::Tuple, axes_sizes::Tuple; T::Type{D}=Float64)::YAXArray where {D}
+function ZeroDataCube(
+    axes_names::Tuple, axes_sizes::Tuple; T::Type{D}=Float64
+)::YAXArray where {D}
     return ZeroDataCube(; T=T, NamedTuple{axes_names}(1:size for size in axes_sizes)...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -363,19 +363,19 @@ function test_rs_w_fig()
     )
 
     # Indicate factor values that are in the top 30 percentile
-    tac_om_70 = ADRIA.sensitivity.outcome_map(
+    tac_om_30 = ADRIA.sensitivity.outcome_map(
         rs, mean_s_tac, x -> any(x .>= 0.7), foi; S=20
     )
     ADRIA.viz.outcome_map!(
         tf[2, 1],
         rs,
-        tac_om_70,
+        tac_om_30,
         foi;
         axis_opts=Dict(
             :title => "Regions which lead to Top 30th Percentile Outcomes",
             :ylabel => "TAC [m²]",
         ))
-    save("outcome_map.png", tf)
+    # save("outcome_map.png", tf)
 
     return rs
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,29 +348,34 @@ function test_rs_w_fig()
     tf = Figure(; size=(1600, 1200))  # resolution in pixels
 
     # Indicate factor values that are in the top 50 percentile
-    # tac_om_50 = ADRIA.sensitivity.outcome_map(rs, mean_s_tac, x -> any(x .>= 0.5), foi; S=20)
-    # ADRIA.viz.outcome_map!(
-    #     tf[1, 1],
-    #     rs,
-    #     tac_om_50,
-    #     foi;
-    #     axis_opts=Dict(:title => "Regions which lead to Top 50th Percentile Outcomes", :ylabel => "TAC [m²]"),
-    # )
+    tac_om_50 = ADRIA.sensitivity.outcome_map(
+        rs, mean_s_tac, x -> any(x .>= 0.5), foi; S=20
+    )
+    ADRIA.viz.outcome_map!(
+        tf[1, 1],
+        rs,
+        tac_om_50,
+        foi;
+        axis_opts=Dict(
+            :title => "Regions which lead to Top 50th Percentile Outcomes",
+            :ylabel => "TAC [m²]",
+        ),
+    )
 
-    # # Indicate factor values that are in the top 30 percentile
-    # tac_om_70 = ADRIA.sensitivity.outcome_map(
-    #     rs, mean_s_tac, x -> any(x .>= 0.7), foi; S=20
-    # )
-    # ADRIA.viz.outcome_map!(
-    #     tf[2, 1],
-    #     rs,
-    #     tac_om_70,
-    #     foi;
-    #     axis_opts=Dict(
-    #         :title => "Regions which lead to Top 30th Percentile Outcomes",
-    #         :ylabel => "TAC [m²]",
-    #     ))
-    # save("outcome_map.png", tf)
+    # Indicate factor values that are in the top 30 percentile
+    tac_om_70 = ADRIA.sensitivity.outcome_map(
+        rs, mean_s_tac, x -> any(x .>= 0.7), foi; S=20
+    )
+    ADRIA.viz.outcome_map!(
+        tf[2, 1],
+        rs,
+        tac_om_70,
+        foi;
+        axis_opts=Dict(
+            :title => "Regions which lead to Top 30th Percentile Outcomes",
+            :ylabel => "TAC [m²]",
+        ))
+    save("outcome_map.png", tf)
 
     return rs
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,8 +358,8 @@ function test_rs_w_fig()
         foi;
         axis_opts=Dict(
             :title => "Regions which lead to Top 50th Percentile Outcomes",
-            :ylabel => "TAC [m²]",
-        ),
+            :ylabel => "TAC [m²]"
+        )
     )
 
     # Indicate factor values that are in the top 30 percentile
@@ -373,7 +373,7 @@ function test_rs_w_fig()
         foi;
         axis_opts=Dict(
             :title => "Regions which lead to Top 30th Percentile Outcomes",
-            :ylabel => "TAC [m²]",
+            :ylabel => "TAC [m²]"
         ))
     # save("outcome_map.png", tf)
 


### PR DESCRIPTION
Fixes bug where the number of bins was being set by the maximum number of categories where a categorical variable was used. Also moves similar code used in `sensitivity.rsa` into functions to be used by both methods.

Closes #615