### PR TITLE
Validating MCDA methods and initial clean/update of tests

### DIFF
--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -22,8 +22,6 @@ using
     DataFrames,
     JMcDM
 
-# dummy dMCDA_vars() for dev
-struct DMCDA_vars end
 
 # dummy functions to allow precompilation
 function unguided_selection() end
@@ -32,32 +30,21 @@ function adria_topsis() end
 function adria_vikor() end
 function decision_matrix() end
 
-function supported_jmcdm_methods()
-    # Those commented out with failed a simple test where only heat stress is considered
-    # and the method selected the hottest locations ("**")
-    # or a nonsensical selection (e.g., 1, 2, 3, 4, 5; marked with "*^")
-    return [
-        #** JMcDM.Topsis.TopsisMethod,
-        JMcDM.VIKOR.VikorMethod,
-        #** JMcDM.ARAS.ArasMethod,
-        #*^ JMcDM.COCOSO.CocosoMethod,
-        #** JMcDM.CODAS.CodasMethod,
-        #** JMcDM.EDAS.EdasMethod,
-        #** JMcDM.GREY.GreyMethod,
-        #** JMcDM.MABAC.MabacMethod,
-        JMcDM.MAIRCA.MaircaMethod,
-        #** JMcDM.MARCOS.MarcosMethod,
-        #*^ JMcDM.MOORA.MooraMethod,
-        JMcDM.PIV.PIVMethod,
-        JMcDM.PSI.PSIMethod,
-        #** JMcDM.SAW.SawMethod,
-        #** JMcDM.WASPAS.WaspasMethod,
-        #** JMcDM.WPM.WPMMethod
-    ]
-end
+"""
+    mcda_methods()
 
+List of MCDA methods found to be suitable for use with ADRIA.
+
+See "Validate included MCDA methods" testset in `test/mcda.jl` for details.
+"""
 function mcda_methods()
-    return supported_jmcdm_methods()
+    return [
+        JMcDM.COCOSO.CocosoMethod,
+        JMcDM.MAIRCA.MaircaMethod,
+        JMcDM.MOORA.MooraMethod,
+        JMcDM.PIV.PIVMethod,
+        JMcDM.VIKOR.VikorMethod,
+    ]
 end
 
 """

--- a/test/io/inputs.jl
+++ b/test/io/inputs.jl
@@ -1,6 +1,7 @@
-using DimensionalData
 using Random
-using YAXArrays
+
+using ADRIA.DimensionalData
+using ADRIA.YAXArrays
 
 @testset "NetCDF" begin
     @testset "Handling Vector of Strings and Matrix{ASCIIChar}" begin

--- a/test/io/inputs.jl
+++ b/test/io/inputs.jl
@@ -62,20 +62,20 @@ end
 
 @testset "ZeroDataCube" begin
     ZeroDataCube = ADRIA.ZeroDataCube
-    
+
     dim_1_name = :timesteps
     dim_1_vals = rand(10)
-    
+
     dim_2_name = :location
     dim_2_vals = ["loc 1", "loc 2", "loc 3", "loc 4", "loc 5"]
 
     yax_res = ZeroDataCube(; T=Int, NamedTuple{(dim_1_name,)}((dim_1_vals,))...)
 
-    @test typeof(yax_res) <: YAXArray{Int, 1} || 
+    @test typeof(yax_res) <: YAXArray{Int, 1} ||
         "Incorrect return type. Expected a subtype of YAXArray{Int, 1} \
          but received $(typeof(yax_res))"
 
-    @test all(0 .== yax_res) || 
+    @test all(0 .== yax_res) ||
         "Incorrect data contained in YAXArray. Expected all 0."
 
     @test size(yax_res) == (10,) ||
@@ -85,16 +85,16 @@ end
         "Incorrect dimension name. Expected $(name(dim_1)) \
          but received $(name(yax_res.axes[1]))"
 
-    @test dim_1_vals == collect(yax_res.axes[1]) || 
+    @test dim_1_vals == collect(yax_res.axes[1]) ||
         "Incorrect axis indices. Expected $(dim_1_vals) but received $(collect(yax_res.axes[1]))"
-      
+
         yax_res = ZeroDataCube(; T=Float64, NamedTuple{(dim_1_name, dim_2_name)}((dim_1_vals, dim_2_vals))...)
 
-    @test typeof(yax_res) <: YAXArray{Float64, 2} || 
+    @test typeof(yax_res) <: YAXArray{Float64, 2} ||
         "Incorrect return type. Expected a subtype of YAXArray{Int, 2} \
          but received $(typeof(yax_res))"
 
-    @test all(0 .== yax_res) || 
+    @test all(0 .== yax_res) ||
         "Incorrect data contained in YAXArray. Expected all 0."
 
     @test size(yax_res) == (10, 5) ||
@@ -108,16 +108,16 @@ end
         "Incorrect dimension name. Expected $(name(dim_2)) \
          but received $(name(yax_res.axes[2]))"
 
-    @test dim_1_vals == collect(yax_res.axes[1]) || 
+    @test dim_1_vals == collect(yax_res.axes[1]) ||
         "Incorrect axis indices. Expected $(dim_1_vals) but received $(collect(yax_res.axes[1]))"
 
-    @test dim_2_vals == collect(yax_res.axes[2]) || 
+    @test dim_2_vals == collect(yax_res.axes[2]) ||
         "Incorrect axis indices. Expected $(dim_2_vals) but received $(collect(yax_res.axes[2]))"
 end
 
 function test_DataCube(data; kwargs...)
     yax_res = ADRIA.DataCube(data; kwargs...)
-    
+
     @test data == yax_res ||
         "Incorrect data stored in yax array."
 
@@ -152,7 +152,7 @@ end
         rand(6); NamedTuple{(dim_3_name,)}((dim_3_vals, ))...
     )
     test_DataCube(
-        rand(6, 5, 10); 
+        rand(6, 5, 10);
         NamedTuple{(dim_3_name, dim_2_name, dim_1_name)}((dim_3_vals, dim_2_vals, dim_1_vals))...
     )
 end

--- a/test/io/inputs.jl
+++ b/test/io/inputs.jl
@@ -91,7 +91,7 @@ end
         yax_res = ZeroDataCube(; T=Float64, NamedTuple{(dim_1_name, dim_2_name)}((dim_1_vals, dim_2_vals))...)
 
     @test typeof(yax_res) <: YAXArray{Float64, 2} ||
-        "Incorrect return type. Expected a subtype of YAXArray{Int, 2} \
+        "Incorrect return type. Expected a subtype of YAXArray{Float64, 2} \
          but received $(typeof(yax_res))"
 
     @test all(0 .== yax_res) ||

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -384,6 +384,7 @@ include("metrics.jl")
 include("sampling.jl")
 include("seeding.jl")
 include("spec.jl")
+include("mcda.jl")
 include("utils/text_display.jl")
 
 # TODO Fix spatial_clustering and site_selection tests

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -17,34 +17,7 @@ end
 
     # ranks = ADRIA.site_selection(dom, p_tbl, 1, 10, 1)
 end
-@testset "MCDA variable constructor" begin
-    dom = ADRIA.load_domain(TEST_DOMAIN_PATH, 45)
-    criteria_df = ADRIA.param_table(dom)  # Get single scenario dataframe
 
-    site_ids = collect(1:length(dom.site_ids))
-    available_space = rand(Uniform(200, 30000), length(site_ids))
-
-    area_to_seed = 962.11  # Area of seeded corals in m^2.
-
-    dhw_scens = dom.dhw_scens[1, :, criteria_df.dhw_scenario[1]]
-    wave_scens = dom.wave_scens[1, :, criteria_df.wave_scenario[1]]
-
-    mcda_vars = ADRIA.decision.DMCDA_vars(
-        dom,
-        criteria_df[1, :],
-        site_ids,
-        available_space,
-        area_to_seed,
-        wave_scens,
-        dhw_scens,
-    )
-    n_sites = length(mcda_vars.site_ids)
-    @test (size(mcda_vars.conn, 1) == n_sites) && (size(mcda_vars.conn, 2) == n_sites) || "Connectivity input is incorrect size."
-    @test length(mcda_vars.dam_prob) == n_sites || "Wave damage input is incorrect size."
-    @test length(mcda_vars.heat_stress_prob) == n_sites || "Heat stress input is incorrect size."
-    @test length(mcda_vars.leftover_space) == n_sites ||
-        "Initial cover input is incorrect size."
-end
 @testset "Unguided site selection" begin
     n_intervention_sites = 5
     pref_seed_sites = zeros(Int64, n_intervention_sites)


### PR DESCRIPTION
A simple assessment is conducted to identify MCDA methods (provided by JMcDM.jl) that are suitable for use with ADRIA.

The details of the assessment are documented in `test/mcda.jl`.
The assessment is included as a test to indicate if/when JMcDM.jl methods change or are updated.

Five methods are identified, which are (in order):

- CoCoSo
- MAIRCA
- Moora
- PIV
- VIKOR

The script below is applies a modified version of the bootstrapped assessment discussed in https://github.com/open-AIMS/ADRIA.jl/issues/452#issuecomment-1942888428

The assessment indicates PIV is the most appropriate (based on this somewhat limited analyses of 256 samples per guided "type").

This is in contrast to the assessment done by @Rosejoycrocker in https://github.com/open-AIMS/ADRIA.jl/pull/702#issuecomment-1993564379 which indicates MAIRCA provides a slight edge. However, the details of that assessment are not provided so it's difficult to judge/compare.

The assessment here was performed using GBR-scale data, so it may be that MAIRCA is more appropriate in smaller spatial scales, whereas PIV leads to improved outcomes at larger spatial scales. Again, these contextualizations require further investigation.


```julia
"""
Run GBR-wide sims with ADRIA using the identified MCDA methods.

Apply some analyses to identify which MCDA method produces outcomes above unguided
scenarios, which are used as a baseline.
"""

using Revise, Infiltrator
using WGLMakie, GeoMakie, GraphMakie
using ADRIA
using Statistics, Bootstrap


# dom = ADRIA.load_domain(RMEDomain, "C:/Users/tiwanaga/development/RME/rme_ml_2023_03_30b", "45")
dom = ADRIA.load_domain(ReefModDomain, "C:/Users/tiwanaga/development/ADRIA_data/reefmod_domain", "45")

ADRIA.fix_factor!(
    dom;
    N_seed_TA=Int64(50e6),
    N_seed_CA=Int64(50e6),
    N_seed_SM=Int64(50e6),
    a_adapt=0.0,
    seed_deployment_freq=1.0,
    cluster_max_member=1.0,
    seed_years=75,
    seed_year_start=5,
    seed_wave_stress=0.0,
    # seed_in_connectivity=0.0,
    seed_out_connectivity=0.8,
    # seed_coral_cover=0.0,
    seed_depth=0.5,
    SRM=0.0,
    fogging=0.0,
    plan_horizon=20.0
)

n_samples = 256
cf_scens = ADRIA.sample_cf(dom, n_samples)
ug_scens = ADRIA.sample_unguided(dom, n_samples)

ADRIA.fix_factor!(dom; guided=1.0)
cocoso_scens = ADRIA.sample_guided(dom, n_samples)

ADRIA.fix_factor!(dom; guided=2.0)
mairca_scens = ADRIA.sample_guided(dom, n_samples)

ADRIA.fix_factor!(dom; guided=3.0)
moora_scens = ADRIA.sample_guided(dom, n_samples)

ADRIA.fix_factor!(dom; guided=4.0)
piv_scens = ADRIA.sample_guided(dom, n_samples)

ADRIA.fix_factor!(dom; guided=5.0)
vikor_scens = ADRIA.sample_guided(dom, n_samples)

scens = vcat(cf_scens, ug_scens, cocoso_scens, mairca_scens, moora_scens, piv_scens, vikor_scens)

# rs = ADRIA.run_scenarios(dom, scens, "45")
rs = ADRIA.load_results("./Outputs/ReefMod__RCPs_45__2024-03-16_23_51_50_743")
stac = ADRIA.metrics.scenario_total_cover(rs)
ADRIA.viz.scenarios(rs, stac)

# Plotting trajectories
# f = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== -1.0])
# f0 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 0.0])
# f1 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 1.0])
# f2 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 2.0])
# f3 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 3.0])
# f4 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 4.0])
# f5 = ADRIA.viz.scenarios(rs, stac[:, scens.guided .== 5.0])

# Bootstrapped assessment against unguided scenarios
n_timesteps = size(stac, 1)

# Dims: Timestep, bootstrap mean/median, lower bound, upper bound, method
guide_delta_mean = zeros(n_timesteps, 3, 5)
guide_delta_median = zeros(n_timesteps, 3, 5)

ug_scen_idx = findall(scens.guided .== 0.0)
for guided_method in 1:5
    guided_scen_idx = findall(scens.guided .== guided_method)

    b_sample = zeros(1000, 2)

    # Bootstrap each timestep
    for n in axes(stac, 1)
        for s in axes(b_sample, 1)
            shuf_set = shuffle(guided_scen_idx)
            ug_scen_idx = shuffle(ug_scen_idx)
            delta = stac[n, shuf_set] .- stac[n, ug_scen_idx]

            b_sample[s, 1] = mean(delta)
            b_sample[s, 2] = median(delta)
        end

        # bootstrap mean/median for each shuffled sample
        guide_delta_mean[n, :, guided_method] .= collect(Iterators.flatten(confint(bootstrap(mean, b_sample[:, 1], BalancedSampling(100)), PercentileConfInt(0.95))))
        guide_delta_median[n, :, guided_method] .= collect(Iterators.flatten(confint(bootstrap(median, b_sample[:, 2], BalancedSampling(100)), PercentileConfInt(0.95))))
    end

    mean_count = count(guide_delta_mean[:, 1, guided_method] .> 0.0)
    median_count = count(guide_delta_median[:, 1, guided_method] .> 0.0)

    # Report the number of times the mean/median delta was > 0
    @info """
        $(string(ADRIA.mcda_methods()[guided_method])) - N timesteps where delta > 0:
        mean: $(mean_count) ($(round((mean_count / n_timesteps) * 100.0, digits=2))%)
        median: $(median_count) ($(round((median_count / n_timesteps) * 100.0, digits=2))%)
    """
end

# N timesteps is 79
# ┌ Info:     CocosoMethod - N timesteps where delta > 0:
# │     mean: 24 (30.38%)
# └     median: 33 (41.77%)
# ┌ Info:     MaircaMethod - N timesteps where delta > 0:
# │     mean: 38 (48.1%)
# └     median: 39 (49.37%)
# ┌ Info:     MooraMethod - N timesteps where delta > 0:
# │     mean: 31 (39.24%)
# └     median: 40 (50.63%)
# ┌ Info:     PIVMethod - N timesteps where delta > 0:
# │     mean: 52 (65.82%)
# └     median: 49 (62.03%)
# ┌ Info:     VikorMethod - N timesteps where delta > 0:
# │     mean: 26 (32.91%)
# └     median: 38 (48.1%)
```