### PR TITLE
Fix mismatched function name in docstring

### DIFF
--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -469,7 +469,7 @@ function ADRIA.viz.connectivity!(
 end
 
 """
-    _get_plottable_geom(gdf::DataFrame)::Union{Symbol, Bool}
+    _get_geom_col(gdf::DataFrame)::Union{Symbol, Bool}
 
 Retrieve first column found to hold plottable geometries.
 


### PR DESCRIPTION
As in title.

Simple one line fix to docstring.