### PR TITLE
Improved support for spatial maps

### DIFF
--- a/ext/AvizExt/AvizExt.jl
+++ b/ext/AvizExt/AvizExt.jl
@@ -38,11 +38,6 @@ include("./analysis.jl")
 include("./viz/viz.jl")
 
 
-function __init__()
-    ADRIA.viz.tmpdir = mktempdir()
-end
-
-
 """Main entry point for app."""
 function julia_main()::Cint
     if "explore" in ARGS
@@ -204,9 +199,6 @@ function ADRIA.viz.explore(rs::ResultSet)
     Label(traj_time_sld[1, 1], left_year_val)
     Label(traj_time_sld[1, 4], right_year_val)
 
-    # Get bounds to display
-    centroids = rs.site_centroids
-
     # Placeholder store to control which trajectories are visible
     X = rs.inputs
     min_color_step = (1.0 / 0.05)
@@ -357,7 +349,7 @@ function ADRIA.viz.explore(rs::ResultSet)
     @info "Generating map"
     map_display = layout.map
     geodata = get_geojson_copy(rs)
-    map_disp = create_map!(map_display, geodata, obs_mean_rc_sites, (:black, 0.05), centroids)
+    map_disp = create_map!(map_display, geodata, obs_mean_rc_sites, (:black, 0.05))
 
     curr_highlighted_sites = _get_seeded_sites(seed_log, (:), (:))
     obs_site_sel = Observable(FC(; features=geodata[curr_highlighted_sites]))

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -321,7 +321,7 @@ function ADRIA.viz.connectivity(
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
-    
+
     ADRIA.viz.connectivity!(g, dom, network, conn_weights; opts, axis_opts)
 
     return f
@@ -344,51 +344,50 @@ function ADRIA.viz.connectivity!(
         axis_opts...
     )
 
-    geodata = get_geojson_copy(dom)
+    geodata = _get_geoms(dom.site_data)
 
     spatial.xticklabelsize = 14
     spatial.yticklabelsize = 14
     spatial.yticklabelpad = 50
     spatial.ytickalign = 10
-    
+
     # Calculate alpha values for edges based on connectivity strength and weighting
-    edge_col = Vector{Tuple{Symbol, Float64}}(undef, ne(network))
+    edge_col = Vector{Tuple{Symbol,Float64}}(undef, ne(network))
     norm_coef = maximum(conn_weights)
     for (ind, e) in enumerate(edges(network))
         if (e.src == e.dst)
-            edge_col[ind] = (:black, 0.0) 
+            edge_col[ind] = (:black, 0.0)
             continue
         end
         edge_col[ind] = (:black, conn_weights[e.src] * e.weight / norm_coef)
     end
-    
+
     # Rescale node size to be visible
     node_size = conn_weights ./ maximum(conn_weights) .* 10.0
-    
+
     # Extract graph kwargs and set defaults
     edge_col = get(opts, :edge_color, edge_col)
-    node_size  = get(opts, :node_size, node_size)
+    node_size = get(opts, :node_size, node_size)
     node_color = get(opts, :node_color, node_size)
-    
+
     # Plot geodata polygons
     poly!(
         spatial,
         geodata;
         color=:white,
         strokecolor=(:black, 0.25),
-        strokewidth=1.0,
+        strokewidth=1.0
     )
     # Plot the connectivity graph
     graphplot!(
-        spatial, 
-        network, 
-        layout=ADRIA.centroids(dom), 
-        edge_color=edge_col, 
-        node_size=node_size, 
+        spatial,
+        network;
+        layout=ADRIA.centroids(dom),
+        edge_color=edge_col,
+        node_size=node_size,
         node_color=node_color,
         edge_plottype=:linesegments
     )
-
 
     return g
 end

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -182,7 +182,7 @@ function ADRIA.viz.map(
         opts[:highlight] = highlight
     end
 
-    ADRIA.viz.map!(g, rs, rs.site_data.k; opts, axis_opts)
+    ADRIA.viz.map!(g, rs, rs.site_data.k * 100.0; opts, axis_opts)
 
     return f
 end

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -47,6 +47,8 @@ function create_map!(
     axis_opts[:title] = get(axis_opts, :title, "Study Area")
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Longitude")
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "Latitude")
+    axis_opts[:xgridwidth] = get(axis_opts, :xgridwidth, 0.5)
+    axis_opts[:ygridwidth] = get(axis_opts, :ygridwidth, 0.5)
 
     spatial = GeoAxis(
         f[1, 1];
@@ -57,8 +59,6 @@ function create_map!(
     spatial.xticklabelsize = 14
     spatial.yticklabelsize = 14
 
-    spatial.yticklabelpad = 50
-    spatial.ytickalign = 10
     max_val = @lift(maximum($data))
 
     # Plot geodata polygons using data as internal color

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -49,10 +49,10 @@ function create_map!(
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "Latitude")
     axis_opts[:xgridwidth] = get(axis_opts, :xgridwidth, 0.5)
     axis_opts[:ygridwidth] = get(axis_opts, :ygridwidth, 0.5)
+    axis_opts[:dest] = get(axis_opts, :dest, "+proj=latlong +datum=WGS84")
 
     spatial = GeoAxis(
         f[1, 1];
-        dest="+proj=latlong +datum=WGS84",
         axis_opts...
     )
 
@@ -201,6 +201,10 @@ function ADRIA.viz.map!(
     legend_params = get(opts, :legend_params, nothing)
     show_colorbar = get(opts, :show_colorbar, true)
     color_map = get(opts, :color_map, :grayC)
+    if !(:dest in keys(axis_opts))
+        col = _get_geom_col(rs.site_data)
+        axis_opts[:dest] = ADRIA.AG.toPROJ4(ADRIA.AG.getspatialref(rs.site_data[1, col]))
+    end
 
     return create_map!(
         g,

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -216,8 +216,66 @@ function ADRIA.viz.map!(
 end
 
 """
-    ADRIA.viz.connectivity(dom::Domain, network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict()) 
-    ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition}, dom::Domain,  network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict=Dict(), axis_opts::Dict=Dict()) 
+    ADRIA.viz.map(gdf::DataFrame; geom_col=:geometry, color=nothing)
+
+Plot an arbitrary GeoDataFrame, optionally specifying a color for each feature.
+
+# Arguments
+- `gdf` : GeoDataFrame to plot
+- `geom_col` : Column in GeoDataFrame that holds feature data
+- `color` : Colors to use for each feature
+"""
+function ADRIA.viz.map(gdf::DataFrame; geom_col=:geometry, color=nothing)
+    f = Figure(; size=(600, 900))
+    ga = GeoAxis(
+        f[1, 1];
+        dest="+proj=latlong +datum=WGS84",
+        xlabel="Longitude",
+        ylabel="Latitude",
+        xticklabelpad=15,
+        yticklabelpad=40,
+        xticklabelsize=10,
+        yticklabelsize=10,
+        aspect=AxisAspect(0.75),
+        xgridwidth=0.5,
+        ygridwidth=0.5
+    )
+
+    ADRIA.viz.map!(ga, gdf; geom_col=geom_col, color=color)
+
+    display(f)
+
+    return f
+end
+
+"""
+    ADRIA.viz.map!(gdf::DataFrame; geom_col=:geometry, color=nothing)::Nothing
+"""
+function ADRIA.viz.map!(gdf::DataFrame; geom_col=:geometry, color=nothing)::Nothing
+    ga = current_axis()
+    ADRIA.viz.map!(ga, gdf; geom_col=geom_col, color=color)
+
+    return nothing
+end
+function ADRIA.viz.map!(
+    ga::GeoAxis, gdf::DataFrame; geom_col=:geometry, color=nothing
+)::Nothing
+    plottable = _get_geoms(dom.site_data, geom_col)
+
+    if !isnothing(color)
+        poly!(ga, plottable; color=color)
+    else
+        poly!(ga, plottable)
+    end
+
+    # Auto-determine x/y limits
+    autolimits!(ga)
+    xlims!(ga)
+    ylims!(ga)
+
+    return nothing
+end
+
 """
     ADRIA.viz.connectivity(dom::Domain, network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict{Symbol, <:Any}=Dict{Symbol, <:Any}(), fig_opts::Dict{Symbol, <:Any}=Dict{Symbol, <:Any}(), axis_opts::Dict{Symbol, <:Any}=Dict{Symbol, <:Any}())
     ADRIA.viz.connectivity!(g::Union{GridLayout, GridPosition}, dom::Domain,  network::SimpleWeightedDiGraph, conn_weights::AbstractVector{<:Real}; opts::Dict{Symbol, <:Any}=Dict{Symbol, <:Any}(), axis_opts::Dict{Symbol, <:Any}=Dict{Symbol, <:Any}())

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -51,13 +51,8 @@ function create_map!(
     spatial = GeoAxis(
         f[1, 1];
         dest="+proj=latlong +datum=WGS84",
-        axis_opts...,
+        axis_opts...
     )
-    # lon = first.(centroids)
-    # lat = last.(centroids)
-    # map_buffer = 0.025
-    # xlims!(spatial, minimum(lon) - map_buffer, maximum(lon) + map_buffer)
-    # ylims!(spatial, minimum(lat) - map_buffer, maximum(lat) + map_buffer)
 
     spatial.xticklabelsize = 14
     spatial.yticklabelsize = 14
@@ -76,7 +71,7 @@ function create_map!(
         colormap=color_map,
         colorrange=color_range,
         strokecolor=(:black, 0.05),
-        strokewidth=1.0,
+        strokewidth=1.0
     )
 
     if show_colorbar
@@ -85,7 +80,7 @@ function create_map!(
             colorrange=color_range,
             colormap=color_map,
             label=colorbar_label,
-            height=Relative(0.65),
+            height=Relative(0.65)
         )
     end
 
@@ -101,7 +96,7 @@ function create_map!(
                 strokecolor=highlight,
                 strokewidth=0.5,
                 linestyle=:solid,
-                overdraw=true,
+                overdraw=true
             )
         else
             hl_groups = unique(highlight)
@@ -117,7 +112,7 @@ function create_map!(
                     strokecolor=color,
                     strokewidth=0.5,
                     linestyle=:solid,
-                    overdraw=true,
+                    overdraw=true
                 )
             end
         end
@@ -212,12 +207,11 @@ function ADRIA.viz.map!(
         geodata,
         data,
         highlight,
-        ADRIA.centroids(rs),
         show_colorbar,
         c_label,
         color_map,
         legend_params,
-        axis_opts,
+        axis_opts
     )
 end
 
@@ -275,12 +269,12 @@ function ADRIA.viz.connectivity(
     return f
 end
 function ADRIA.viz.connectivity!(
-    g::Union{GridLayout, GridPosition},
-    dom::Domain, 
+    g::Union{GridLayout,GridPosition},
+    dom::Domain,
     network::SimpleWeightedDiGraph,
     conn_weights::AbstractVector{<:Real};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
+    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
 )
     axis_opts[:title] = get(axis_opts, :title, "Study Area")
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Longitude")
@@ -289,7 +283,7 @@ function ADRIA.viz.connectivity!(
     spatial = GeoAxis(
         g[1, 1];
         dest="+proj=latlong +datum=WGS84",
-        axis_opts...,
+        axis_opts...
     )
 
     geodata = get_geojson_copy(dom)


### PR DESCRIPTION
```julia
using ADRIA
using GeoMakie, GraphMakie, GeoMakie

moore_dom = ADRIA.load_domain("<path to cluster-scale domain>")
gbr_dom = ADRIA.load_domain(RMEDomain, "<path to RME dataset>", "45")

ADRIA.viz.map(moore_dom)  # See figure 1
ADRIA.viz.map(gbr_dom)  # See figure 2

```

Figure 1:
![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/db3201cc-09fd-44f5-bbd0-f422ad72d168)

Figure 2:
![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/3dac5bf7-065a-4512-af15-a167d0fc5ff6)

I've yet to work out why the gridlines (with lat/longs) disappear for the smaller spatial scale, and why there is a relatively large space between the map and the colorbar.

Any thoughts @DanTanAtAims ?

FYI I've made the figures with the following Domain versions:

`Moore_2024-02-05b_v060_rc1` and `rme_ml_2024_01_08`
