### PR TITLE
Address tests failing due to type mismatch (scenario confint)

### DIFF
--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -210,9 +210,9 @@ function scenarios_confint!(
     ax::Axis,
     confints::AbstractArray,
     ordered_groups::Vector{Symbol},
-    _colors::Dict{Symbol,Union{Symbol,RGBA{Float32},String}};
+    _colors::Dict{Symbol, T};
     x_vals::Union{Vector{Int64},Vector{Float64}}=collect(1:size(confints, 1)),
-)::Nothing
+)::Nothing where {T<:Union{RGBA{Float32},String,Symbol}}
 
     for idx in eachindex(ordered_groups)
         band_color = (_colors[ordered_groups[idx]], 0.4)
@@ -248,8 +248,8 @@ function scenarios_series!(
     scen_groups::Dict{Symbol,BitVector},
     group_names::Vector{Symbol};
     series_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
-    x_vals::Union{Vector{Int64},Vector{Float64}}=collect(1:size(outcomes, 1)),
-)::Nothing
+    x_vals::T=collect(1:size(outcomes, 1)),
+)::Nothing where {T<:Union{Vector{Int64},Vector{Float64}}}
     _colors::Dict{Symbol,Union{Symbol,RGBA{Float32}}} = colors(scen_groups)
     _alphas::Dict{Symbol,Float64} = alphas(scen_groups)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,14 +212,14 @@ function test_rs_w_fig()
     n_clusters = 4
     clusters = ADRIA.analysis.cluster_scenarios(s_tac, n_clusters)
 
-    axis_opts = Dict(
+    axis_opts = Dict{Symbol,Any}(
         :title => "Time Series Clustering with $n_clusters clusters",
         :ylabel => "TAC [m²]",
         :xlabel => "Timesteps [years]",
     )
 
     tsc_fig = ADRIA.viz.clustered_scenarios(
-        s_tac, clusters; opts=Dict(:summarize => true), fig_opts=fig_opts,
+        s_tac, clusters; opts=Dict{Symbol,Any}(:summarize => true), fig_opts=fig_opts,
         axis_opts=axis_opts,
     )
 


### PR DESCRIPTION
Minor fix to resolve failing test related to scenario clustering/confidence intervals.

Tests still fail due to unrelated issues, but this is a step towards resolving them.