### PR TITLE
fix permutation of initial cover dimensions

### DIFF
--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -476,7 +476,7 @@ function load_initial_cover(
     # Reshape and Permute icc_data from
     # [n_locs ⋅ n_groups ⋅ n_sizes] to [(n_groups × n_sizes) ⋅ n_locs]
     icc_data = reshape(
-        permutedims(icc_data, (2, 3, 1)), (n_sizes * n_groups, n_locs)
+        permutedims(icc_data, (3, 2, 1)), (n_sizes * n_groups, n_locs)
     )
 
     # Convert values relative to absolute area to values relative to k area


### PR DESCRIPTION
Unfortunately, I appeared to have incorrectly loaded RMEDomain initial cover when migrating to use CoralBlox. @Zapiano @ConnectedSystems 

This wouldn't impact calibration runs as initial cover is overwritten.

### Before

The first taxa has very small initial cover which is actually the initial cover values for the small size classes and the last taxa has very large cover values.

<img width="551" alt="bugged_init_cover" src="https://github.com/user-attachments/assets/43130ed2-9fe1-42ea-b02d-edc8bf5c174c">

2 counterfactuals
![bug_not_fix](https://github.com/user-attachments/assets/4cdce1fa-be19-4af3-abe2-2eea1e9074e1)

### After

<img width="539" alt="bug_fix_init_cover" src="https://github.com/user-attachments/assets/08e1b254-3d5c-4d28-957a-c40d678e970b">

![bug_fix](https://github.com/user-attachments/assets/412cd3e1-8df1-48d9-aed8-ec683c15ce9b)
