### PR TITLE
Results Interface

### DIFF
--- a/docs/src/dMCDA.md
+++ b/docs/src/dMCDA.md
@@ -1,1 +1,37 @@
 # Dynamic Multi-Criteria Decision Analysis
+
+## Multi-Criteria Decision Making
+
+Multi-criteria decision analysis (MCDA) encompasses a series of methods for conducting
+decision making in a way that is formalised, structured and transparent. It evaluates the
+decision objective according to numerical measures of decision criteria assembled by the
+decision maker. Constructing explicit criteria over which to evaluate alternatives allows a
+transparent evaluation of benefits, negatives and trade-offs in coming to a decision
+solution.
+
+Typical approaches to MCDA require the construction of a "decision matrix", which takes the
+form of a $X^{n \cdot m}$, where $n$ is the number of alternate options available, and $m$
+is the number of criteria.
+
+In the context of ADRIA, the alternate options relate to the locations being assessed.
+The criteria then relate to the common set of attributes on which the locations
+are being judged, such as the projected heat stress (in terms of DHW), depth, and level of
+incoming or outgoing connectivity.
+
+MCDA methods provide a ranking according to the set of assessed criteria, in the form of:
+
+$$r = g(X, w, d)$$
+
+where:
+
+- $g()$ refers to a given MCDA algorithm (see [JMcDM.jl](https://jbytecode.github.io)).
+- $X$ is the decision matrix
+- $w$ is the weights afforded to each criteria, indicating their relative importance
+- $d$ is the desired directionality for each criterion (to minimize the criteria value, or to maximize)
+- $r$ is the ranking determined by $g()$
+
+When applied in conjunction with scenario analyses, locations are assessed at each decision
+point.
+
+When conducting location selection, the analyses are applied to the initial conditions
+represented in the Domain.

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -90,7 +90,7 @@ function ADRIA.viz.scenarios(
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
     ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
 
-    scen_groups = Dict(:CScape => BitVector([true for _ in 1:length(outcomes.scenarios)]))
+    scen_groups = rs.scenario_groups
     ADRIA.viz.scenarios!(g, ax, outcomes, scen_groups; opts, axis_opts, series_opts)
     return f
 end

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -1,6 +1,6 @@
 using JuliennedArrays: Slices
 using ADRIA.analysis: series_confint
-using ADRIA: axes_names
+using ADRIA: axes_names, CScapeResultSet
 
 """
     ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::YAXArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
@@ -74,6 +74,25 @@ function ADRIA.viz.scenarios!(
         axis_opts=axis_opts,
         series_opts=series_opts,
     )
+end
+function ADRIA.viz.scenarios(
+    rs::CScapeResultSet,
+    outcomes::YAXArray,
+    opts::Dict=Dict(),
+    fig_opts::Dict=Dict(:size=>(800, 300)),
+    axis_opts::Dict=Dict(),
+    series_opts::Dict=Dict(),
+)::Figure
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+
+    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
+    xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
+    ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
+
+    scen_groups = Dict(:CScape => BitVector([true for _ in 1:length(outcomes.scenarios)]))
+    ADRIA.viz.scenarios!(g, ax, outcomes, scen_groups; opts, axis_opts, series_opts)
+    return f
 end
 function ADRIA.viz.scenarios(
     scenarios::DataFrame,

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -77,7 +77,7 @@ function ADRIA.viz.scenarios!(
 end
 function ADRIA.viz.scenarios(
     rs::CScapeResultSet,
-    outcomes::YAXArray,
+    outcomes::YAXArray;
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(:size=>(800, 300)),
     axis_opts::Dict=Dict(),

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -1,6 +1,6 @@
 using JuliennedArrays: Slices
 using ADRIA.analysis: series_confint
-using ADRIA: axes_names, CScapeResultSet
+using ADRIA: axes_names, CScapeResultSet, ReefModResultSet
 
 """
     ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::YAXArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
@@ -76,7 +76,7 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
-    rs::CScapeResultSet,
+    rs::Union{CScapeResultSet, ReefModResultSet},
     outcomes::YAXArray;
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(:size=>(800, 300)),

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -66,6 +66,7 @@ include("interventions/fogging.jl")
 
 include("io/ResultSet.jl")
 include("io/result_io.jl")
+include("io/cscape_result_io.jl")
 include("io/result_post_processing.jl")
 include("io/sampling.jl")
 include("metrics/metrics.jl")

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -67,6 +67,7 @@ include("interventions/fogging.jl")
 include("io/ResultSet.jl")
 include("io/result_io.jl")
 include("io/cscape_result_io.jl")
+include("io/reefmod_result_io.jl")
 include("io/result_post_processing.jl")
 include("io/sampling.jl")
 include("metrics/metrics.jl")
@@ -88,12 +89,15 @@ export
     create_coral_struct, Intervention, Corals, SimConstants,
     SeedCriteriaWeights, FogCriteriaWeights,
     site_area, site_k_area,
-    Domain, ADRIADomain,
+    Domain, ADRIADomain, ADRIAResultSet,
     metrics, select, timesteps, env_stats, viz
 
 # Interfaces for external models
 export RMEDomain
 export ReefModDomain
+
+export CScapeResultSet
+export ReefModResultSet
 
 # metric helper methods
 # export dims, ndims

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -154,3 +154,7 @@ Base.@kwdef struct Intervention <: EcoModel
         description="Start of fogging deployments after this number of years has elapsed.",
     )
 end
+
+function interventions()
+    return [:seed, :fog]
+end

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -73,12 +73,23 @@ function ResultSet(
         input_set.attrs["sim_constants"],
         model_spec,
         outcomes,
-        DataCube(log_set["rankings"], Symbol.(Tuple(log_set["rankings"].attrs["structure"]))),
+        _rankings_data(log_set["rankings"]),
         DataCube(log_set["seed"], Symbol.(Tuple(log_set["seed"].attrs["structure"]))),
         DataCube(log_set["fog"], Symbol.(Tuple(log_set["fog"].attrs["structure"]))),
         DataCube(log_set["shade"], Symbol.(Tuple(log_set["shade"].attrs["structure"]))),
         DataCube(log_set["coral_dhw_log"], Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))),
     )
+end
+
+function _rankings_data(rankings_set::ZArray{T})::YAXArray{T} where {T}
+    ax_names = Symbol.(Tuple(rankings_set.attrs["structure"]))
+    ax_labels::Vector{Union{UnitRange{Int64},Vector{Symbol}}} = range.([1], size(rankings_set))
+
+    # Replace intervention
+    intervention_idx = findfirst(x -> x == :intervention, ax_names)
+    ax_labels[intervention_idx] = interventions()
+
+    return DataCube(rankings_set; NamedTuple{ax_names}(ax_labels)...)
 end
 
 """

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -14,7 +14,9 @@ const MODEL_SPEC = "model_spec"
 const RESULTS = "results"
 const SPATIAL_DATA = "spatial"
 
-struct ResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF}
+abstract type ResultSet end
+
+struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF} <: ResultSet
     name::String
     RCP::String
     invoke_time::String
@@ -56,7 +58,7 @@ function ResultSet(
     model_spec::DataFrame,
 )::ResultSet
     rcp = "RCP" in keys(input_set.attrs) ? input_set.attrs["RCP"] : input_set.attrs["rcp"]
-    return ResultSet(input_set.attrs["name"],
+    return ADRIAResultSet(input_set.attrs["name"],
         string(rcp),
         input_set.attrs["invoke_time"],
         input_set.attrs["ADRIA_VERSION"],
@@ -447,7 +449,7 @@ function model_spec(rs::ResultSet)::DataFrame
     return rs.model_spec
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", rs::ResultSet)
+function Base.show(io::IO, mime::MIME"text/plain", rs::ADRIAResultSet)
     vers_id = rs.ADRIA_VERSION
 
     tf, sites, scens = size(rs.outcomes[:relative_cover])

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -1,0 +1,226 @@
+using ADRIA: EnvLayer, GDF, ZeroDataCube, DataCube
+using ArchGDAL: centroid
+using DataFrames
+using YAXArrays
+using CSV
+
+struct CScapeResultSet <: ResultSet
+    name::String
+    RCP::String
+
+    site_ids
+    site_area::Vector{Float64}
+    site_max_coral_cover::Vector{Float64}
+    site_centroids
+    env_layer_md::EnvLayer
+    connectivity_data
+    site_data
+
+    sim_constants
+
+    # raw::AbstractArray
+    outcomes
+end
+
+
+function load_results(::Type{CScapeResultSet}, result_loc::String)
+    !isdir(result_loc) ? error("Expected a directory but received $(result_loc)") : nothing
+    
+    result_path = _get_output_path(result_loc)
+    raw_set = open_dataset(result_path)
+
+    res_name::String = _get_result_name(raw_set)
+    res_rcp::String = _get_rcp(raw_set)
+    
+    !haskey(raw_set.cubes, :reef_siteid) ? error("Unable to find location ids.") : nothing
+    location_ids = _get_reefids(raw_set.cubes[:reef_siteid])
+    # "Moore_MR_C_1" -> "MR_C_1"
+    short_loc_ids = [id[(findfirst('_', id)+1):end] for id in location_ids]
+
+    gpkg_path = _get_gpkg_path(result_loc)
+    geodata = GDF.read(gpkg_path)
+
+    connectivity_path = joinpath(result_loc, "connectivity", "connectivity.csv")
+    connectivity = CSV.read(connectivity_path, DataFrame, comment="#", header=false)
+    
+    # There is missing location data in site data. Use intersection
+    gpkg_mask = BitVector([loc_name in short_loc_ids for loc_name in geodata.site_id])
+    res_mask  = BitVector([loc_name in geodata.site_id for loc_name in short_loc_ids])
+    conn_mask = BitVector(
+        [!ismissing(loc_name) &&
+         (loc_name in location_ids) && 
+         (loc_name[findfirst('_', loc_name)+1:end] in geodata.site_id)
+        for loc_name in connectivity[1, :]]
+    )
+
+    geodata = geodata[gpkg_mask, :]
+    conn_sites = connectivity[1, :][conn_mask] 
+    connectivity = connectivity[conn_mask, conn_mask]
+
+    geo_id_order = [first(findall(x .== geodata.site_id)) for x in short_loc_ids[res_mask]]
+    conn_id_order = [first(findall(x .== Vector(conn_sites))) for x in location_ids[res_mask]]
+    
+    geodata = geodata[geo_id_order, :]
+    connectivity = connectivity[conn_id_order, conn_id_order]
+
+    timeframe = 2009:2099
+    if !haskey(raw_set.properties, "temporal_range")
+        @warn "Unable to find timeframe defaulting to $(timeframe[1]):$(timeframe[end])"
+    else
+        tf_str = split(raw_set.properties["temporal_range"], ":")
+        timeframe = parse(Int, tf_str[1]):parse(Int, tf_str[2])
+    end
+
+    env_layer_md::EnvLayer = EnvLayer(
+        result_loc,
+        gpkg_path,
+        "site_id",
+        "Reef",
+        "",
+        connectivity_path,
+        "",
+        "",
+        timeframe
+    )
+
+    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
+
+    outcome_keys = [
+        :larvae, 
+        :external_larvae, 
+        :internal_received_larvae, 
+        :settlers, 
+        :eggs, 
+        :size_classes,
+        :cover
+    ]
+    outcomes = Dict{Symbol, YAXArray}()
+    for outcome_key ∈ outcome_keys
+        if !haskey(raw_set.cubes, outcome_key)
+            @warn "Unable to find $(string(outcome_key). Skipping)"
+            continue
+        end
+        if outcome_key == :cover
+            outcomes[:relative_cover] = raw_set.cubes[outcome_key]
+            continue
+        end
+        outcomes[outcome_key] = raw_set.cubes[outcome_key]
+    end
+
+    return CScapeResultSet(
+        res_name,
+        res_rcp,
+        geodata.site_id,
+        geodata.area,
+        location_max_coral_cover,
+        location_centroids,
+        env_layer_md,
+        connectivity,
+        geodata,
+        SimConstants(),
+        outcomes,
+    )
+end
+
+"""
+    _get_output_path(result_loc::String)::String
+
+Get the filename of the netcdf file contained in the result subdirectory. Must have a NetCDF
+suffix and begin with `NetCDF_Scn`.
+"""
+function _get_output_path(result_loc::String)::String
+    res_subdir = joinpath(result_loc, "results")
+    possible_files = filter(isfile, readdir(res_subdir, join=true))
+    possible_files = filter(x -> occursin(r"NetCDF_Scn.*.nc", x), possible_files)
+    if length(possible_files) == 0
+        error("Unable to find result netcdf file in subdirectory $(res_subdir)")
+    elseif length(possible_files) > 1
+        @warn "Found multiple netcdf files, using first."
+    end
+    return possible_files[1]
+end
+
+"""
+    _get_gpkg_path(result_loc::String)
+
+Get the path to the gpkg file contained in the site_data subdirectory. 
+"""
+function _get_gpkg_path(result_loc::String)
+    gpkg_dir = joinpath(result_loc, "site_data")
+    possible_files = filter(isfile, readdir(gpkg_dir, join=true))
+    possible_files = filter(x -> occursin(".gpkg", x), possible_files)
+    if length(possible_files) == 0
+        error("Unable to find site data in $(gpkg_dir)")
+    elseif length(possible_files) > 1
+        @warn "Found multiple gpkg files, using first."
+    end
+    return possible_files[1]
+end
+"""
+    _get_result_name()::String
+
+Get the name of the data set from the properties of the dataset.
+"""
+function _get_result_name(ds::Dataset)::String
+    name = "CScape Results"
+    if !haskey(ds.properties, "title")
+        @warn "Unable to find key `title` in dataset properties, \
+               defaulting to `CScape Results`"
+    else
+        name = ds.properties["title"]
+    end
+    return name
+end
+
+"""
+    _get_rcp(ds::Datset)::String
+
+Get the RCP from the ssp field in dataset properties. Assume RCP is last two numbers.
+"""
+function _get_rcp(ds::Dataset)::String
+    rcp = ""
+    if !haskey(ds.properties, "ssp")
+        @warn "Unable to find key `ssp` in dataset properties."
+    else
+        rcp = ds.properties["ssp"][end-1:end]
+    end
+    return rcp
+end
+
+"""
+    _get_reefids(ds::YAXArray)::String
+
+Reef IDs are stored in a space seperated list in the properties of reef_siteids cube.
+"""
+function _get_reefids(reef_cube::YAXArray)::Vector{String}
+    # Site IDs are necessary to extract the correct data from the geopackage
+    if !haskey(reef_cube.properties, "flag_meanings")
+        error("Unable to find key `flag_meanings` in Cube properties.")
+    end
+
+    reef_ids = split(reef_cube.properties["flag_meanings"], " ")
+    if (reef_ids[1] == reef_ids[2])
+        return reef_ids[2:end] # Possible first element duplication
+    end 
+    return reef_ids
+end
+
+
+function Base.show(io::IO, mime::MIME"text/plain", rs::CScapeResultSet)
+    rcps = rs.RCP
+    scens = length(rs.outcomes[:relative_cover].draws)
+    sites = length(rs.outcomes[:relative_cover].reef_sites)
+    tf = rs.env_layer_md.timeframe
+
+    println("""
+    Name: $(rs.name)
+
+    Results stored at: $(rs.env_layer_md.dpkg_path)
+
+    RCP(s) represented: $(rcps)
+    Scenarios run: $(scens)
+    Number of sites: $(sites)
+    Timesteps: $(tf)
+    """)
+end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -40,7 +40,7 @@ function load_results(::Type{CScapeResultSet}, result_loc::String)::CScapeResult
     gpkg_path = _get_gpkg_path(result_loc)
     geodata = GDF.read(gpkg_path)
 
-    connectivity_path = joinpath(result_loc, "connectivity.csv")
+    connectivity_path = joinpath(result_loc, "connectivity/connectivity.csv")
     connectivity = CSV.read(connectivity_path, DataFrame, comment="#", header=true)
     
     # There is missing location data in site data. Use intersection

--- a/src/io/reefmod_result_io.jl
+++ b/src/io/reefmod_result_io.jl
@@ -84,7 +84,7 @@ function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)
         timeframe = raw_set.timestep[1]:raw_set.timestep[end]
     end
 
-    scenario_groups = Dict(:Counterfactual => BitVector(true for _ in raw_set.scenario))
+    scenario_groups = Dict(:counterfactual => BitVector(true for _ in raw_set.scenario))
 
     env_layer_md::EnvLayer = EnvLayer(
         result_loc,

--- a/src/io/reefmod_result_io.jl
+++ b/src/io/reefmod_result_io.jl
@@ -15,6 +15,7 @@ struct ReefModResultSet{T1, T2, D, G, D1} <: ResultSet
     env_layer_md::EnvLayer
     connectivity_data::D
     site_data::G
+    scenario_groups
 
     sim_constants::D1
 
@@ -78,6 +79,8 @@ function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)
         timeframe = raw_set.timestep[1]:raw_set.timestep[end]
     end
 
+    scenario_groups = Dict(:Counterfactual => BitVector(true for _ in raw_set.scenario))
+
     env_layer_md::EnvLayer = EnvLayer(
         result_loc,
         geodata_path,
@@ -120,6 +123,7 @@ function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)
         env_layer_md,
         connectivity,
         geodata,
+        scenario_groups,
         SimConstants(),
         outcomes
 

--- a/src/io/reefmod_result_io.jl
+++ b/src/io/reefmod_result_io.jl
@@ -1,0 +1,193 @@
+using ADRIA: GDF, ResultSet
+
+using YAXArrays
+using NetCDF
+
+
+struct ReefModResultSet{T1, T2, D, G, D1} <: ResultSet
+    name::String
+    RCP::String
+
+    site_ids::T1
+    site_area::Vector{Float64}
+    site_max_coral_cover::Vector{Float64}
+    site_centroids::T2
+    env_layer_md::EnvLayer
+    connectivity_data::D
+    site_data::G
+
+    sim_constants::D1
+
+    # raw::AbstractArray
+    outcomes::Dict{Symbol, YAXArray}
+    # seed_log::B  # Values stored in m^2
+    # fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
+    # shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
+    # coral_dhw_tol_log::D3
+end
+
+function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)::ReefModResultSet
+    !isdir(result_loc) ? error("Expected a directory but received $(result_loc)") : nothing
+
+    result_path = _get_netcdf(result_loc, RCP)
+    raw_set = open_dataset(result_path)
+    
+    name::String = raw_set.properties["reef model"]
+    netcdf_rcp::String = raw_set.properties["climate scenario (RCP)"]
+    if netcdf_rcp != RCP
+        @warn "RCPs given and file found do not match. Using RCP of file found."
+    end
+    
+    geodata_path = joinpath(result_loc, "region", "reefmod_gbr.gpkg")
+    geodata = GDF.read(geodata_path)
+    
+    # Correct site ids in the same manner 
+    _standardize_cluster_ids!(geodata)
+
+    reef_id_col = "UNIQUE_ID"
+    cluster_id_col = "UNIQUE_ID"
+    site_ids = geodata[:, reef_id_col]
+
+    # Load accompanying ID list
+    id_list_fn = _find_file(joinpath(result_loc, "id"), Regex("id_list.*.csv"))
+    id_list = CSV.read(
+        id_list_fn,
+        DataFrame;
+        header=false,
+        comment="#",
+    )
+
+    _manual_id_corrections!(geodata, id_list)
+
+    # Load reef area and convert from km^2 to m^2
+    geodata[:, :area] = id_list[:, 2] .* 1e6
+
+    # Calculate `k` area (1.0 - "ungrazable" area)
+    geodata[:, :k] = 1 .- id_list[:, 3]
+    
+    # Connectivity is loaded using the same method as the Domain
+    connectivity = load_connectivity(RMEDomain, result_loc, site_ids)
+
+    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
+
+    timeframe = 2008:2101
+    if !haskey(raw_set.axes, :timestep)
+        @warn "Unable to find timestep axes. Defaulting to $(timeframe[1]):$(timeframe[end])"
+    else
+        timeframe = raw_set.timestep[1]:raw_set.timestep[end]
+    end
+
+    env_layer_md::EnvLayer = EnvLayer(
+        result_loc,
+        geodata_path,
+        reef_id_col,
+        cluster_id_col,
+        "",
+        joinpath(result_loc, "con_bin"),
+        "",
+        "",
+        timeframe
+    )
+    
+    outcome_keys = [
+        :coral_larval_supply,
+        :coral_cover_per_taxa,
+        :nb_coral_offspring,
+        :nb_coral_adol,
+        :COTS_larval_supply,
+        :nb_coral_adult,
+        :nb_coral_juv,
+        :nb_coral_recruit,
+        :reef_shelter_volume_relative
+    ]
+    outcomes::Dict{Symbol, YAXArray} = Dict()
+    for outcome in outcome_keys
+        if !haskey(raw_set.cubes, outcome)
+            @warn "Unable to find $(string(outcome)). Skipping."
+            continue
+        end
+        outcomes[outcome] = reformat_cube(ReefModResultSet, raw_set.cubes[outcome])
+    end
+
+    return ReefModResultSet(
+        name,
+        netcdf_rcp,
+        site_ids,
+        geodata.area,
+        location_max_coral_cover,
+        location_centroids,
+        env_layer_md,
+        connectivity,
+        geodata,
+        SimConstants(),
+        outcomes
+
+    )
+end
+
+function _get_netcdf(result_loc::String, RCP::String)::String
+    possible_files = filter(x->occursin(RCP, x), readdir(result_loc))
+    possible_files = filter(x->occursin(".nc", x), possible_files)
+    if length(possible_files) == 0
+        throw(ArgumentError("Unable to find ReefMod NetCDF file"))
+    elseif length(possible_files) > 1
+        @warn "Found multiple matching netcdf files. Using first."
+    end
+    return possible_files[1]
+end 
+
+"""
+   reformat_cube(cube::YAXArray)::YAXArray
+
+Temporary function. Reefmod NetCDF files should follow expected dimension naming and ordering.
+"""
+function reformat_cube(::Type{ReefModResultSet}, cube::YAXArray)::YAXArray
+    dim_names = name.(cube.axes)
+    reefmod_names = [:timestep, :location, :group, :scenario]
+    adria_names = [:timesteps, :sites, :taxa, :scenarios]
+    final_ordering::Vector{Int} = Vector{Int}(undef, length(dim_names))
+    current_index = 1
+    # rename expected dimensions and update the permutation vector
+    for (cscape_nm, adria_nm) in zip(reefmod_names, adria_names)
+        if cscape_nm ∉ dim_names
+            continue
+        end
+        cube = renameaxis!(cube, cscape_nm=>adria_nm)
+        final_ordering[current_index] = findfirst(x->x==cscape_nm, dim_names)
+        current_index += 1
+    end
+     # append the indices of non-adria axis to end of permutation vector
+    for dim_name in dim_names
+        if dim_name in reefmod_names
+            continue
+        end
+        final_ordering[current_index] = findfirst(x->x==dim_name, dim_names)
+        current_index += 1;
+    end
+    if haskey(cube.properties, "units")
+        if cube.properties["units"] == "percent"
+            cube = cube ./ 100
+            cube.properties["units"] == "proportion [0, 1]"
+        end
+    end
+    return permutedims(cube, final_ordering)
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", rs::ReefModResultSet)
+    rcps = rs.RCP
+    scens = length(rs.outcomes[:coral_cover_per_taxa].scenarios)
+    sites = length(rs.outcomes[:coral_cover_per_taxa].sites)
+    tf = rs.env_layer_md.timeframe
+
+    println("""
+    Name: $(rs.name)
+
+    Results stored at: $(rs.env_layer_md.dpkg_path)
+
+    RCP(s) represented: $(rcps)
+    Scenarios run: $(scens)
+    Number of sites: $(sites)
+    Timesteps: $(tf)
+    """)
+end

--- a/src/io/reefmod_result_io.jl
+++ b/src/io/reefmod_result_io.jl
@@ -32,7 +32,9 @@ end
 
 Reefmod result interface.
 """
-function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)::ReefModResultSet
+function load_results(
+    ::Type{ReefModResultSet}, result_loc::String, RCP::String
+)::ReefModResultSet
     !isdir(result_loc) ? error("Expected a directory but received $(result_loc)") : nothing
 
     result_path = _get_netcdf(result_loc, RCP)
@@ -117,7 +119,9 @@ function load_results(::Type{ReefModResultSet}, result_loc::String, RCP::String)
             continue
         end
         if outcome == :reef_shelter_volume_relative
-            outcomes[:relative_shelter_volume] = reformat_cube(ReefModResultSet, raw_set.cubes[outcome])
+            outcomes[:relative_shelter_volume] = reformat_cube(
+                ReefModResultSet, raw_set.cubes[outcome]
+            )
             continue
         end
         outcomes[outcome] = reformat_cube(ReefModResultSet, raw_set.cubes[outcome])
@@ -162,7 +166,7 @@ end
 """
    reformat_cube(cube::YAXArray)::YAXArray
 
-Temporary function. Reefmod NetCDF files should follow expected dimension naming and ordering.
+Rename and reorder dimensions to align with ADRIA expectations.
 """
 function reformat_cube(::Type{ReefModResultSet}, cube::YAXArray)::YAXArray
     dim_names = name.(cube.axes)

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -197,7 +197,8 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
 
     # Store ranked sites
-    rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_sites, 2, n_scens)  # sites, site id and rank, no. scenarios
+    n_interventions = length(interventions())
+    rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_sites, n_interventions, n_scens)  # sites, site id and rank, no. scenarios
     fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_sites, n_scens)  # timeframe, sites, no. scenarios
 
     # tf, no. species to seed, site id and rank, no. scenarios

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -196,9 +196,9 @@ Run individual scenarios for a given domain, saving results to a Zarr data store
 Results are stored in Zarr format at a pre-configured location.
 Sets up a new `cache` if not provided.
 
-# Notes
-Logs of site ranks only store the mean site rankings over all environmental scenarios.
-This is to reduce the volume of data stored.
+# Arguments
+- `domain` : Domain
+- `idx` : Scenario index
 
 # Returns
 Nothing
@@ -320,9 +320,6 @@ end
 
 Core scenario running function.
 
-# Notes
-Only the mean site rankings are kept
-
 # Returns
 NamedTuple of collated results
 """
@@ -417,11 +414,11 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     # Avoid placing importance on sites that were not considered
     # Lower values are higher importance/ranks.
     # Values of n_locs+1 indicate locations that were not considered in rankings.
-    log_location_ranks = DataCube(
-        fill(0.0, tf, n_locs, 2);  # log seeding/fogging ranks
+    log_location_ranks = ZeroDataCube(;     # log seeding/fogging ranks
+        T=Float64,
         timesteps=1:tf,
         locations=domain.site_ids,
-        intervention=[:seed, :fog]
+        intervention=interventions()
     )
 
     Yshade = SparseArray(spzeros(tf, n_locs))


### PR DESCRIPTION
The main contribution is the addition of the type `CScapeResultSet <: ResultSet` and a `load_result(::Typeof{CScapeResultSet}, filepath::String)` function.

An example result set is included in the teams files, `cscape_results.zip`.

Connectivity and Geospatial data are loaded into the struct similarly to the existing `load_results` function. CScape Outputs are contained in the outcomes dictionary.

Should methods be added to allow interface more easily with the metrics module?

The scenario visualization function, `ADRIA.viz.scenarios` is overloaded for the domain as the results do not come with an input scenario matrix, so the scenario grouping (`counterfactual`, `guided`, `unguided`) has to be set when the data is loaded. The current data we have is counterfactual so this is the default. See the following usage below:

```julia
using Revise
using ADRIA
using WGLMakie, GeoMakie, GraphMakie

# Load results
results_path = "<path to directory>"
rs = ADRIA.load_results(ADRIA.CScapeResultSet, results_path)
```
Total Cover Plot
```julia
dimension_sum = (:thermal_tolerance, :taxa, :intervened)
relative_cover = dropdims(sum(rs.outcomes[:relative_cover], dims=dimension_sum), dims=dimension_sum)
location_area = reshape(rs.site_area, (1, length(relative_cover.sites), 1))
total_cover = dropdims(sum(relative_cover .* location_area, dims=:sites), dims=:sites)

ADRIA.viz.scenarios(rs, total_cover; axis_opts=Dict(:title=>"Total Cover"))
```
<img width="880" alt="cscape_total_cover" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/c2c0baa0-5adf-4710-9d0c-f84d5bf1a3f0">

Egg Count
```julia
dimension_sum = (:thermal_tolerance, :taxa, :intervened, :sites)
eggs = dropdims(sum(rs.outcomes[:eggs], dims=dimension_sum), dims=dimension_sum)

ADRIA.viz.scenarios(rs, eggs; axis_opts=Dict(:title=>"Egg Counts"))
```
<img width="876" alt="cscape_egg_counts" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/4b57ac64-9e78-405c-892d-533f14626150">

Map Visualisation
```julia
dimension_sum = (:thermal_tolerance, :taxa, :intervened)
relative_cover = dropdims(sum(rs.outcomes[:relative_cover], dims=dimension_sum), dims=dimension_sum)
relative_cover_2030 = dropdims(mean(relative_cover, dims=:scenarios), dims=:scenarios)[timesteps=At(2030)]

ADRIA.viz.map(rs, relative_cover_2030)
```
<img width="671" alt="cscape_map_visualisation" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/fa3484c0-95a0-449d-b01e-772f61a50683">

