### PR TITLE
Yax sensitivity

### DIFF
--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -343,7 +343,7 @@ function convergence(
 end
 
 """
-    tsa(X::DataFrame, y::AbstractMatrix)::NamedDimsArray
+    tsa(X::DataFrame, y::AbstractMatrix)::YAXArray
 
 Perform Temporal (or time-varying) Sensitivity Analysis using the PAWN sensitivity index.
 
@@ -366,12 +366,12 @@ ADRIA.sensitivity.tsa(rs.inputs, y_tac)
 - `y` : scenario outcomes over time
 
 # Returns
-NamedDimsArray, of shape \$D\$ ⋅ 6 ⋅ \$T\$, where
+YAXArray, of shape \$D\$ ⋅ 6 ⋅ \$T\$, where
 - \$D\$ is the number of dimensions/factors
 - 6 corresponds to the min, mean, median, max, std, and cv of the PAWN indices
 - \$T\$ is the number of time steps
 """
-function tsa(X::DataFrame, y::AbstractMatrix{<:Real})::NamedDimsArray
+function tsa(X::DataFrame, y::AbstractMatrix{<:Real})::YAXArray
     local ts
     try
         ts = axiskeys(y, 1)
@@ -383,8 +383,8 @@ function tsa(X::DataFrame, y::AbstractMatrix{<:Real})::NamedDimsArray
         end
     end
 
-    t_pawn_idx = NamedDimsArray(
-        zeros(ncol(X), 8, size(y, 1));
+    t_pawn_idx = ZeroDataCube(
+        Float64;
         factors=Symbol.(names(X)),
         Si=[:min, :lb, :mean, :median, :ub, :max, :std, :cv],
         timesteps=ts,
@@ -392,13 +392,13 @@ function tsa(X::DataFrame, y::AbstractMatrix{<:Real})::NamedDimsArray
 
     for t in axes(y, 1)
         t_pawn_idx[:, :, t] .= col_normalize(
-            pawn(X, vec(mean(y[1:t, :]; dims=1)))
+            pawn(X, vec(mean(y[1:t, :]; dims=1))).data
         )
     end
 
     return t_pawn_idx
 end
-function tsa(rs::ResultSet, y::AbstractMatrix{<:Real})::NamedDimsArray
+function tsa(rs::ResultSet, y::AbstractMatrix{<:Real})::YAXArray
     return tsa(rs.inputs, y)
 end
 

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -4,7 +4,6 @@ using Logging
 
 using
     NamedDims,
-    AxisKeys,
     StaticArrays,
     YAXArrays
 using DataFrames
@@ -374,7 +373,7 @@ YAXArray, of shape \$D\$ ⋅ 6 ⋅ \$T\$, where
 function tsa(X::DataFrame, y::AbstractMatrix{<:Real})::YAXArray
     local ts
     try
-        ts = axiskeys(y, 1)
+        ts = collect(y.axes[1])
     catch err
         if err isa MethodError
             ts = 1:size(y, 1)


### PR DESCRIPTION
This pull request would override changes on the (unmerged) branch [yax-sensitivity-analysis](https://github.com/open-AIMS/ADRIA.jl/tree/yax-sensitivity-analysis). The older branch seemed only to find and replace `NamedDimsArray` and was most likely unfinished.

This branch does not migrate `outcome_maps` as this function is migrated in #702. 

Part of #695 