### PR TITLE
Remove MKL from build process

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,0 @@
-using CpuId, Pkg
-
-if occursin("Intel", cpubrand())
-    # Add MKL library to leverage faster performance for matrix operations
-    Pkg.add("MKL")
-end


### PR DESCRIPTION
Removes installation of MKL (the Intel-specific math library) on computers with Intel CPU.

The purpose was to improve runtimes (small but noticeable) due to the large number of matrix operations.

However, it has been noted that deploying to AWS via Docker containers:

1. the end target system may not be an Intel based CPU at all
2. Docker build current fails when MKL is included.

Given the long-term plan is to leverage GPUs for matrix operations, I've decided it is best to remove MKL now.


