### PR TITLE
Fix visualization type error

### DIFF
--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -113,9 +113,9 @@ function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
     data::AbstractArray{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -128,8 +128,8 @@ function ADRIA.viz.map!(
     rs::Union{Domain,ResultSet},
     data::AbstractVector{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Union{GridLayout,GridPosition}
     # Although this function is called scenario_clusters, here we have locations clusters
     loc_groups::Dict{Symbol,BitVector} = ADRIA.analysis.scenario_clusters(clusters)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -92,8 +92,8 @@ function ADRIA.viz.clustered_scenarios!(
 end
 
 """
-    map(rs::Union{Domain,ResultSet}, data::AbstractMatrix, clusters::AbstractVector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    map(g, rs, data, clusters; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    map(rs::Union{Domain,ResultSet}, data::AbstractMatrix, clusters::AbstractVector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    map(g, rs, data, clusters; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Visualize clustered time series for each site and map.
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -113,9 +113,9 @@ function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
     data::AbstractArray{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -128,8 +128,8 @@ function ADRIA.viz.map!(
     rs::Union{Domain,ResultSet},
     data::AbstractVector{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
 )::Union{GridLayout,GridPosition}
     # Although this function is called scenario_clusters, here we have locations clusters
     loc_groups::Dict{Symbol,BitVector} = ADRIA.analysis.scenario_clusters(clusters)

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -1,8 +1,8 @@
 using Statistics
 
 """
-    scenarios(outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    scenarios!(g::Union{GridLayout,GridPosition}, outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    scenarios(outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    scenarios!(g::Union{GridLayout,GridPosition}, outcomes::AbstractMatrix, clusters::Vector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Visualize clustered time series of scenarios.
 
@@ -18,9 +18,9 @@ Figure
 function ADRIA.viz.scenarios(
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    fig_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -33,9 +33,9 @@ function ADRIA.viz.scenarios!(
     g::Union{GridLayout,GridPosition},
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    series_opts::OPT_TYPE=DEFAULT_OPT_VAL,
 )::Union{GridLayout,GridPosition}
     # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
@@ -56,8 +56,8 @@ function ADRIA.viz.scenarios!(
 end
 
 """
-    clustered_scenarios(outcomes::AbstractMatrix{<:Real}, clusters::Vector{Int64}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    clustered_scenarios!(g::Union{GridLayout,GridPosition}, outcomes::AbstractMatrix{<:Real}, clusters::Vector{Int64}; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    clustered_scenarios(outcomes::AbstractMatrix{<:Real}, clusters::Vector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    clustered_scenarios!(g::Union{GridLayout,GridPosition}, outcomes::AbstractMatrix{<:Real}, clusters::Vector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Visualize clustered time series of scenarios.
 
@@ -73,9 +73,9 @@ Figure
 function ADRIA.viz.clustered_scenarios(
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    fig_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
 )::Figure
     return ADRIA.viz.scenarios(
         outcomes, clusters; opts=opts, fig_opts=fig_opts, axis_opts=axis_opts
@@ -85,8 +85,8 @@ function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
 )::Union{GridLayout,GridPosition}
     return ADRIA.viz.scenarios!(g, outcomes, clusters; axis_opts=axis_opts, opts=opts)
 end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -18,9 +18,9 @@ Figure
 function ADRIA.viz.scenarios(
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
-    opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    fig_opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -33,9 +33,9 @@ function ADRIA.viz.scenarios!(
     g::Union{GridLayout,GridPosition},
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    series_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Union{GridLayout,GridPosition}
     # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
@@ -73,9 +73,9 @@ Figure
 function ADRIA.viz.clustered_scenarios(
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    fig_opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Figure
     return ADRIA.viz.scenarios(
         outcomes, clusters; opts=opts, fig_opts=fig_opts, axis_opts=axis_opts
@@ -85,8 +85,8 @@ function ADRIA.viz.clustered_scenarios!(
     g::Union{GridLayout,GridPosition},
     outcomes::AbstractMatrix{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
-    opts::OPT_TYPE=DEFAULT_OPT_VAL,
-    axis_opts::OPT_TYPE=DEFAULT_OPT_VAL,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )::Union{GridLayout,GridPosition}
     return ADRIA.viz.scenarios!(g, outcomes, clusters; axis_opts=axis_opts, opts=opts)
 end

--- a/ext/AvizExt/viz/location_selection.jl
+++ b/ext/AvizExt/viz/location_selection.jl
@@ -3,18 +3,18 @@ using ADRIA: ResultSet
 
 """
     ADRIA.viz.ranks_to_frequencies!(g::Union{GridLayout,GridPosition},rs::ResultSet,
-        frequencies::YAXArray,rank_ids::Vector{Int64};opts::Dict=Dict(),axis_opts::Dict=Dict(),)
+        frequencies::YAXArray,rank_ids::Vector{Int64};opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
     ADRIA.viz.ranks_to_frequencies!(g::Union{GridLayout,GridPosition},rs::ResultSet,
-        frequencies::YAXArray,rank_id::Int64;opts::Dict=Dict(:color_map => :CMRmap),axis_opts::Dict=Dict())
+        frequencies::YAXArray,rank_id::Int64;opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(:color_map => :CMRmap),axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
     ADRIA.viz.ranks_to_frequencies(rs::ResultSet,frequencies::YAXArray,rank_ids::Union{Int64,Vector{Int64}};
-        opts::Dict=Dict(),fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-        
+        opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+
 Plot a spatial map of location selection frequencies.
 
 # Arguments
 - `g` : Figure GridPosition or GridLayout.
 - `rs` : Result set.
-- `frequencies` : Set of frequencies for each rank over a set of scenarios and/or timesteps. 
+- `frequencies` : Set of frequencies for each rank over a set of scenarios and/or timesteps.
     As calculated using`ranks_to_frequencies`.
 - `rank_id`/`rank_ids` : Rank or set of ranks to plot frequency maps for. E.g. 1, [1,2,3].
 - `opts` : Aviz options
@@ -33,8 +33,8 @@ function ADRIA.viz.ranks_to_frequencies!(
     rs::ResultSet,
     frequencies::YAXArray,
     rank_ids::Vector{Int64};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     sym_rank_ids = Symbol.(rank_ids)
     rank_groups = Dict(rank_grp => rank_grp .== sym_rank_ids for rank_grp in sym_rank_ids)
@@ -90,8 +90,9 @@ function ADRIA.viz.ranks_to_frequencies!(
     rs::ResultSet,
     frequencies::YAXArray,
     rank_id::Int64;
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)
     opts[:colorbar_label] = get(opts, :colorbar_label, "Selection frequency")
     opts[:color_map] = get(
         opts,
@@ -111,9 +112,10 @@ function ADRIA.viz.ranks_to_frequencies(
     rs::ResultSet,
     frequencies::YAXArray,
     rank_ids::Union{Int64,Vector{Int64}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
     ADRIA.viz.ranks_to_frequencies!(

--- a/ext/AvizExt/viz/rule_extraction.jl
+++ b/ext/AvizExt/viz/rule_extraction.jl
@@ -2,9 +2,9 @@ using SIRUS
 import ADRIA.analysis: Rule
 
 """
-    ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector}, Vector{Float64}}}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())::Figure
-    ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::BitVector, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())::Figure
-    ADRIA.viz.rules_scatter!(g::Union{GridLayout,GridPosition}, rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict=Dict(), axis_opts::Dict=Dict())
+ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector}, Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
+ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::BitVector, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
+ADRIA.viz.rules_scatter!(g::Union{GridLayout,GridPosition}, rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 # Description
 For each condition Rule, plots a scatter showing one condition clause at each axis.
@@ -30,9 +30,9 @@ function ADRIA.viz.rules_scatter(
     scenarios::DataFrame,
     clusters::Vector{Int64},
     rules::Vector{Rule{Vector{Vector},Vector{Float64}}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -51,9 +51,9 @@ function ADRIA.viz.rules_scatter(
     scenarios::DataFrame,
     clusters::BitVector,
     rules::Vector{Rule{Vector{Vector},Vector{Float64}}};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     return ADRIA.viz.rules_scatter(
         rs,
@@ -71,8 +71,8 @@ function ADRIA.viz.rules_scatter!(
     scenarios::DataFrame,
     clusters::Vector{Int64},
     rules::Vector{Rule{Vector{Vector},Vector{Float64}}};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict()
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     sub_g = g[1, 1] = GridLayout()
 

--- a/ext/AvizExt/viz/rule_extraction.jl
+++ b/ext/AvizExt/viz/rule_extraction.jl
@@ -2,9 +2,9 @@ using SIRUS
 import ADRIA.analysis: Rule
 
 """
-ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector}, Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
-ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::BitVector, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
-ADRIA.viz.rules_scatter!(g::Union{GridLayout,GridPosition}, rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector}, Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
+    ADRIA.viz.rules_scatter(rs::ResultSet, scenarios::DataFrame, clusters::BitVector, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
+    ADRIA.viz.rules_scatter!(g::Union{GridLayout,GridPosition}, rs::ResultSet, scenarios::DataFrame, clusters::Vector{Int64}, rules::Vector{Rule{Vector{Vector},Vector{Float64}}}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 # Description
 For each condition Rule, plots a scatter showing one condition clause at each axis.

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -3,8 +3,8 @@ using ADRIA.analysis: series_confint
 using ADRIA: axes_names, RMEResultSet
 
 """
-    ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::YAXArray; opts=Dict(by_RCP => false), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())
-    ADRIA.viz.scenarios(scenarios::DataFrame, outcomes::YAXArray; opts::Dict=Dict(:by_RCP => false), fig_opts::Dict=Dict(), axis_opts::Dict=Dict(), series_opts::Dict=Dict())::Figure
+    ADRIA.viz.scenarios(rs::ADRIA.ResultSet, outcomes::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(by_RCP => false), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.scenarios(scenarios::DataFrame, outcomes::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(:by_RCP => false), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
     ADRIA.viz.scenarios!(g::Union{GridLayout,GridPosition}, scenarios::DataFrame, outcomes::YAXArray; opts=Dict(by_RCP => false), axis_opts=Dict(), series_opts=Dict())
 
 Plot scenario outcomes over time.
@@ -42,10 +42,10 @@ Figure or GridPosition
 function ADRIA.viz.scenarios(
     rs::ResultSet,
     outcomes::YAXArray;
-    opts::Dict=Dict(:by_RCP => false),
-    fig_opts::Dict=Dict(:size=>(800, 300)),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict()
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(:size=>(800, 300)),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     return ADRIA.viz.scenarios(
         rs.inputs,
@@ -60,9 +60,9 @@ function ADRIA.viz.scenarios!(
     g::Union{GridLayout,GridPosition},
     rs::ResultSet,
     outcomes::YAXArray;
-    opts::Dict=Dict(:by_RCP => false),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Union{GridLayout,GridPosition}
     opts[:histogram] = get(opts, :histogram, false)
 
@@ -78,10 +78,10 @@ end
 function ADRIA.viz.scenarios(
     rs::RMEResultSet,
     outcomes::YAXArray;
-    opts::Dict=Dict(:by_RCP => false),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -97,7 +97,7 @@ function ADRIA.viz.scenarios(
         outcomes,
         scen_groups;
         opts=opts,
-        axis_opts=axis_opts, 
+        axis_opts=axis_opts,
         series_opts=series_opts
     )
     return f
@@ -105,10 +105,10 @@ end
 function ADRIA.viz.scenarios(
     scenarios::DataFrame,
     outcomes::YAXArray;
-    opts::Dict=Dict(:by_RCP => false),
-    fig_opts::Dict=Dict(:size=>(800, 300)),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(:size=>(800, 300)),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -122,10 +122,13 @@ function ADRIA.viz.scenarios!(
     g::Union{GridLayout,GridPosition},
     scenarios::DataFrame,
     outcomes::YAXArray;
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Union{GridLayout,GridPosition}
+    if isdefined(Main, :Infiltrator)
+      Main.infiltrate(@__MODULE__, Base.@locals, @__FILE__, @__LINE__)
+    end
     # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
@@ -153,9 +156,9 @@ function ADRIA.viz.scenarios!(
     ax::Axis,
     outcomes::YAXArray,
     scen_groups::Dict{Symbol,BitVector};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
-    series_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Union{GridLayout,GridPosition}
     if get(opts, :summarize, true)
         scenarios_confint!(ax, outcomes, scen_groups)
@@ -233,7 +236,7 @@ function scenarios_series!(
     ax::Axis,
     outcomes::YAXArray,
     scen_groups::Dict{Symbol,BitVector};
-    series_opts::Dict=Dict(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     x_vals::Union{Vector{Int64},Vector{Float64}}=collect(1:size(outcomes, 1)),
     sort_by=:size,
 )::Nothing

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -293,8 +293,8 @@ function ADRIA.viz.rsa(
 end
 
 """
-ADRIA.viz.outcome_map(rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
-ADRIA.viz.outcome_map!(f::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.outcome_map(rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.outcome_map!(f::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot outcomes mapped to factor regions for up to 30 factors.
 

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -3,8 +3,8 @@ using Printf
 using ADRIA.sensitivity: _get_cat_quantile
 
 """
-    ADRIA.viz.pawn(Si::YAXArray; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    ADRIA.viz.pawn!(f::Union{GridLayout,GridPosition}, Si::YAXArray; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    ADRIA.viz.pawn(Si::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.pawn!(f::Union{GridLayout,GridPosition}, Si::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Display heatmap of sensitivity analysis.
 
@@ -33,8 +33,8 @@ Makie figure
 function ADRIA.viz.pawn!(
     g::Union{GridLayout,GridPosition},
     Si::YAXArray;
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )
     xtick_rot = get(axis_opts, :xticklabelrotation, 2.0 / π)
 
@@ -67,7 +67,10 @@ function ADRIA.viz.pawn!(
     return g
 end
 function ADRIA.viz.pawn(
-    Si::YAXArray; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict()
+    Si::YAXArray;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -77,8 +80,8 @@ function ADRIA.viz.pawn(
 end
 
 """
-    ADRIA.viz.tsa(rs::ResultSet, si::YAXArray; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    ADRIA.viz.tsa!(f::Union{GridLayout,GridPosition}, rs::ResultSet, si::YAXArray; opts, axis_opts)
+    ADRIA.viz.tsa(rs::ResultSet, si::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
+    ADRIA.viz.tsa!(f::Union{GridLayout,GridPosition}, rs::ResultSet, si::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Display temporal sensitivity analysis
 
@@ -96,7 +99,10 @@ Display temporal sensitivity analysis
 Makie figure
 """
 function ADRIA.viz.tsa!(
-    g::Union{GridLayout,GridPosition}, rs::ResultSet, si::YAXArray; opts, axis_opts
+    g::Union{GridLayout,GridPosition},
+    rs::ResultSet, si::YAXArray;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     stat = get(opts, :stat, :median)
 
@@ -143,9 +149,9 @@ end
 function ADRIA.viz.tsa(
     rs::ResultSet,
     si::YAXArray;
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -155,8 +161,8 @@ function ADRIA.viz.tsa(
 end
 
 """
-    ADRIA.viz.rsa(rs::ResultSet, si::Dataset, factors::Vector{String}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    ADRIA.viz.rsa!(f::Union{GridLayout,GridPosition}, rs::ResultSet, si::Dataset, factors::Vector{String}; opts::Dict=Dict(), axis_opts::Dict=Dict())
+    ADRIA.viz.rsa(rs::ResultSet, si::Dataset, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.rsa!(f::Union{GridLayout,GridPosition}, rs::ResultSet, si::Dataset, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot regional sensitivities of up to 30 factors.
 
@@ -177,8 +183,8 @@ function ADRIA.viz.rsa!(
     rs::ResultSet,
     si::Dataset,
     factors::Vector{Symbol};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )
     n_factors::Int64 = length(factors)
     if n_factors > 30
@@ -275,9 +281,9 @@ function ADRIA.viz.rsa(
     rs::ResultSet,
     si::Dataset,
     factors::Vector{Symbol};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -287,8 +293,8 @@ function ADRIA.viz.rsa(
 end
 
 """
-    ADRIA.viz.outcome_map(rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict=Dict(), fig_opts::Dict=Dict(), axis_opts::Dict=Dict())
-    ADRIA.viz.outcome_map!(f::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts, axis_opts)
+ADRIA.viz.outcome_map(rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+ADRIA.viz.outcome_map!(f::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot outcomes mapped to factor regions for up to 30 factors.
 
@@ -310,8 +316,8 @@ function ADRIA.viz.outcome_map!(
     rs::ResultSet,
     outcomes::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )
     # TODO: Clean up and compartmentalize as a lot of code here are duplicates of those
     #       found in `rsa()`
@@ -431,9 +437,9 @@ function ADRIA.viz.outcome_map(
     rs::ResultSet,
     si::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -444,7 +450,7 @@ end
 
 """
     _series_convergence(g::GridPosition, Si_conv::YAXArray, factors::Vector{Symbol};
-        opts::Dict=Dict(:plot_overlay => true), axis_opts::Dict=Dict())
+        opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(:plot_overlay => true), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot sensitivity values for an increasing number of scenarios as a series, with each member
     of the series representing a factor or model component.
@@ -464,8 +470,8 @@ function _series_convergence(
     g::GridPosition,
     Si_conv::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(:plot_overlay => true),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:plot_overlay => true),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
 )
     plot_overlay = get(opts, :plot_overlay, true)
     n_scenarios = collect(lookup(Si_conv, :n_scenarios))
@@ -567,7 +573,7 @@ end
 
 """
     _heatmap_convergence(g::GridPosition, Si_conv::YAXArray, factors::Vector{Symbol};
-        opts::Dict=Dict(), axis_opts::Dict=Dict())
+        opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot sensitivity values for an increasing number of scenarios as a heatmap, with each row
     of the heatmap representing a factor or model component.
@@ -588,8 +594,8 @@ function _heatmap_convergence(
     g::GridPosition,
     Si_conv::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     y_label = get(axis_opts, :ylabel, "Factors")
     x_label = get(axis_opts, :xlabel, "N scenarios")
@@ -619,10 +625,10 @@ function _heatmap_convergence(
 end
 
 """
-    ADRIA.viz.convergence(Si_conv::YAXArray, factors::Vector{Symbol}; series_opts::Dict=Dict(),
-        axis_opts::Dict=Dict())
-    ADRIA.viz.convergence!(f::Figure, Si_conv::YAXArray, factors::Vector{Symbol}; series_opts::Dict=Dict(),
-        axis_opts::Dict=Dict())
+    ADRIA.viz.convergence(Si_conv::YAXArray, factors::Vector{Symbol}; series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+        axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
+    ADRIA.viz.convergence!(f::Figure, Si_conv::YAXArray, factors::Vector{Symbol}; series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
+        axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
 Plot sensitivity metric for increasing number of scenarios to illustrate convergence.
 
@@ -645,9 +651,9 @@ Makie figure
 function ADRIA.viz.convergence(
     Si_conv::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(:viz_type => :series),
-    fig_opts::Dict=Dict(),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:viz_type => :series),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     f = Figure(; fig_opts...)
     ADRIA.viz.convergence!(
@@ -663,8 +669,8 @@ function ADRIA.viz.convergence!(
     g::Union{GridLayout,GridPosition},
     Si_conv::YAXArray,
     factors::Vector{Symbol};
-    opts::Dict=Dict(:viz_type => :series),
-    axis_opts::Dict=Dict(),
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(:viz_type => :series),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
     viz_type = get(opts, :viz_type, :series)
     if viz_type == :series

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -116,11 +116,10 @@ function create_map!(
 
             for color in hl_groups
                 m = findall(highlight .== [color])
-                subset_feat = FC(; features=geodata[m])
 
                 poly!(
                     spatial,
-                    subset_feat;
+                    geodata[m];
                     color="transparent",
                     strokecolor=color,
                     strokewidth=0.5,

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -6,7 +6,7 @@ using Graphs, GraphMakie, SimpleWeightedGraphs
 Base.getindex(fc::AbstractFeatureCollection, i::UnitRange) = features(fc)[i]
 Base.getindex(fc::AbstractFeatureCollection, i::Vector) = features(fc)[i]
 
-function set_figure_defaults(fig_opts::Dict{Symbol,<:Any})::Dict{Symbol,<:Any}
+function set_figure_defaults(fig_opts::OPT_TYPE)::OPT_TYPE
     fig_opts[:size] = get(fig_opts, :size, (600, 900))
     fig_opts[:xticklabelsize] = get(fig_opts, :xticklabelsize, 14)
     fig_opts[:yticklabelsize] = get(fig_opts, :yticklabelsize, 14)
@@ -14,7 +14,7 @@ function set_figure_defaults(fig_opts::Dict{Symbol,<:Any})::Dict{Symbol,<:Any}
     return fig_opts
 end
 
-function set_axis_defaults(axis_opts::Dict{Symbol,<:Any})::Dict{Symbol,<:Any}
+function set_axis_defaults(axis_opts::OPT_TYPE)::OPT_TYPE
     axis_opts[:title] = get(axis_opts, :title, "Study Area")
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Longitude")
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "Latitude")

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -62,7 +62,7 @@ function create_map!(
     colorbar_label::String="",
     color_map::Union{Symbol,Vector{Symbol},RGBA{Float32},Vector{RGBA{Float32}}}=:grayC,
     legend_params::Union{Tuple,Nothing}=nothing,
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     spatial = GeoAxis(
         f[1, 1];
@@ -164,9 +164,9 @@ GridPosition
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
     y::Union{YAXArray,AbstractVector{<:Real}};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=set_figure_defaults(Dict{Symbol,Any}()),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -177,9 +177,9 @@ function ADRIA.viz.map(
 end
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=set_figure_defaults(Dict{Symbol,Any}()),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -206,8 +206,8 @@ function ADRIA.viz.map!(
     g::Union{GridLayout,GridPosition},
     rs::Union{Domain,ResultSet},
     y::AbstractVector{<:Real};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     geodata = _get_geoms(rs.site_data)
     data = Observable(collect(y))
@@ -355,9 +355,9 @@ function ADRIA.viz.connectivity(
     dom::Domain;
     in_method=nothing,
     out_method=eigenvector_centrality,
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=set_figure_defaults(Dict{Symbol,Any}()),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     return ADRIA.viz.connectivity(dom, dom.conn; in_method, out_method, opts, fig_opts, axis_opts)
 end
@@ -366,9 +366,9 @@ function ADRIA.viz.connectivity(
     conn::AbstractMatrix;
     in_method=nothing,
     out_method=eigenvector_centrality,
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=set_figure_defaults(Dict{Symbol,Any}()),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     if !isnothing(in_method) && !isnothing(out_method)
         @warn "Both in and out centrality measures provided. Plotting out centralities."
@@ -391,9 +391,9 @@ function ADRIA.viz.connectivity(
     dom::Domain,
     network::SimpleWeightedDiGraph,
     conn_weights::AbstractVector{<:Real};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=set_figure_defaults(Dict{Symbol,Any}()),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
@@ -407,8 +407,8 @@ function ADRIA.viz.connectivity!(
     dom::Domain,
     network::SimpleWeightedDiGraph,
     conn_weights::AbstractVector{<:Real};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=set_axis_defaults(Dict{Symbol,Any}())
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(Dict{Symbol,Any}())
 )
     axis_opts[:title] = get(axis_opts, :title, "Study Area")
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Longitude")

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -2,7 +2,7 @@ using ADRIA.analysis: series_confint
 using ADRIA: functional_group_names, human_readable_name
 
 """
-    ADRIA.viz.taxonomy(rs::ResultSet; opts::Dict=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
+    ADRIA.viz.taxonomy(rs::ResultSet; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
     ADRIA.viz.taxonomy(scenarios::DataFrame, relative_taxa_cover::YAXArray; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Figure
     ADRIA.viz.taxonomy!(g::Union{GridLayout,GridPosition}, relative_taxa_cover::YAXArray, scen_groups::Dict{Symbol, BitVector}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())::Union{GridLayout,GridPosition}
 
@@ -36,10 +36,10 @@ Figure or GridPosition
 """
 function ADRIA.viz.taxonomy(
     rs::ResultSet;
-    opts::Dict=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     if !haskey(rs.outcomes, :relative_taxa_cover)
         throw(ArgumentError("Unable to found relative_taxa_cover in outcomes. This variable may be passed manually."))
@@ -56,10 +56,10 @@ end
 function ADRIA.viz.taxonomy(
     scenarios::DataFrame,
     relative_taxa_cover::YAXArray;
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
     fig_opts[:size] = get(fig_opts, :size, (1200, 1200))
     f = Figure(; fig_opts...)
@@ -88,9 +88,9 @@ function ADRIA.viz.taxonomy!(
     g::Union{GridLayout,GridPosition},
     relative_taxa_cover::YAXArray,
     scen_groups::Dict{Symbol, BitVector};
-    opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Union{GridLayout,GridPosition}
     axis_opts[:xlabel] = get(axis_opts, :xlabel, "Year")
     axis_opts[:ylabel] = get(axis_opts, :ylabel, "Relative Cover")
@@ -150,8 +150,8 @@ function taxonomy_by_intervention!(
     scen_groups::Dict{Symbol},
     colors::Union{Vector{Symbol},Vector{RGBA{T}}};
     show_confints=true,
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Nothing where {T<:Float32}
     # Get taxonomy names for legend
     taxa_names = human_readable_name(functional_group_names(), title_case=true)
@@ -180,7 +180,7 @@ function taxonomy_by_intervention!(
     colors::Union{Vector{Symbol},Array{RGBA{T},1}};
     show_confints=true,
     show_legend=true,
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Nothing where {T<:Float32}
     n_timesteps::Int64 = length(relative_taxa_cover.timesteps)
     n_functional_groups::Int64 = length(relative_taxa_cover.taxa)
@@ -215,8 +215,8 @@ function intervention_by_taxonomy!(
     scen_groups::Dict{Symbol,BitVector},
     colors::Union{Vector{Symbol},Vector{RGBA{T}}};
     show_confints::Bool=true,
-    axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(),
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Nothing where {T<:Float32}
     taxa_names = human_readable_name(functional_group_names(), title_case=true)
 
@@ -247,7 +247,7 @@ function intervention_by_taxonomy!(
     scen_groups::Dict{Symbol,BitVector};
     show_confints::Bool=true,
     show_legend::Bool=true,
-    series_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}()
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Nothing where {T<:Float32}
     scenario_group_names::Vector{Symbol} = collect(keys(scen_groups))
 

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -5,6 +5,9 @@ using DimensionalData, YAXArrays
 using .AvizExt
 using Makie.Colors
 
+const OPT_TYPE = Dict{Symbol,<:Any}
+const DEFAULT_OPT_VAL = Dict{Symbol,Any}()
+
 """
     _time_labels(labels)
 

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -6,7 +6,7 @@ using .AvizExt
 using Makie.Colors
 
 const OPT_TYPE = Dict{Symbol,<:Any}
-const DEFAULT_OPT_VAL = Dict{Symbol,Any}()
+const DEFAULT_OPT_TYPE = Dict{Symbol,Any}
 
 """
     _time_labels(labels)


### PR DESCRIPTION
<img width="694" alt="example_err" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/c1a54876-833f-4e8e-806d-fdc0a8397988">

The update to use `Dict{Symbol,<:Any}` in `ADRIA.viz.map` for optional arguments caused type mismatches in visualisations that were using mapping. Specifically, spatial visualization of clustering results.

This pull requests fixes this mismatch and allows tests to be run without erroring again.