### PR TITLE
Use underlying data instead of YAXArray type

### DIFF
--- a/ext/AvizExt/viz/environment/dhw.jl
+++ b/ext/AvizExt/viz/environment/dhw.jl
@@ -18,7 +18,7 @@ function ADRIA.viz.dhw_scenario(dom::Domain, scen_id::Int64; fig_opts=Dict(), ax
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "DHW")
     ax = Axis(f[1, 1]; axis_opts...)
 
-    each_loc = series!(ax, loc_scens'; solid_color=(:red, 0.05))
+    each_loc = series!(ax, loc_scens.data'; solid_color=(:red, 0.05))
     scen_mean = lines!(ax, mean_dhw_scen; color=(:black, 0.8))
 
     Legend(


### PR DESCRIPTION
Addresses issue where data is misplaced in the figure

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/487fc2a0-bcc1-4806-84dc-60b02bcf8aa4)

With fix:

![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/f446cc25-42d0-4d07-a54b-884538ccb405)

