### PR TITLE
RME Result Interface

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(
         "Usage" => [
             "usage/getting_started.md",
             "usage/domain.md",
+            "usage/results.md",
             "usage/scenario_generation.md",
             "usage/scenario_runs.md",
             "usage/analysis.md",

--- a/docs/src/usage/results.md
+++ b/docs/src/usage/results.md
@@ -2,14 +2,13 @@
 
 ## Loading ReefModEngine Results
 
-Results from ReefModEngine.jl can be loaded with the `load_results` function. There are two
-options depending on the location of the results and accompanying data files. 
+Results from ReefModEngine.jl can be loaded with the `load_results` function.
 
 ```julia
-rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to results dir>")
+rs = ADRIA.load_results(RMEResultSet, "<path to data dir>")
 ```
 
-Expected data directory structure.
+Expected data directory structure:
 
 ```bash
 data_dir
@@ -25,24 +24,17 @@ data_dir
 ├───id
 │       id_list_2023_03_30.csv
 │
-└───region
-       reefmod_gbr.gpkg
+├───region
+│       reefmod_gbr.gpkg
+│
+└───results
+        results.nc
+        scenarios.csv
 ```
-
-The results data directory should contain a `results.nc` NetCDF file and `scenarios.csv`. If
-the path to the results directory is not supplied, the results are expected to be
-contained in a results subdirectory.
+In order to reduce the duplication of geospatial and conectivity data, the data directory
+and results directory can be supplied seperately to avoid having copies for each resuilt set
+analysed.
 
 ```julia
-rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>")
-```
-
-Expected data directory structure for defaulted result directory.
-
-```bash
-data_dir
-├───con_bin
-├───id
-├───region
-└───results
+rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>", "<path to results dir>")
 ```

--- a/docs/src/usage/results.md
+++ b/docs/src/usage/results.md
@@ -1,0 +1,48 @@
+# Loading Results
+
+## Loading ReefModEngine Results
+
+Results from ReefModEngine.jl can be loaded with the `load_results` function. There are two
+options depending on the location of the results and accompanying data files. 
+
+```julia
+rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to results dir>")
+```
+
+Expected data directory structure.
+
+```bash
+data_dir
+│
+├───con_bin
+│       CONNECT_ACRO_2010_11.bin
+│       CONNECT_ACRO_2011_12.bin
+│       CONNECT_ACRO_2012_13.bin
+│       CONNECT_ACRO_2014_15.bin
+│       CONNECT_ACRO_2015_16.bin
+│       CONNECT_ACRO_2016_17.bin
+│
+├───id
+│       id_list_2023_03_30.csv
+│
+└───region
+       reefmod_gbr.gpkg
+```
+
+The results data directory should contain a `results.nc` NetCDF file and `scenarios.csv`. If
+the path to the results directory is not supplied, the results are expected to be
+contained in a results subdirectory.
+
+```julia
+rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>")
+```
+
+Expected data directory structure for defaulted result directory.
+
+```bash
+data_dir
+├───con_bin
+├───id
+├───region
+└───results
+```

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -1,6 +1,6 @@
 using JuliennedArrays: Slices
 using ADRIA.analysis: series_confint
-using ADRIA: axes_names
+using ADRIA: axes_names, RMEResultSet
 
 """
     ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::YAXArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
@@ -45,7 +45,7 @@ function ADRIA.viz.scenarios(
     opts::Dict=Dict(:by_RCP => false),
     fig_opts::Dict=Dict(:size=>(800, 300)),
     axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    series_opts::Dict=Dict()
 )::Figure
     return ADRIA.viz.scenarios(
         rs.inputs,
@@ -74,6 +74,33 @@ function ADRIA.viz.scenarios!(
         axis_opts=axis_opts,
         series_opts=series_opts,
     )
+end
+function ADRIA.viz.scenarios(
+    rs::RMEResultSet,
+    outcomes::YAXArray;
+    opts::Dict=Dict(:by_RCP => false),
+    fig_opts::Dict=Dict(),
+    axis_opts::Dict=Dict(),
+    series_opts::Dict=Dict(),
+)
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+
+    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
+    xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
+    ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
+    scen_groups = rs.scenario_groups
+
+    ADRIA.viz.scenarios!(
+        g,
+        ax,
+        outcomes,
+        scen_groups;
+        opts=opts,
+        axis_opts=axis_opts, 
+        series_opts=series_opts
+    )
+    return f
 end
 function ADRIA.viz.scenarios(
     scenarios::DataFrame,

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -66,6 +66,7 @@ include("interventions/fogging.jl")
 
 include("io/ResultSet.jl")
 include("io/result_io.jl")
+include("io/rme_result_io.jl")
 include("io/result_post_processing.jl")
 include("io/sampling.jl")
 include("metrics/metrics.jl")
@@ -94,6 +95,7 @@ export
 export RMEDomain
 export ReefModDomain
 
+export RMEResultSet
 # metric helper methods
 # export dims, ndims
 

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -14,7 +14,9 @@ const MODEL_SPEC = "model_spec"
 const RESULTS = "results"
 const SPATIAL_DATA = "spatial"
 
-struct ResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF}
+abstract type ResultSet end
+
+struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF} <: ResultSet
     name::String
     RCP::String
     invoke_time::String
@@ -56,7 +58,7 @@ function ResultSet(
     model_spec::DataFrame,
 )::ResultSet
     rcp = "RCP" in keys(input_set.attrs) ? input_set.attrs["RCP"] : input_set.attrs["rcp"]
-    return ResultSet(input_set.attrs["name"],
+    return ADRIAResultSet(input_set.attrs["name"],
         string(rcp),
         input_set.attrs["invoke_time"],
         input_set.attrs["ADRIA_VERSION"],

--- a/src/io/rme_result_io.jl
+++ b/src/io/rme_result_io.jl
@@ -173,24 +173,29 @@ function _construct_scenario_groups(
     if size(inputs) == (0, 0)
         return Dict(:counterfactual => BitVector([true for _ in 1:n_scenarios]))
     end
+
     counterfactual_scens::BitVector = BitVector([
         p_a == 0.0 && e_a == 0 for (p_a, e_a)
             in zip(inputs.outplant_area_pct, inputs.enrichment_area_pct)
     ])
+
     # Intervened if not counterfactual
     intervened_scens::BitVector = BitVector([
         p_a != 0 || e_a != 0 for (p_a, e_a)
             in zip(inputs.outplant_area_pct, inputs.enrichment_area_pct)
     ])
+
     scenario_groups::Dict{Symbol, BitVector} = Dict()
 
     # If the runs do not contain counterfactual or intervened runs exclude the key
     if any(counterfactual_scens)
         scenario_groups[:counterfactual] = counterfactual_scens
     end
+
     if any(intervened_scens)
         scenario_groups[:intervened] = intervened_scens
     end
+
     return scenario_groups
 end
 
@@ -204,6 +209,7 @@ function _reformat_cube(::Type{RMEResultSet}, cube::YAXArray)::YAXArray
     if :locations in name.(cube.axes)
         cube = renameaxis!(cube, :locations => :sites)
     end
+
     return cube
 end
 

--- a/src/io/rme_result_io.jl
+++ b/src/io/rme_result_io.jl
@@ -25,7 +25,8 @@ struct RMEResultSet{T1, T2, D, G, D1} <: ResultSet
 end
 
 """
-    load_results(::Type{RMEResultSet}, result_loc::String, RCP::String)::RMEResultSet
+    load_results(::Type{RMEResultSet}, data_dir::String)::RMEResultSet
+    load_results(::Type{RMEResultSet}, data_dir::String, result_dir::String)::RMEResultSet
 
 Reefmod result interface.
 

--- a/src/io/rme_result_io.jl
+++ b/src/io/rme_result_io.jl
@@ -1,0 +1,189 @@
+using ADRIA: GDF, ResultSet
+using ArchGDAL: centroid
+using DataFrames,
+    DimensionalData,
+    NetCDF,
+    YAXArrays
+
+struct RMEResultSet{T1, T2, D, G, D1} <: ResultSet
+    name::String
+    RCP::String
+
+    site_ids::T1
+    site_area::Vector{Float64}
+    site_max_coral_cover::Vector{Float64}
+    site_centroids::T2
+    env_layer_md::EnvLayer
+    connectivity_data::D
+    site_data::G
+    scenario_groups
+    inputs::DataFrame
+
+    sim_constants::D1
+
+    outcomes::Dict{Symbol, YAXArray}
+end
+
+"""
+    load_results(::Type{RMEResultSet}, result_loc::String, RCP::String)::RMEResultSet
+
+Reefmod result interface.
+
+# Arguments
+- `data_dir`: Path to directory containing geospatial and connectivity data
+- `result_dir`: Path to directory containing results in a netcdf file. Defaults to subdirectory of `data_dir` named "results"
+
+# Returns
+RMEResultSet struct compatible with most ADRIA analysis functionality.
+"""
+function load_results(
+    ::Type{RMEResultSet}, data_dir::String
+)::RMEResultSet
+    return load_results(RMEResultSet, data_dir, joinpath(data_dir, "results"))
+end
+function load_results(
+    ::Type{RMEResultSet}, data_dir::String, result_dir::String
+)::RMEResultSet
+    !isdir(data_dir) ? error("Expected a directory but received $(data_dir)") : nothing
+    
+    result_path = joinpath(result_dir, "results.nc")
+    raw_set = open_dataset(result_path)
+
+    input_path = joinpath(result_dir, "scenarios.csv")
+    inputs::DataFrame = CSV.read(input_path, DataFrame, header=true)
+    
+    name::String = "ReefModEngine Result Set"
+    netcdf_rcp::String = "Unknown"
+    
+    geodata_path = joinpath(data_dir, "region", "reefmod_gbr.gpkg")
+    geodata = GDF.read(geodata_path)
+    
+    # Correct site ids in the same manner 
+    _standardize_cluster_ids!(geodata)
+
+    reef_id_col = "UNIQUE_ID"
+    cluster_id_col = "UNIQUE_ID"
+    site_ids = geodata[:, reef_id_col]
+
+    # Load accompanying ID list
+    id_list_fn = _find_file(joinpath(data_dir, "id"), Regex("id_list.*.csv"))
+    id_list = CSV.read(
+        id_list_fn,
+        DataFrame;
+        header=false,
+        comment="#",
+    )
+
+    _manual_id_corrections!(geodata, id_list)
+
+    # Load reef area and convert from km^2 to m^2
+    geodata[:, :area] = id_list[:, 2] .* 1e6
+
+    # Calculate `k` area (1.0 - "ungrazable" area)
+    geodata[:, :k] = 1 .- id_list[:, 3]
+    
+    # Connectivity is loaded using the same method as the Domain
+    connectivity = load_connectivity(RMEDomain, data_dir, site_ids)
+
+    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
+
+    timeframe = 2008:2101
+    if !haskey(raw_set.axes, :timesteps)
+        @warn "Unable to find timestep axes. Defaulting to $(timeframe[1]):$(timeframe[end])"
+    else
+        timeframe = raw_set.timesteps[1]:raw_set.timesteps[end]
+    end
+    
+    # Counterfactual scenario if outplant area and enrichment area are both 0
+    counterfactual_scens::BitVector = BitVector([
+        p_a == 0.0 && e_a == 0 for (p_a, e_a) 
+            in zip(inputs.outplant_area_pct, inputs.enrichment_area_pct)
+    ])
+    # Intervened if not counterfactual
+    intervened_scens::BitVector = BitVector([
+        p_a != 0 || e_a != 0 for (p_a, e_a)
+            in zip(inputs.outplant_area_pct, inputs.enrichment_area_pct)
+    ])
+    scenario_groups::Dict{Symbol, BitVector} = Dict()
+    
+    # If the runs do not contain counterfactual or intervened runs exclude the key
+    if any(counterfactual_scens)
+        scenario_groups[:counterfactual] = counterfactual_scens
+    end
+    if any(intervened_scens) 
+        scenario_groups[:intervened] = intervened_scens
+    end
+
+
+    env_layer_md::EnvLayer = EnvLayer(
+        data_dir,
+        geodata_path,
+        reef_id_col,
+        cluster_id_col,
+        "",
+        joinpath(data_dir, "con_bin"),
+        "",
+        "",
+        timeframe
+    )
+    
+    outcomes::Dict{Symbol, YAXArray} = Dict();
+    for (key, cube) in raw_set.cubes
+        outcomes[key] = _reformat_cube(RMEResultSet, cube)
+    end
+    
+    # Calculate relative cover
+    n_locations::Int = length(raw_set.locations)
+    outcomes[:relative_cover] = 
+        (outcomes[:total_cover] ./ 100) ./ reshape(geodata.k, (1, n_locations, 1))
+    outcomes[:relative_taxa_cover] = 
+        (outcomes[:total_taxa_cover] ./ 100) ./ reshape(geodata.k, (1, n_locations, 1))
+
+    return RMEResultSet(
+        name,
+        netcdf_rcp,
+        site_ids,
+        geodata.area,
+        location_max_coral_cover,
+        location_centroids,
+        env_layer_md,
+        connectivity,
+        geodata,
+        scenario_groups,
+        inputs,
+        SimConstants(),
+        outcomes
+    )
+end
+
+"""
+    _reformat_cube(::Type{RMEResultSet}, cube::YAXArray)::YAXArray
+
+Reformat an outcome cube to match dimension names and ordering of ADRIA cubes.
+"""
+function _reformat_cube(::Type{RMEResultSet}, cube::YAXArray)::YAXArray
+    # Eventually ADRIA will use locations instead of sites
+    if :locations in name.(cube.axes)
+        cube = renameaxis!(cube, :locations => :sites)
+    end
+    return cube
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", rs::RMEResultSet)
+    rcps = rs.RCP
+    scens = length(rs.outcomes[:total_cover].scenarios)
+    locations = length(rs.outcomes[:total_cover].sites)
+    tf = rs.env_layer_md.timeframe
+
+    println("""
+    Name: $(rs.name)
+
+    Results stored at: $(rs.env_layer_md.dpkg_path)
+
+    RCP(s) represented: $(rcps)
+    Scenarios run: $(scens)
+    Number of locations: $(locations)
+    Timesteps: $(tf)
+    """)
+end


### PR DESCRIPTION
Results from ReefModEngine.jl can be loaded with the `load_results` function. There are two options depending on the location of the results and accompanying data files. The datafiles in the RME directory can be used as the data directory.

```julia
rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to results dir>")
```

Expected data directory structure.

```bash
data_dir
│
├───con_bin
│       CONNECT_ACRO_2010_11.bin
│       CONNECT_ACRO_2011_12.bin
│       CONNECT_ACRO_2012_13.bin
│       CONNECT_ACRO_2014_15.bin
│       CONNECT_ACRO_2015_16.bin
│       CONNECT_ACRO_2016_17.bin
│
├───id
│       id_list_2023_03_30.csv
│
└───region
       reefmod_gbr.gpkg
```

The results data directory should contain a `results.nc` NetCDF file and `scenarios.csv`. If
the path to the results directory is not supplied, the results are expected to be
contained in a results subdirectory.

```julia
rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>")
```

Expected data directory structure for defaulted result directory.

```bash
data_dir
├───con_bin
├───id
├───region
└───results
```
Allows access to sensitivity analysis, some of ADRIA metrics and map visualization.

![image](https://github.com/open-AIMS/ADRIA.jl/assets/156630392/857d5659-f16e-487e-b5ac-9bf3dbb088fe)
![image](https://github.com/open-AIMS/ADRIA.jl/assets/156630392/971d3979-07dd-470e-9fe7-959d6fe82439)
