### PR TITLE
Fix broken tests

### DIFF
--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -210,7 +210,7 @@ function scenarios_confint!(
     ax::Axis,
     confints::AbstractArray,
     ordered_groups::Vector{Symbol},
-    _colors::Dict{Symbol, T};
+    _colors::Dict{Symbol,T};
     x_vals::Union{Vector{Int64},Vector{Float64}}=collect(1:size(confints, 1)),
 )::Nothing where {T<:Union{RGBA{Float32},String,Symbol}}
 
@@ -256,7 +256,7 @@ function scenarios_series!(
     for group in group_names
         color = (_colors[group], _alphas[group])
         scens = outcomes[:, scen_groups[group]]'
-        series!(ax, x_vals, scens; solid_color=color, series_opts...)
+        series!(ax, x_vals, scens.data; solid_color=color, series_opts...)
     end
 
     return nothing

--- a/test/clustering.jl
+++ b/test/clustering.jl
@@ -54,7 +54,8 @@
         end
 
         @testset "Call cluster_series function" begin
-            num_clusters = 5
+            # Since test_data is a 3x3 matrix, Clustering.kmeioids requires num_clusters ≤ 3
+            num_clusters = 3
             clusters = ADRIA.analysis.cluster_series(test_data, num_clusters)
 
             @test length(clusters) == size(test_data, 2)


### PR DESCRIPTION
- Clustering test was broken because the test data we use is a 3x3 matrix and the new clustering method requires the maximum number of clusters to be the size of this matrix. 
- In some cases, scenarios plot was raising an error when we tried to call `series!` passing an YAXArray of data as input. 

This PR fix those two issues. 