### PR TITLE
Coerce to MultiPolygon instead of Polygon

### DIFF
--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -55,7 +55,7 @@ Create a spatial choropleth figure.
 """
 function create_map!(
     f::Union{GridLayout,GridPosition},
-    geodata::Vector{<:GeoMakie.GeometryBasics.Polygon},
+    geodata::Vector{<:GeoMakie.GeometryBasics.MultiPolygon},
     data::Observable,
     highlight::Union{Vector,Tuple,Nothing},
     show_colorbar::Bool=true,
@@ -489,5 +489,5 @@ function _get_geoms(gdf::DataFrame)
     return _get_geoms(gdf, geom_col)
 end
 function _get_geoms(gdf::DataFrame, geom_col::Symbol)
-    return GeoMakie.geo2basic(AG.forceto.(gdf[!, geom_col], AG.wkbPolygon))
+    return GeoMakie.geo2basic(AG.forceto.(gdf[!, geom_col], AG.wkbMultiPolygon))
 end


### PR DESCRIPTION
As in title.

Closes #792

```julia
dom = ADRIA.load_domain("<path to domain>")
dom2 = ADRIA.switch_RCPs!(dom, "45")

ADRIA.viz.map(
    dom2,
    vec(mean(dhw_scens[timesteps=At(20)], dims=2));
    opts=Dict(:color_map => :lighttest),
    axis_opts=Dict(:title => "Mean DHW 2045")
)

```


![image](https://github.com/open-AIMS/ADRIA.jl/assets/4075136/e0dcbc36-8a9a-42d8-ac8a-81cc30974ca3)

Note this is a temporary fix on top of a temporary implementation.
Further work to utilize/leverage GeoMakie/GeoDataFrames functionality much more is needed.
