### PR TITLE
Connectivity viz

### DIFF
--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -216,6 +216,81 @@ function ADRIA.viz.map!(
 end
 
 """
+    ADRIA.viz.connectivity(dom::Domain, conn_weights::AbstractVector{<:Real};opts::Dict=Dict(),fig_opts::Dict=Dict(),axis_opts::Dict=Dict())
+    ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition},dom::Domain,conn_weights::AbstractVector{<:Real};opts::Dict=Dict(),axis_opts::Dict=Dict())
+
+Plot spatial distribution of connectivity measures.
+
+# Examples
+
+in_conn, out_conn, network = ADRIA.connectivity_strength(
+    dom.conn; 
+    in_method=indegree_centrality, 
+    out_method=eigenvector_centrality
+)
+
+opts = Dict(
+    :colorbar_label => "Eigenvector Centrality"
+)
+
+ADRIA.viz.connectivity(
+    dom,
+    out_conn;
+    opts
+)
+
+# Arguments
+- `dom` : Domain
+- `conn_weights` : Connectivity weights for each location
+- `opts` : Aviz options 
+- `fig_opts` : Figure options
+- `axis_opts` : Axis options
+"""
+function ADRIA.viz.connectivity(
+    dom::Domain, 
+    conn_weights::AbstractVector{<:Real};
+    opts::Dict=Dict(),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+
+    ADRIA.viz.connectivity!(g, dom, conn_weights; opts, axis_opts)
+
+    return f
+end
+function ADRIA.viz.connectivity!(
+    g::Union{GridLayout, GridPosition},
+    dom::Domain,
+    conn_weights::AbstractVector{<:Real};
+    opts::Dict=Dict(),
+    axis_opts::Dict=Dict()
+)
+    geodata = get_geojson_copy(dom)
+    data = Observable(collect(conn_weights))
+
+    highlight = get(opts, :highlight, nothing)
+    c_label = get(opts, :colorbar_label, "Connectivity Measure")
+    legend_params = get(opts, :legend_params, nothing)
+    show_colorbar = get(opts, :show_colorbar, true)
+    color_map = get(opts, :color_map, :PuBuGn)
+
+    return create_map!(
+        g,
+        geodata,
+        data,
+        highlight,
+        ADRIA.centroids(dom),
+        show_colorbar,
+        c_label,
+        color_map,
+        legend_params,
+        axis_opts,
+    )
+end
+
+"""
     make_geojson_copy(ds::Union{ResultSet,Domain})::String
 
 Make a temporary copy of GeoPackage as GeoJSON.

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -244,6 +244,10 @@ ADRIA.viz.connectivity(
 - `network` : SimpleWeightedDiGraph calculated from the connectivity matrix
 - `conn_weights` : Connectivity weighted for each node
 - `opts` : AvizOpts
+    - `edge_color`, vector of colours for edges. Defaults to reasonable weighting
+    - `node_color`, vector of colours for node. Defaults to conn_weights
+    - `node_size`, size of nodes in the graph
+    - `exp_node_size`, bool, indicating whether node size should be emphasised by exp.
 - `fig_opts` : Figure options
 - `axis_opts` : Axis options
 """
@@ -287,7 +291,7 @@ function ADRIA.viz.connectivity!(
     spatial.yticklabelpad = 50
     spatial.ytickalign = 10
     
-    # Calculate alpha values for edges based on connectvity strength and weighting
+    # Calculate alpha values for edges based on connectivity strength and weighting
     edge_col = Vector{Tuple{Symbol, Float64}}(undef, ne(network))
     norm_coef = maximum(conn_weights)
     for (ind, e) in enumerate(edges(network))
@@ -322,7 +326,7 @@ function ADRIA.viz.connectivity!(
         edge_plottype=:linesegments
     )
 
-    # Plot geodata polygons using data as internal color
+    # Plot geodata polygons
     poly!(
         spatial,
         geodata;

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -220,10 +220,11 @@ end
     ADRIA.viz.connectivity(dom::Domain, network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict()) 
     ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition}, dom::Domain,  network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), axis_opts::Dict=Dict()) 
 
-Produce visualisation of connectivity between reef sites with node size and edge visability
+Produce visualization of connectivity between reef sites with node size and edge visibility
 weighted by the connectivity values and node weights.
 
-# Example
+# Examples
+
 ```julia
 dom = ADRIA.load_domain("<Path to Domain>")
 
@@ -238,15 +239,16 @@ ADRIA.viz.connectivity(
     axis_opts=axis_opts
 )
 ```
+
 # Arguments
 - `dom` : Domain
 - `network` : SimpleWeightedDiGraph calculated from the connectivity matrix
 - `conn_weights` : Connectivity weighted for each node
 - `opts` : AvizOpts
     - `edge_color`, vector of colours for edges. Defaults to reasonable weighting
-    - `node_color`, vector of colours for node. Defaults to conn_weights
+    - `node_color`, vector of colours for node. Defaults to `conn_weights`
     - `node_size`, size of nodes in the graph
-    - `exp_node_size`, bool, indicating whether node size should be emphasised by exp.
+    - `exp_node_size`, bool, indicating whether node size should be emphasised by exponentiation
 - `fig_opts` : Figure options
 - `axis_opts` : Axis options
 """
@@ -302,17 +304,18 @@ function ADRIA.viz.connectivity!(
     end
     
     # Rescale node size to be visible
-    node_sz = conn_weights ./ maximum(conn_weights) .* 10.0
+    node_size = conn_weights ./ maximum(conn_weights) .* 10.0
     
     # Extract graph kwargs and set defaults
     edge_col = get(opts, :edge_color, edge_col)
-    node_sz  = get(opts, :node_size, node_sz)
+    node_size  = get(opts, :node_size, node_size)
+
     # Add emphasis on connectivity weightings by setting node size to be exponential
     expo_size = get(opts, :exp_node_size, false)
     if (expo_size)
-        node_sz = exp.(node_sz)
+        node_size = exp.(node_size)
     end
-    node_cl = get(opts, :node_color, node_sz)
+    node_color = get(opts, :node_color, node_size)
     
     # Plot the connectivity graph
     graphplot!(
@@ -320,8 +323,8 @@ function ADRIA.viz.connectivity!(
         network, 
         layout=ADRIA.centroids(dom), 
         edge_color=edge_col, 
-        node_size=node_sz, 
-        node_color=node_cl,
+        node_size=node_size, 
+        node_color=node_color,
         edge_plottype=:linesegments
     )
 

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -310,6 +310,14 @@ function ADRIA.viz.connectivity!(
     node_size  = get(opts, :node_size, node_size)
     node_color = get(opts, :node_color, node_size)
     
+    # Plot geodata polygons
+    poly!(
+        spatial,
+        geodata;
+        color=:white,
+        strokecolor=(:black, 0.25),
+        strokewidth=1.0,
+    )
     # Plot the connectivity graph
     graphplot!(
         spatial, 
@@ -321,14 +329,6 @@ function ADRIA.viz.connectivity!(
         edge_plottype=:linesegments
     )
 
-    # Plot geodata polygons
-    poly!(
-        spatial,
-        geodata;
-        color=:white,
-        strokecolor=(:black, 0.05),
-        strokewidth=1.0,
-    )
 
     return g
 end

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -238,7 +238,6 @@ ADRIA.viz.connectivity(
     axis_opts=axis_opts
 )
 ```
-
 # Arguments
 - `dom` : Domain
 - `network` : SimpleWeightedDiGraph calculated from the connectivity matrix

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -248,7 +248,6 @@ ADRIA.viz.connectivity(
     - `edge_color`, vector of colours for edges. Defaults to reasonable weighting
     - `node_color`, vector of colours for node. Defaults to `conn_weights`
     - `node_size`, size of nodes in the graph
-    - `exp_node_size`, bool, indicating whether node size should be emphasised by exponentiation
 - `fig_opts` : Figure options
 - `axis_opts` : Axis options
 """
@@ -309,12 +308,6 @@ function ADRIA.viz.connectivity!(
     # Extract graph kwargs and set defaults
     edge_col = get(opts, :edge_color, edge_col)
     node_size  = get(opts, :node_size, node_size)
-
-    # Add emphasis on connectivity weightings by setting node size to be exponential
-    expo_size = get(opts, :exp_node_size, false)
-    if (expo_size)
-        node_size = exp.(node_size)
-    end
     node_color = get(opts, :node_color, node_size)
     
     # Plot the connectivity graph

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -222,7 +222,7 @@ end
 Plot spatial distribution of connectivity measures.
 
 # Examples
-
+```julia
 in_conn, out_conn, network = ADRIA.connectivity_strength(
     dom.conn; 
     in_method=indegree_centrality, 
@@ -238,6 +238,7 @@ ADRIA.viz.connectivity(
     out_conn;
     opts
 )
+```
 
 # Arguments
 - `dom` : Domain

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -216,8 +216,8 @@ function ADRIA.viz.map!(
 end
 
 """
-    ADRIA.viz.connectivity(dom::Domain, conn_weights::AbstractVector{<:Real};opts::Dict=Dict(),fig_opts::Dict=Dict(),axis_opts::Dict=Dict())
-    ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition},dom::Domain,conn_weights::AbstractVector{<:Real};opts::Dict=Dict(),axis_opts::Dict=Dict())
+    ADRIA.viz.connectivity(dom::Domain, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition}, dom::Domain, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), axis_opts::Dict=Dict())
 
 Plot spatial distribution of connectivity measures.
 

--- a/src/viz/viz.jl
+++ b/src/viz/viz.jl
@@ -42,5 +42,7 @@ function ranks_to_frequencies!() end
 # Spatial
 function map() end
 function map!() end
+function connectivity() end
+function connectivity!() end
 
 end  # module


### PR DESCRIPTION
Add connectivity visualistion method.
```julia
dom = ADRIA.load_domain("<Path to Domain>")
in_conn, out_conn, network = ADRIA.connectivity_strength(dom; out_method=eigenvector_centrality)
ADRIA.viz.connectivity(
    dom,
    network,
    out_conn;
    opts=opts,
    fig_opts=fig_opts,
    axis_opts=axis_opts
)
```
Providing reasonable defaults for the graph visualisation is difficult because of the size of the graph and the variance from south to north. However, the interactivity somewhat remedies this. Feel free to provide suggestions.

### Entire 
<img width="230" alt="entire_gbr_conn" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/be65ae88-db72-4e8c-a491-1df311144412">

### South
<img width="281" alt="south_gbr_conn" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/9a959fbf-b975-46d4-aadc-6581008de814">

### Central
<img width="281" alt="central_gbr_conn" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/05066d6f-71dd-4670-ad26-837c673dce78">

### North
<img width="227" alt="north_gbr_conn" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/9e79e695-b0f4-41e8-a712-00af4f98f6a8">

