### PR TITLE
improve load_domain docs

### DIFF
--- a/docs/src/usage/domain.md
+++ b/docs/src/usage/domain.md
@@ -1,16 +1,21 @@
 # Loading a Domain
 
 ADRIA is designed to work with `Domain` data packages.
-In short, these are pre-packaged data sets that hold all the necessary data to run
-simulations for a given spatial domain.
+
+At their core, data packages are a directory containing a `datapackage.json` file,
+following the [spec](https://specs.frictionlessdata.io/data-package/) as
+outlined by Frictionless Data. In short, these are pre-packaged data sets that hold all the
+necessary data to run simulations for a given spatial domain.
 
 See [Architectural overview](@ref) for more information.
 
-A `Domain` may be loaded by calling the `load_domain` function with the path to the data package directory containing the *datapackage.json* file.
+A `Domain` may be loaded by calling the `load_domain` function with the path to the data
+package. Note that the data package is the *directory*.
+
 By convention we assign the `Domain` to `dom`, although this variable can be named anything.
 
 ```julia
-dom = ADRIA.load_domain("path to domain data package directory")
+dom = ADRIA.load_domain("path to domain data package")
 ```
 
 ReefMod Engine datasets can also be used to run ADRIAmod simulations for the Great Barrier

--- a/docs/src/usage/domain.md
+++ b/docs/src/usage/domain.md
@@ -6,11 +6,11 @@ simulations for a given spatial domain.
 
 See [Architectural overview](@ref) for more information.
 
-A `Domain` may be loaded with the `load_domain` function.
+A `Domain` may be loaded by calling the `load_domain` function with the path to the data package directory containing the *datapackage.json* file.
 By convention we assign the `Domain` to `dom`, although this variable can be named anything.
 
 ```julia
-dom = ADRIA.load_domain("path to domain data package")
+dom = ADRIA.load_domain("path to domain data package directory")
 ```
 
 ReefMod Engine datasets can also be used to run ADRIAmod simulations for the Great Barrier

--- a/docs/src/usage/getting_started.md
+++ b/docs/src/usage/getting_started.md
@@ -67,7 +67,7 @@ Load data for a spatial domain. See [Loading a Domain](@ref) for more details:
 ```julia
 using ADRIA
 
-dom = ADRIA.load_domain("path to domain data package")
+dom = ADRIA.load_domain("path to domain data package directory")
 ```
 
 Generate scenarios based on available environmental data layers and model parameters. The

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -230,6 +230,8 @@ end
 - `rcp` : RCP scenario to run. If none provided, no data path is set.
 """
 function load_domain(::Type{ADRIADomain}, path::String, rcp::String)::ADRIADomain
+    isdir(path) ? true : error("Path does not exist or is not a directory.")
+
     domain_name::String = basename(path)
     if length(domain_name) == 0
         domain_name = basename(dirname(path))

--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -112,6 +112,8 @@ Load a ReefMod Engine dataset.
 RMEDomain
 """
 function load_domain(::Type{RMEDomain}, fn_path::String, RCP::String)::RMEDomain
+    isdir(fn_path) ? true : error("Path does not exist or is not a directory.")
+
     data_files = joinpath(fn_path, "data_files")
     dhw_scens::YAXArray{Float64} = load_DHW(RMEDomain, data_files, RCP)
     loc_ids::Vector{String} = collect(dhw_scens.locs)

--- a/src/ExtInterface/ReefMod/ReefModDomain.jl
+++ b/src/ExtInterface/ReefMod/ReefModDomain.jl
@@ -64,6 +64,7 @@ function load_domain(
     RCP::String;
     timeframe::Tuple=(2022, 2100)
 )::ReefModDomain
+    isdir(fn_path) ? true : error("Path does not exist or is not a directory.")
     netcdf_file = _find_netcdf(fn_path, RCP)
     dom_dataset::Dataset = open_dataset(netcdf_file)
 


### PR DESCRIPTION
Clarify that path is to the directory, not the datapackage.json file.

Note: could make ADRIA support pointing to either, but just updating the docs for now.