### PR TITLE
Add default option to _sort_keys

### DIFF
--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -44,6 +44,8 @@ function ADRIA.viz.scenarios!(
 
     scen_groups = ADRIA.analysis.scenario_clusters(clusters)
     opts[:histogram] = false
+    opts[:legend_labels] = sort(collect(keys(scen_groups)))
+
     return ADRIA.viz.scenarios!(
         g,
         ax,


### PR DESCRIPTION
As in title. Default order is "counterfactual", "unguided", "guided".

> NOTE: When plotting clusters, the legend is always in the same order, but the plot order might change depending on `sort_by`

Below are some plots of scenarios and clusters, sorted by default, variance and size:

| `sort_by` | Scenarios | Cluster |
| -------- | --------- | ------- |
| `:default` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/76e1c441-cfe9-4306-ac55-de2e108a9e49) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/22faffe3-aa72-48d1-bd58-57ce3445d774) |
| `:default` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/decdbc86-cb31-4c5c-842d-91cef6984d36) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/f69fafac-eca0-48f3-bf1f-807f17acde6e) |
| `:variance` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/c2950a40-d890-4f19-a6c0-7c7896a11881) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/28d7af22-bd2f-4588-9505-c5138e304cef) |
| `:variance` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/a7e5c0bd-dc32-4c96-9d27-319430ada44c) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/6c0518cb-a582-4e2d-8f50-a0809ade4cc2) |
| `:size` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/a87918c8-2636-42e5-a233-6a652d212e5e) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/bad923b1-6d24-4209-901a-840b045e3765) |
| `:size` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/2a96bd5f-50d3-4765-ab27-423b65e9a024) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/23d3c9d4-9898-49b4-a8e0-72e71913a19e) |

Grouped by RCP:

| `sort_by` | summarize = true | summarize = false |
| --- | --- | --- |
| `:default` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/3f2d4ac7-e329-430d-b429-6824a1e6d4fc) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/b63d5696-a62a-46e6-9892-892d4cb6592e) |
| `:variance` | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/40277671-b0bd-4adf-8443-be2d3a55cec4) | ![image](https://github.com/open-AIMS/ADRIA.jl/assets/8040719/868cc8e7-acc8-476a-9013-f3b154098334) |
  
 Closes #769 

