### PR TITLE
add range to for loop

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -830,7 +830,7 @@ function cyclone_mortality!(coral_cover, coral_params, cyclone_mortality)::Nothi
 
     # Mid class coral mortality
     coral_mid = hcat(collect(Iterators.partition(coral_params.mid, 4))...)
-    for i in size(coral_mid, 1)
+    for i in 1:size(coral_mid, 1)
         coral_deaths_mid = coral_cover[coral_mid[i, :], :] .* cyclone_mortality
         coral_cover[coral_mid[i, :], :] -= coral_deaths_mid
     end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -830,9 +830,9 @@ function cyclone_mortality!(coral_cover, coral_params, cyclone_mortality)::Nothi
 
     # Mid class coral mortality
     coral_mid = hcat(collect(Iterators.partition(coral_params.mid, 4))...)
-    for i in 1:size(coral_mid, 1)
-        coral_deaths_mid = coral_cover[coral_mid[i, :], :] .* cyclone_mortality
-        coral_cover[coral_mid[i, :], :] -= coral_deaths_mid
+    for row in eachrow(coral_mid)
+        coral_deaths_mid = coral_cover[row, :] .* cyclone_mortality
+        coral_cover[row, :] -= coral_deaths_mid
     end
 
     # Large class coral mortality


### PR DESCRIPTION
This is the same fix added in #761.

Cyclone mortality was only being applied to the last function group of corals in the middle size classes.