### PR TITLE
remove hardcoded coral spec from metrics and data store

### DIFF
--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -61,6 +61,23 @@ function bin_widths()
 end
 
 """
+    planar_area_params()
+
+Colony planar area parameters (see Fig 2B in Aston et al., [1])
+First column is `b`, second column is `a`
+log(S) = b + a * log(x)
+"""
+function planar_area_params()
+    return Array{Float64,2}([
+        # -8.97 3.14   # Abhorescent Acropora (using branching porites parameters as similar method of growing ever expanding colonies).
+        -8.95 2.80   # Tabular Acropora
+        -9.13 2.94   # Corymbose Acropora
+        -8.90 2.94   # Corymbose non-Acropora (using branching pocillopora values from fig2B)
+        -8.87 2.30   # Small massives
+        -8.87 2.30   # Large massives
+    ])
+end
+"""
     colony_areas()
 
 Generate colony area data based on Bozec et al., [1].

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -199,7 +199,7 @@ function coral_spec()::NamedTuple
     params.mean_colony_diameter_m = reshape(mean_colony_diameter_m', n_species)[:]
 
     ## Coral growth rates as linear extensions (Bozec et al 2021 S2, Table 1)
-    # all values in cm/year
+    # all values in m/year
     linear_extension = Array{Float64,2}([
         0.006094558 0.010718383 0.025514863 0.050798784 0.094509136 0.168505241 0.0;  # Tabular Acropora
         0.007685561 0.012208521 0.01864468  0.028229656 0.035293827 0.030042179 0.0;              # Corymbose Acropora
@@ -215,8 +215,8 @@ function coral_spec()::NamedTuple
     # coral sizes are evenly distributed within each bin
 
     # Second, growth as transitions of cover to higher bins is estimated as
-    # rate of growth per year
-    params.growth_rate .= reshape(growth_rate(linear_extension, bin_widths()), n_species)[:]
+    # rate of growth per year. Convert bin widths in cm to m
+    params.growth_rate .= reshape(growth_rate(linear_extension, bin_widths() ./ 100), n_species)[:]
     # params.growth_rate[1:6:36] .= 1.0
     # params.growth_rate[6:6:36] .= 1.0
 

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -210,6 +210,7 @@ function combine_results(result_sets...)::ResultSet
                 nrow(all_inputs),
                 size(rs1.seed_log, :timesteps),
                 size(rs1.seed_log, :sites),
+                36 # TODO: Find a way to remove this constant
             ))...
     )
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -274,7 +274,6 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_size)
         :unique_site_ids => unique_sites,
     )
     
-    # Get the number of species/groups represented
     local coral_dhw_log
     if parse(Bool, ENV["ADRIA_DEBUG"]) == true
         coral_dhw_log = zcreate(
@@ -437,9 +436,9 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             compressor=COMPRESSOR)
         for m_name in met_names
     ]
-    n_groups::Int = domain.coral_growth.n_groups
 
     # Handle special case for relative taxa cover
+    n_groups::Int64 = domain.coral_growth.n_groups
     push!(
         stores,
         zcreate(Float32, (result_dims[1], n_groups, result_dims[3])...;
@@ -496,7 +495,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     end
     stat_store_names = vcat(dhw_stat_names, wave_stat_names)
 
-    n_group_size::Int = domain.coral_growth.n_group_size
+    n_group_size::Int64 = domain.coral_growth.n_group_size
     # Group all data stores
     stores = [
         stores...,

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -181,17 +181,18 @@ function scenario_attributes(domain::Domain, param_df::DataFrame)
 end
 
 """
-    setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
+    setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_size)
 
 - `z_store` : ZArray
 - `unique_sites` : Unique site ids
 - `n_scens` : number of scenarios
 - `tf` : timeframe
 - `n_sites` : number of sites
+- `n_group_size` : number of function groups ⋅ number of size classes
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
+function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_size)
     # Set up logs for site ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -272,35 +273,35 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites)
         :structure => ("timesteps", "species", "sites", "scenarios"),
         :unique_site_ids => unique_sites,
     )
-
-    # 36 is the number of species/groups represented
+    
+    # Get the number of species/groups represented
     local coral_dhw_log
     if parse(Bool, ENV["ADRIA_DEBUG"]) == true
         coral_dhw_log = zcreate(
             Float32,
             tf,
-            36,
+            n_group_size,
             n_sites,
             n_scens;
             name="coral_dhw_log",
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, 36, n_sites, 1),
+            chunks=(tf, n_group_size, n_sites, 1),
             attrs=attrs,
         )
     else
         coral_dhw_log = zcreate(
             Float32,
             tf,
-            36,
+            n_group_size,
             1,
             n_scens;
             name="coral_dhw_log",
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, 36, 1, 1),
+            chunks=(tf, n_group_size, 1, 1),
             attrs=attrs,
         )
     end
@@ -436,14 +437,15 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             compressor=COMPRESSOR)
         for m_name in met_names
     ]
+    n_groups::Int = domain.coral_growth.n_groups
 
     # Handle special case for relative taxa cover
     push!(
         stores,
-        zcreate(Float32, (result_dims[1], 6, result_dims[3])...;
+        zcreate(Float32, (result_dims[1], n_groups, result_dims[3])...;
             fill_value=nothing, fill_as_missing=false,
             path=joinpath(z_store.folder, RESULTS, "relative_taxa_cover"),
-            chunks=((result_dims[1], 6)..., 1),
+            chunks=((result_dims[1], n_groups)..., 1),
             attrs=Dict(
                 :structure => string.(ADRIA.metrics.relative_taxa_cover.dims)
             ),
@@ -494,13 +496,14 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     end
     stat_store_names = vcat(dhw_stat_names, wave_stat_names)
 
+    n_group_size::Int = domain.coral_growth.n_group_size
     # Group all data stores
     stores = [
         stores...,
         dhw_stats...,
         wave_stats...,
         connectivity...,
-        setup_logs(z_store, unique_sites(domain), nrow(scen_spec), tf, n_sites)...,
+        setup_logs(z_store, unique_sites(domain), nrow(scen_spec), tf, n_sites, n_group_size)...,
     ]
 
     return domain,

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -880,10 +880,8 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         # Update record
         C_cover[tstep, :, :] .= C_t
         cover_copy[cover_copy .== 0] .= 1.0
-        temp_change = permutedims(
-            reshape(C_cover[tstep, :, :], (n_sizes, n_groups, n_locs)),
-            [2, 1, 3]
-        ) ./ cover_copy
+        temp_change = 
+            _group_cover_locs(domain.coral_growth, C_cover[tstep, :, :]) ./ cover_copy
     end
 
     # Could collate critical DHW threshold log for corals to reduce disk space...

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -882,6 +882,8 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         cover_copy[cover_copy .== 0] .= 1.0
         temp_change = 
             _group_cover_locs(domain.coral_growth, C_cover[tstep, :, :]) ./ cover_copy
+        # The smallest size class is reconstructed everytimestep from the cover
+        temp_change[:, 1, :] .= 1.0
     end
 
     # Could collate critical DHW threshold log for corals to reduce disk space...

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -304,11 +304,11 @@ function run_scenario(
     vals[vals.<threshold] .= 0.0
     data_store.juvenile_indicator[:, :, idx] .= vals
 
-    vals = relative_taxa_cover(rs_raw, site_k_area(domain))
+    vals = relative_taxa_cover(rs_raw, site_k_area(domain), domain.coral_growth.n_groups)
     vals[vals.<threshold] .= 0.0
     data_store.relative_taxa_cover[:, :, idx] .= vals
 
-    vals = relative_loc_taxa_cover(rs_raw, site_k_area(domain))
+    vals = relative_loc_taxa_cover(rs_raw, site_k_area(domain), domain.coral_growth.n_groups)
     vals = coral_evenness(vals.data)
     vals[vals.<threshold] .= 0.0
     data_store.coral_evenness[:, :, idx] .= vals
@@ -644,13 +644,13 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
                 size_classes[i],
                 site_data.k[i] * site_data.area[i],
                 tstep,
-                i==20
+                false
             )
         end
-        cover_copy .= copy(C_tmp)
 
         C_tmp ./= reshape(site_data.area .* site_data.k, (1, 1, n_locs))
         replace!(C_tmp, NaN=>0.0)
+        cover_copy .= copy(C_tmp)
         C_t .= _flatten_cover(domain.coral_growth, C_tmp)
 
         # Check if size classes are inappropriately out-growing available space
@@ -879,11 +879,10 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
         # Update record
         C_cover[tstep, :, :] .= C_t
-        temp_change = abs.(
-            permutedims(
-                reshape(C_cover[tstep, :, :], (n_sizes, n_groups, n_locs)),
-                [2, 1, 3]
-            ) .- cover_copy
+        cover_copy[cover_copy .== 0] .= 1.0
+        temp_change = permutedims(
+            reshape(C_cover[tstep, :, :], (n_sizes, n_groups, n_locs)),
+            [2, 1, 3]
         ) ./ cover_copy
     end
 


### PR DESCRIPTION
Should allow complete scenario runs and analysis afterwards. 

I moved the planar_area array into a function call so that all/nearly all coral parameters are in one place. 