### PR TITLE
constrain growth by available area

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -671,8 +671,7 @@ function run_model(domain::Domain, param_set::YAXArray, functional_groups::Vecto
         )
 
         # Constrain growth by available area
-        # Constraint Coefficient -> log(1 + left over space)
-        growth_spatial_constraint .= log.(2, 1 .+ relative_leftover_space(
+        growth_spatial_constraint .= log2.(1 .+ relative_leftover_space(
             dropdims(sum(C_t; dims=(1, 2)), dims=(1, 2))
         ))
 


### PR DESCRIPTION
Add growth constraints based on available area. 

The initial implementation in the main branch uses `actual_growth = growth * log(1 + leftover space)`. 

This implementation uses `actual_growth = growth * log(2, 1 + leftover space)`. Using log base 2 so that when leftover space is 100% the log is 1 and growth is unconstrained.

This assumes the growth rates being used are unconstrained growth rates which probably isn't the case and depends on available space when the measurement took place. 

### Unconstrained RCP4.5 (Before changes)

<img width="596" alt="unconstrained_45" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/df1b12c3-bf18-4cd9-8361-eff75e4250f0">

### Constrained RCP4.5 (After Changes)

<img width="598" alt="constrained_45" src="https://github.com/open-AIMS/ADRIA.jl/assets/156630392/5d0f0203-19ba-476e-8ca1-0ab8efc863af">
