### PR TITLE
Remove GC workaround

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -304,10 +304,6 @@ function run_scenario(
         end
     end
 
-    if (idx % 256) == 0
-        @everywhere GC.gc()
-    end
-
     return nothing
 end
 function run_scenario(


### PR DESCRIPTION
Workaround added to resolve #416 is now no longer needed as the memory leak has been resolved upstream in Julia v1.10.
The issue was likely caused by something to do with the (auto-)garbage collection process.

See other details noted in #405 .

Might require bumping the minimum supported Julia version to v1.10