### PR TITLE
Multidimensional cover

### DIFF
--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -246,6 +246,10 @@ end
     bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
         depth_coeff::Vector{Float64}, stdev::Vector{Float64}, dist_t_1::Matrix,
         dist_t::Matrix, prop_mort::SubArray{Float64}, n_sizes::Int64)::Nothing
+    bleaching_mortality!(cover::AbstractArray{Float64, 3}, dhw::Vector{Float64},
+        depth_coeff::Vector{Float64}, stdev::AbstractMatrix{Float64},
+        dist_t_1::AbstractArray{Float64, 3}, dist_t::AbstractArray{Float64, 3},
+        prop_mort::SubArray{Float64})::Nothing
 
 Applies bleaching mortality by assuming critical DHW thresholds are normally distributed for
 all non-Juvenile (> 5cm diameter) size classes.
@@ -367,7 +371,71 @@ function bleaching_mortality!(cover::Matrix{Float64}, dhw::Vector{Float64},
 
     return nothing
 end
+function bleaching_mortality!(
+    cover::AbstractArray{Float64, 3},
+    dhw::Vector{Float64},
+    depth_coeff::Vector{Float64},
+    stdev::AbstractMatrix{Float64},
+    dist_t_1::AbstractArray{Float64, 3},
+    dist_t::AbstractArray{Float64, 3},
+    prop_mort::SubArray{Float64}
+)::Nothing
+    n_groups, n_sizes, n_locs = size(cover)
 
+    non_juveniles = 2:n_sizes
+
+    # Adjust distributions for each functional group over all locations, ignoring juveniles
+    # we assume the high background mortality of juveniles includes DHW mortality
+    for loc in 1:n_locs
+        # Skip locations that have no heat stress
+        if dhw[loc] == 0.0
+            continue
+        end
+
+        # Determine bleaching mortality for each non-juvenile species/size class
+        for grp in 1:n_groups
+            for sc in non_juveniles
+                # Skip location if there is no population
+                if cover[grp, sc, loc] == 0.0
+                    continue
+                end
+
+                μ::Float64 = dist_t_1[grp, sc, loc]
+                affected_pop::Float64 = truncated_normal_cdf(
+                    # Use previous mortality threshold as minimum
+                    dhw[loc], μ, stdev[grp, sc], prop_mort[1, grp, sc, loc], μ + HEAT_UB
+                )
+
+                mort_pop::Float64 = 0.0
+                if affected_pop > 0.0
+                    # Calculate depth-adjusted bleaching mortality
+                    mort_pop = (affected_pop * depth_coeff[loc])
+
+                    # Set values close to 0.0 (e.g., 1e-214) to 0.0
+                    # https://github.com/JuliaLang/julia/issues/23376#issuecomment-324649815
+                    if (mort_pop + one(mort_pop)) ≈ one(mort_pop)
+                        mort_pop = 0.0
+                    end
+                end
+
+                prop_mort[2, grp, sc, loc] = mort_pop
+                if mort_pop > 0.0
+                    # Re-create distribution
+                    # Use same stdev as target size class to maintain genetic variance
+                    # pers comm K.B-N (2023-08-09 16:24 AEST)
+                    dist_t[grp, sc, loc] = truncated_normal_mean(
+                        μ, stdev[grp, sc], mort_pop, μ + HEAT_UB
+                    )
+
+                    # Update population
+                    cover[grp, sc, loc] = cover[grp, sc, loc] * (1.0 - mort_pop)
+                end
+            end
+        end
+    end
+
+    return nothing
+end
 
 """
     breeders(μ_o::T, μ_s::T, h²::T)::T where {T<:Float64}

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -694,8 +694,6 @@ function settler_DHW_tolerance!(
     return nothing
 end
 
-
-
 """
     fecundity_scope!(fec_groups::Array{Float64, 2}, fec_all::Array{Float64, 2},
                      fec_params::Array{Float64}, C_t::Array{Float64, 2},

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -82,6 +82,7 @@ function proportional_adjustment!(
     end
 
     coral_cover .= max.(coral_cover, 0.0)
+
     return nothing
 end
 """
@@ -94,6 +95,7 @@ function proportional_adjustment!(
     coral_cover::Union{SubArray{T},Matrix{T}}
 )::Nothing where {T<:Float64}
     cover_tmp = zeros(size(coral_cover, 2))
+
     return proportional_adjustment!(coral_cover, cover_tmp)
 end
 
@@ -560,6 +562,7 @@ function adjust_DHW_distribution!(
             )
         end
     end
+
     return nothing
 end
 
@@ -691,6 +694,7 @@ function settler_DHW_tolerance!(
             end
         end
     end
+
     return nothing
 end
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -30,7 +30,7 @@ function distribute_seeded_corals(
     # Convert to relative cover proportion by dividing by location area
     scaled_seed = ((prop_area_avail .* seeded_area.data') ./ seed_loc_k_m²)'
     #scaled_seed = ((prop_area_avail .* seeded_area') ./ seed_loc_k_m²)'
-    
+
     return DataCube(scaled_seed, taxa=caxes(seeded_area)[1].val.data, locations=1:length(available_space))
 end
 
@@ -113,5 +113,66 @@ function seed_corals!(
         c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
     end
 
+    return nothing
+end
+function seed_corals!(
+    cover::AbstractArray{Float64, 3},
+    loc_k_area::Vector{T},
+    leftover_space_m²::Vector{T},
+    seed_locs::Vector{Int64},
+    seeded_area::YAXArray,
+    seed_sc::Matrix{Bool},
+    a_adapt::Matrix{T},
+    Yseed::SubArray,
+    stdev::Matrix{T},
+    c_dist_t::Array{Float64, 3},
+)::Nothing where {T<:Float64}
+    # Selected locations can fill up over time so avoid locations with no space
+    seed_locs = seed_locs[findall(leftover_space_m²[seed_locs] .> 0.0)]
+    loc_mask::BitVector = [loc in seed_locs for loc in 1:length(loc_k_area)]
+
+    # Calculate proportion to seed based on current available space
+    scaled_seed = distribute_seeded_corals(
+        loc_k_area[seed_locs],
+        leftover_space_m²[seed_locs],
+        seeded_area,
+    )
+
+    # Seed each location and log
+    cover[seed_sc, loc_mask] .+= scaled_seed
+    Yseed[:, seed_locs] .= scaled_seed
+
+    # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
+    # Note: It is entirely possible for a location to be ranked in the top N, but
+    #       with no deployments (for a given species). A location with 0 cover
+    #       and no deployments will therefore be NaN due to zero division.
+    #       These are replaced with 1.0 so that the distribution for unseeded
+    #       corals are used.
+    w_taxa::Matrix{Float64} = scaled_seed ./ cover[seed_sc, seed_locs]
+    replace!(w_taxa, NaN => 1.0)
+
+    # Update critical DHW distribution for deployed size classes
+    for (i, loc) in enumerate(seed_locs)
+        # Previous distributions
+        c_dist_ti = @view(c_dist_t[seed_sc, loc])
+
+        # Truncated normal distributions for deployed corals
+        # Assume same stdev and bounds as original
+        tn::Vector{Float64} = truncated_normal_mean.(
+            a_adapt[seed_sc], stdev[seed_sc], 0.0, a_adapt[seed_sc] .+ HEAT_UB,
+        )
+
+        # If seeding an empty location, no need to do any further calculations
+        if all(isapprox.(w_taxa[:, i], 1.0))
+            c_dist_t[seed_sc, loc] .= tn
+            continue
+        end
+
+        # Create new distributions by mixing previous and current distributions using
+        # proportional cover as the priors/weights
+        # Priors (weights based on cover for each species)
+        tx::Vector{Weights} = Weights.(eachcol(vcat(w_taxa[:, i]', 1.0 .- w_taxa[:, i]')))
+        c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
+    end
     return nothing
 end

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -174,5 +174,6 @@ function seed_corals!(
         tx::Vector{Weights} = Weights.(eachcol(vcat(w_taxa[:, i]', 1.0 .- w_taxa[:, i]')))
         c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
     end
+
     return nothing
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -968,7 +968,7 @@ function cyclone_mortality!(
     coral_cover::AbstractArray{Float64, 3}, cyclone_mortality::AbstractMatrix{Float64}
 )::Nothing
     n_groups, n_locs = size(cyclone_mortality)
-    coral_deaths = coral_cover .* reshape(cyclone_mortality, (n_groups, 1, n_locs))
-    coral_cover -= coral_deaths
+    coral_cover .*= (1 .- reshape(cyclone_mortality, (n_groups, 1, n_locs)))
+    clamp!(coral_cover, 0.0, 1.0)
     return nothing
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -650,13 +650,13 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         C_tmp ./= reshape(site_data.area .* site_data.k, (1, 1, n_locs))
         replace!(C_tmp, NaN=>0.0)
         cover_copy .= copy(C_tmp)
-        C_t .= _flatten_cover(domain.coral_growth, C_tmp)
 
         # Check if size classes are inappropriately out-growing available space
         proportional_adjustment!(
-            @view(C_t[:, valid_locs]),
+            @view(C_tmp[:, :, valid_locs]),
             cover_tmp[valid_locs]
         )
+        C_t .= _flatten_cover(domain.coral_growth, C_tmp)
 
         # Update initial condition
         C_cover[tstep, :, valid_locs] .= C_t[:, valid_locs]

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -573,7 +573,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     dhw_tol_mean_log = cache.dhw_tol_mean_log  # tmp log for mean dhw tolerances
 
     # Cache for proportional mortality and coral population increases
-    bleaching_mort = zeros(tf, n_group_and_size, n_locs)
+    bleaching_mort = zeros(tf, n_groups, n_sizes, n_locs)
 
     #### End coral constants
 
@@ -878,11 +878,10 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
             C_t,
             dhw_t,  # collect(dhw_t .* (1.0 .- @view(wave_scen[tstep, :]))),
             depth_coeff,
-            corals.dist_std,
+            c_std,
             c_mean_t_1,
             c_mean_t,
-            @view(bleaching_mort[(tstep-1):tstep, :, :]),
-            n_sizes
+            @view(bleaching_mort[(tstep-1):tstep, :, :, :])
         )
 
         # Coral deaths due to selected cyclone scenario

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -462,7 +462,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
     # Coral cover relative to available area (i.e., 1.0 == site is filled to max capacity)
     C_cover::Array{Float64,4} = zeros(tf, n_groups, n_sizes, n_locs)
-    C_cover[1, :, :] .= _group_cover_locs(domain.coral_growth, domain.init_coral_cover)
+    C_cover[1, :, :, :] .= _group_cover_locs(domain.coral_growth, domain.init_coral_cover)
     cover_tmp = zeros(n_locs)
 
     # Locations that can support corals
@@ -624,8 +624,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
     # Preallocate memory for temporaries
     temp_change = ones(n_groups, n_sizes, n_locs)
-    C_tmp = zeros(n_groups, n_sizes, n_locs)
-    C_t = zeros(n_group_and_size, n_locs)
+    C_t = zeros(n_groups, n_sizes, n_locs)
     cover_copy = zeros(n_groups, n_sizes, n_locs)
 
     for tstep::Int64 in 2:tf
@@ -633,13 +632,13 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         DynamicCoralCoverModel.blocks_model.apply_changes!.(size_classes, change_view)
         recruitment .*= reshape(temp_change[:, 1, :], (n_groups, n_locs))
 
-        C_tmp .= C_cover[tstep-1, :, :, :] .* reshape(
+        C_t .= C_cover[tstep-1, :, :, :] .* reshape(
             site_data.area .* site_data.k, (1, 1, n_locs)
         )
 
         for i in 1:n_locs
-            C_tmp[:, :, i] .= DynamicCoralCoverModel.blocks_model.timestep(
-                C_tmp[:, :, i],
+            C_t[:, :, i] .= DynamicCoralCoverModel.blocks_model.timestep(
+                C_t[:, :, i],
                 recruitment[:, i],
                 size_classes[i],
                 site_data.k[i] * site_data.area[i],
@@ -648,27 +647,23 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
             )
         end
 
-        C_tmp ./= reshape(site_data.area .* site_data.k, (1, 1, n_locs))
-        replace!(C_tmp, NaN=>0.0)
-        cover_copy .= copy(C_tmp)
+        C_t ./= reshape(site_data.area .* site_data.k, (1, 1, n_locs))
+        replace!(C_t, NaN=>0.0)
+        cover_copy .= copy(C_t)
 
         # Check if size classes are inappropriately out-growing available space
         proportional_adjustment!(
-            @view(C_tmp[:, :, valid_locs]),
+            @view(C_t[:, :, valid_locs]),
             cover_tmp[valid_locs]
         )
-        C_t .= _flatten_cover(domain.coral_growth, C_tmp)
 
         # Update initial condition
-        C_cover[tstep, :, valid_locs] .= C_t[:, valid_locs]
+        C_cover[tstep, :, :, valid_locs] .= C_t[:, :, valid_locs]
 
         if tstep <= tf
-            if isdefined(Main, :Infiltrator)
-                Main.infiltrate(@__MODULE__, Base.@locals, @__FILE__, @__LINE__)
-            end
             # Natural adaptation
             adjust_DHW_distribution!(
-                @view(C_cover[(tstep-1), :, :]), c_mean_t, p.r
+                @view(C_cover[(tstep-1), :, :, :]), c_mean_t, p.r
             )
 
             # Set values for t to t-1
@@ -683,7 +678,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         # Calculates scope for coral fedundity for each size class and at each location
         fecundity_scope!(fec_scope, fec_all, fec_params_per_m², C_t, loc_k_area)
 
-        loc_coral_cover = sum(C_t; dims=1)  # dims: 1 * nsites
+        loc_coral_cover = dropdims(sum(C_t; dims=(1, 2)), dims=1)  # dims: 1 * nsites
         leftover_space_m² = relative_leftover_space(loc_coral_cover) .* loc_k_area
 
         # Reset potential settlers to zero
@@ -713,18 +708,17 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
             recruitment,
             fec_params_per_m²,
             param_set[At("heritability")],
-            n_sizes
         )
 
         # Add recruits to current cover
-        C_t[p.small, :] .+= recruitment
+        C_t[:, 1, :] .+= recruitment
 
         # Cover copy needs to include recruits so overall mortality can be calculated to
         # apply to cover blocks
-        cover_copy[:, 1, :] .= C_t[p.small, :]
+        cover_copy[:, 1, :] .= C_t[:, 1, :]
 
         # Update available space
-        loc_coral_cover = sum(C_t, dims=1)  # dims: 1 * nsites
+        loc_coral_cover = dropdims(sum(C_t, dims=(1, 2)), dims=1)  # dims: 1 * nsites
         leftover_space_m² = relative_leftover_space(loc_coral_cover) .* loc_k_area
 
         # Determine intervention locations whose deployment is assumed to occur

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -86,7 +86,7 @@ end
 
 Reshape vector to shape [groups ⋅ sizes]
 """
-function _to_group_size(growth_spec::CoralGrowth, data::AbstractVector{<:Union{Float32, Float64}})::Matrix{<:Union{Float32, Float64}}
+function _to_group_size(growth_spec::CoralGrowth, data::AbstractVector{T})::Matrix{T} where {T<:Union{Float32, Float64, Bool}}
     # Data is reshaped to size ⋅ groups then transposed to maintain expected order
     return Matrix(reshape(data, (growth_spec.n_sizes, growth_spec.n_groups))')
 end
@@ -504,14 +504,16 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     taxa_names::Vector{String} = collect(param_set.factors[occursin.("N_seed_", param_set.factors)])
 
     # Identify taxa and size class to be seeded
-    seed_sc = (corals.taxa_id .∈ [taxa_to_seed]) .& target_class_id
+    seed_sc = _to_group_size(domain.coral_growth, (corals.taxa_id .∈ [taxa_to_seed]) .& target_class_id)
 
     # Extract colony areas for sites selected in m^2 and add adaptation values
-    colony_areas = colony_mean_area(corals.mean_colony_diameter_m)
+    colony_areas = _to_group_size(
+        domain.coral_growth, colony_mean_area(corals.mean_colony_diameter_m)
+    )
     seeded_area = colony_areas[seed_sc] .* param_set[At(taxa_names)]
 
     # Set up assisted adaptation values
-    a_adapt = zeros(n_group_and_size)
+    a_adapt = zeros(n_groups, n_sizes)
     a_adapt[seed_sc] .= param_set[At("a_adapt")]
 
     # Flag indicating whether to seed or not to seed when unguided
@@ -561,6 +563,9 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     c_mean_t_1::Array{Float64, 3} = repeat(_to_group_size(
         domain.coral_growth, corals.dist_mean
     ), 1, 1, n_locs)
+    c_std::Array{Float64, 2} = _to_group_size(
+        domain.coral_growth, corals.dist_std
+    )
 
     c_mean_t = copy(c_mean_t_1)
 
@@ -575,7 +580,9 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     ## Update ecological parameters based on intervention option
 
     # Treat as enhancement from mean of "natural" DHW tolerance
-    a_adapt[a_adapt.>0.0] .+= corals.dist_mean[a_adapt.>0.0]
+    a_adapt[a_adapt.>0.0] .+= _to_group_size(
+        domain.coral_growth, corals.dist_mean
+    )[a_adapt.>0.0]
 
     # Pre-calculate proportion of survivers from wave stress
     # Sw_t = wave_damage!(cache.wave_damage, wave_scen, corals.wavemort90, n_species)
@@ -852,13 +859,13 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
                 seed_sc,
                 a_adapt,
                 @view(Yseed[tstep, :, :]),
-                corals.dist_std,
+                c_std,
                 c_mean_t,
             )
 
             # Add coral seeding to cover copy and recruitment
-            recruitment += C_t[p.small, :] .- cover_copy[:, 1, :]
-            cover_copy[:, 1, :] .= C_t[p.small, :]
+            recruitment += C_t[:, 1, :] .- cover_copy[:, 1, :]
+            cover_copy[:, 1, :] .= C_t[:, 1, :]
         end
 
         # Calculate and apply bleaching mortality

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -950,7 +950,7 @@ function cyclone_mortality!(coral_cover, coral_params, cyclone_mortality)::Nothi
 
     # Mid class coral mortality
     coral_mid = hcat(collect(Iterators.partition(coral_params.mid, length(coral_params.small)))...)
-    for i in size(coral_mid, 1)
+    for i in 1:size(coral_mid, 1)
         coral_deaths_mid = coral_cover[coral_mid[i, :], :] .* cyclone_mortality
         coral_cover[coral_mid[i, :], :] -= coral_deaths_mid
     end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -30,7 +30,7 @@ function setup_cache(domain::Domain)::NamedTuple
 
     cache = (
         # sf=zeros(n_groups, n_sites),  # stressed fecundity, commented out as it is disabled
-        fec_all=zeros(n_group_and_size, n_locs),  # all fecundity
+        fec_all=zeros(n_groups, n_sizes, n_locs),  # all fecundity
         fec_scope=zeros(n_groups, n_locs),  # fecundity scope
         recruitment=zeros(n_groups, n_locs),  # coral recruitment
         dhw_step=zeros(n_locs),  # DHW for each time step
@@ -440,7 +440,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     fog_years::Int64 = param_set[At("fog_years")]  # number of years to fog
 
     loc_k_area::Matrix{Float64} = cache.site_k_area
-    fec_params_per_m²::Vector{Float64} = corals.fecundity  # number of larvae produced per m²
+    fec_params_per_m²::Matrix{Float64} = _to_group_size(domain.coral_growth, corals.fecundity) # number of larvae produced per m²
 
     # Caches
     conn = domain.conn
@@ -461,8 +461,8 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     depth_coeff .= depth_coefficient.(site_data.depth_med)
 
     # Coral cover relative to available area (i.e., 1.0 == site is filled to max capacity)
-    C_cover::Array{Float64,3} = zeros(tf, n_group_and_size, n_locs)
-    C_cover[1, :, :] .= domain.init_coral_cover
+    C_cover::Array{Float64,4} = zeros(tf, n_groups, n_sizes, n_locs)
+    C_cover[1, :, :] .= _group_cover_locs(domain.coral_growth, domain.init_coral_cover)
     cover_tmp = zeros(n_locs)
 
     # Locations that can support corals
@@ -558,7 +558,9 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
     end
 
     # Set up distributions for natural adaptation/heritability
-    c_mean_t_1::Matrix{Float64} = repeat(corals.dist_mean, 1, n_locs)
+    c_mean_t_1::Array{Float64, 3} = repeat(_to_group_size(
+        domain.coral_growth, corals.dist_mean
+    ), 1, 1, n_locs)
 
     c_mean_t = copy(c_mean_t_1)
 
@@ -602,7 +604,7 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
 
     cover_blocks::Vector{Matrix{CoverBlock}} = [
         DynamicCoralCoverModel.blocks_model.CoverBlock.(
-            _to_group_size(domain.coral_growth, C_cover[1, :, loc] .* (site_data.area[loc] .* site_data.k[loc])),
+            C_cover[1, :, :, loc] .* (site_data.area[loc] .* site_data.k[loc]),
             C_bins[:, 1:end-1],
             C_bins[:, 2:end]
         ) for loc in 1:n_locs
@@ -631,9 +633,8 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         DynamicCoralCoverModel.blocks_model.apply_changes!.(size_classes, change_view)
         recruitment .*= reshape(temp_change[:, 1, :], (n_groups, n_locs))
 
-        C_tmp .= _group_cover_locs(
-            domain.coral_growth,
-            C_cover[tstep-1, :, :] .* (site_data.area .* site_data.k)'
+        C_tmp .= C_cover[tstep-1, :, :, :] .* reshape(
+            site_data.area .* site_data.k, (1, 1, n_locs)
         )
 
         for i in 1:n_locs
@@ -662,9 +663,12 @@ function run_model(domain::Domain, param_set::YAXArray)::NamedTuple
         C_cover[tstep, :, valid_locs] .= C_t[:, valid_locs]
 
         if tstep <= tf
+            if isdefined(Main, :Infiltrator)
+                Main.infiltrate(@__MODULE__, Base.@locals, @__FILE__, @__LINE__)
+            end
             # Natural adaptation
             adjust_DHW_distribution!(
-                @view(C_cover[(tstep-1):tstep, :, :]), n_sizes, c_mean_t, p.r
+                @view(C_cover[(tstep-1), :, :]), c_mean_t, p.r
             )
 
             # Set values for t to t-1


### PR DESCRIPTION
The commits reshape `C_cover` from `time x group_size x locs` to `time x group x size x locs`.

This involves providing duplicate implementations of processes that accept multidimensional inputs. The new implementations are for `proportional_adjustment`, `fecundity_scope`, `settler_DHW_tolerance`, `seed_corals`, `bleaching_mortality`, and `cyclone_mortality`. These changes are limited to functions called within `run_model`.

There is probably no rush to merge, to make the review easier compare the new function implementations with the non-multidimensional equivalents