### PR TITLE
Change assisted adaptation to a Discrete Uniform value

### DIFF
--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -68,8 +68,8 @@ Base.@kwdef struct Intervention <: EcoModel
     a_adapt::Param = Factor(
         0.0;
         ptype="continuous",
-        dist=TriangularDist,
-        dist_params=(0.0, 8.0, 0.0),
+        dist=DiscreteUniform,
+        dist_params=(0.0, 15.0),
         name="Assisted Adaptation",
         description="Assisted adaptation in terms of DHW resistance.",
     )

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -67,9 +67,9 @@ Base.@kwdef struct Intervention <: EcoModel
     )
     a_adapt::Param = Factor(
         0.0;
-        ptype="continuous",
-        dist=DiscreteUniform,
-        dist_params=(0.0, 15.0),
+        ptype="ordered discrete",
+        dist=DiscreteOrderedUniformDist,
+        dist_params=(0.0, 15.0, 0.5),  # increase in steps of 0.5 DHW enhancement
         name="Assisted Adaptation",
         description="Assisted adaptation in terms of DHW resistance.",
     )


### PR DESCRIPTION
Previously the assisted adaptation factor - indicating the level of enhancement/efficacy in terms of increased DHW tolerance - was defined as a Triangular Distribution.

I am changing this to a DiscreteOrderedUniform distribution to reflect that no one knows what the likely level of enhancement is.