### PR TITLE
use provided centrality measures instead of defaults

### DIFF
--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -182,8 +182,8 @@ function connectivity_strength(
     g = SimpleWeightedDiGraph(conn)
 
     # Measure centrality based on number of incoming connections
-    C1 = indegree_centrality(g)
-    C2 = outdegree_centrality(g)
+    C1 = in_method(g)
+    C2 = out_method(g)
 
     return (in_conn=C1, out_conn=C2, network=g)
 end


### PR DESCRIPTION
I should have found this when reviewing pull request #737. The connectivity strength was always using defaults instead of provided centrality measures. 

It also appears that the default connectivity visualisation is quite poor for small reefs.

```julia
in_conn, out_conn, network = ADRIA.connectivity_strength(dom.conn, out_method=eigenvector_centrality)
ADRIA.viz.connectivity(dom, network, out_conn)
```

![image](https://github.com/open-AIMS/ADRIA.jl/assets/156630392/08cc7ba8-aa93-461f-863b-fb9be7bdaba9)

closes #749.

