### PR TITLE
Support more vector types for maps

### DIFF
--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -17,7 +17,7 @@ Figure
 """
 function ADRIA.viz.scenarios(
     outcomes::AbstractMatrix{<:Real},
-    clusters::Union{BitVector,Vector{Int64}};
+    clusters::Union{BitVector,AbstractVector{Int64}};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),
@@ -92,7 +92,7 @@ function ADRIA.viz.clustered_scenarios!(
 end
 
 """
-    map(rs::Union{Domain,ResultSet}, data::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    map(rs::Union{Domain,ResultSet}, data::AbstractMatrix, clusters::AbstractVector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
     map(g, rs, data, clusters; opts::Dict=Dict(), axis_opts::Dict=Dict())
 
 Visualize clustered time series for each site and map.
@@ -112,7 +112,7 @@ Figure
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
     data::AbstractArray{<:Real},
-    clusters::Union{BitVector,Vector{Int64}};
+    clusters::Union{BitVector,AbstractVector{Int64}};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -146,7 +146,7 @@ GridPosition
 """
 function ADRIA.viz.map(
     rs::Union{Domain, ResultSet},
-    y::YAXArray;
+    y::Union{YAXArray, AbstractVector{<:Real}};
     opts::Dict=Dict(),
     fig_opts::Dict=Dict(),
     axis_opts::Dict=Dict(),


### PR DESCRIPTION
Previous implementation only supported YAXArrays, so if you could not easily plot an arbitrary dataset

```julia
# This could not be done
some_values = [...]
ADRIA.viz.map(dom, some_values )
```

This PR expands the supported datatypes to include `AbstractVector{<:Real}`.