### PR TITLE
Clean up connectivity and centrality methods

### DIFF
--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -21,9 +21,6 @@ mutable struct RMEDomain <: AbstractReefModDomain
     env_layer_md::ADRIA.EnvLayer
     scenario_invoke_time::String  # time latest set of scenarios were run
     const conn::YAXArray{Float64}
-    const in_conn::Vector{Float64}
-    const out_conn::Vector{Float64}
-    const strong_pred::Vector{Int64}
     const site_data::DataFrames.DataFrame
     const site_id_col::String
     const cluster_id_col::String
@@ -158,9 +155,6 @@ function load_domain(::Type{RMEDomain}, fn_path::String, RCP::String)::RMEDomain
     init_coral_cover::YAXArray{Float64} = load_initial_cover(RMEDomain, data_files, loc_ids, spatial_data)
 
     conn_data::YAXArray{Float64} = load_connectivity(RMEDomain, data_files, loc_ids)
-    in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(
-        conn_data, vec(spatial_data.area .* spatial_data.k), similar(conn_data)
-    )
 
     # Set all site depths to 7m below sea level
     # (ReefMod does not account for depth)
@@ -223,9 +217,6 @@ function load_domain(::Type{RMEDomain}, fn_path::String, RCP::String)::RMEDomain
         env_md,
         "",
         conn_data,
-        in_conn,
-        out_conn,
-        strong_pred,
         spatial_data,
         reef_id_col,
         cluster_id_col,

--- a/src/ExtInterface/ReefMod/ReefModDomain.jl
+++ b/src/ExtInterface/ReefMod/ReefModDomain.jl
@@ -19,9 +19,6 @@ mutable struct ReefModDomain <: AbstractReefModDomain
     env_layer_md
     scenario_invoke_time::String  # time latest set of scenarios were run
     const conn
-    const in_conn
-    const out_conn
-    const strong_pred
     const site_data
     const site_id_col
     const cluster_id_col
@@ -119,9 +116,6 @@ function load_domain(
 
     # Connectivity data is retireved from a subdirectory because it's not contained in matfiles
     conn_data = load_connectivity(RMEDomain, fn_path, site_ids)
-    in_conn, out_conn, strong_pred = ADRIA.connectivity_strength(
-        conn_data, vec(spatial_data.area .* spatial_data.k), similar(conn_data)
-    )
 
     spatial_data[:, :depth_med] .= 6.0
     spatial_data[!, :depth_med] = convert.(Float64, spatial_data[!, :depth_med])
@@ -174,9 +168,6 @@ function load_domain(
         env_md,
         "",
         conn_data,
-        in_conn,
-        out_conn,
-        strong_pred,
         spatial_data,
         reef_id_col,
         cluster_id_col,

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -105,7 +105,8 @@ function rank_locations(
     area_weighted_conn = dom.conn.data .* site_k_area(dom)
     conn_cache = similar(area_weighted_conn)
 
-    in_conn, out_conn, strong_pred = connectivity_strength(area_weighted_conn, sum_cover, conn_cache)
+    in_conn, out_conn, network = connectivity_strength(area_weighted_conn, sum_cover, conn_cache)
+    # strong_pred = strongest_source(g, network)
 
     scens = DataCube(
         Matrix(scenarios);

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -656,7 +656,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
             # Determine connectivity strength weighting by area.
             # Accounts for strength of connectivity where there is low/no coral cover
-            in_conn, out_conn, strong_pred = connectivity_strength(area_weighted_conn, vec(loc_coral_cover), conn_cache)
+            in_conn, out_conn, _ = connectivity_strength(area_weighted_conn, vec(loc_coral_cover), conn_cache)
 
             update_criteria_values!(
                 decision_mat;


### PR DESCRIPTION
This PR:

- Separates out determination of the strongest source locations
- Allows flexible use of alternate centrality measures in determining centrality
- Removes unused connectivity data from Domain types, making them more memory efficient

Previous implementation of the strongest source location violated the Single Responsibility Principle, as it was lumped in with all other connectivity-related calculations. In addition, it was unused but was being recalculated every decision point. As it was naively iterating through all nodes in the graph (rather than just target nodes of interest), it would take upwards of 10 seconds per decision point.

In the worst case for a large network (such as one representing the entire GBR), this would explode run times from ~2 hours to ~12 hours for a small set of 768 scenarios.

This set of changes makes `connectivity_strength()` essentially a wrapper around two lines of code. Really, it could be removed, but I am leaving it as is for now.

As an aside, I am unsure of the area-weighted implementation of connectivity is worthwhile given MCDA considers available space as a separate criteria already, but again, leaving it as is for now.
