### PR TITLE
Add reshape to fix dimension mismatch when logging dhw tolerances

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -761,7 +761,9 @@ function run_model(
 
             if in_debug_mode
                 # Log dhw tolerances if in debug mode
-                dhw_tol_mean_log[tstep, :, :] .= mean.(c_mean_t)
+                dhw_tol_mean_log[tstep, :, :] .= reshape(
+                    mean.(c_mean_t), size(dhw_tol_mean_log)[2:3]
+                )
             end
         end
 


### PR DESCRIPTION
Resolves #826

Reshape retains order of size classes then species. Seems some repetitiveness though in logged values, maybe it can be further aggregated?