### PR TITLE
updates docs github action to use Julia 1.10.*

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.9'
+          version: '1.10'
       - uses: julia-actions/cache@v2
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'


### PR DESCRIPTION
Bump the Julia version for the documentation build action.

This should fix the Pkg error.

## Notes

`1.10` matches `1.10.*`
https://github.com/julia-actions/setup-julia?tab=readme-ov-file#julia-versions

