### PR TITLE
Rename metrics `:sites` dimension with `:locations`

### DIFF
--- a/docs/src/development/metrics.md
+++ b/docs/src/development/metrics.md
@@ -12,8 +12,8 @@ Note that the unit of measure is optional and can be left out.
 Below is the implementation of the `total_absolute_cover` metric.
 
 ```julia
-function _total_absolute_cover(X::AbstractArray{<:Real}, site_area::Vector{<:Real})::AbstractArray{<:Real}
-    return dropdims(sum(X, dims=:species), dims=:species) .* site_area'
+function _total_absolute_cover(X::AbstractArray{<:Real}, loc_area::Vector{<:Real})::AbstractArray{<:Real}
+    return dropdims(sum(X, dims=:species), dims=:species) .* loc_area'
 end
 function _total_absolute_cover(rs::ResultSet)::AbstractArray{<:Real}
     return rs.outcomes[:total_absolute_cover]

--- a/ext/AvizExt/AvizExt.jl
+++ b/ext/AvizExt/AvizExt.jl
@@ -357,7 +357,7 @@ function ADRIA.viz.explore(rs::ResultSet)
 
     @info "Generating map"
     map_display = layout.map
-    geodata = _get_geoms(rs.site_data)
+    geodata = _get_geoms(rs.loc_data)
     map_disp = create_map!(map_display, geodata, obs_mean_rc_sites, (:black, 0.05))
 
     curr_highlighted_sites = _get_seeded_sites(seed_log, (:), (:))
@@ -759,11 +759,11 @@ end
 #     # TODO: Separate this out into own function
 #     # Make temporary copy of GeoPackage as GeoJSON
 #     tmpdir = mktempdir()
-#     geo_fn = GDF.write(joinpath(tmpdir, "Aviz_$(rs.name).geojson"), rs.site_data; driver="geojson")
+#     geo_fn = GDF.write(joinpath(tmpdir, "Aviz_$(rs.name).geojson"), rs.loc_data; driver="geojson")
 #     geodata = GeoMakie.GeoJSON.read(read(geo_fn))
 
 #     # Get bounds to display
-#     centroids = rs.site_centroids
+#     centroids = rs.loc_centroids
 #     lon = first.(centroids)
 #     lat = last.(centroids)
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -7,7 +7,7 @@ using Statistics
 Visualize clustered time series of scenarios.
 
 # Arguments
-- `outcomes` : AbstractMatrix of outcomes for several scenarios or sites
+- `outcomes` : AbstractMatrix of outcomes for several scenarios or locations
 - `clusters` : Vector of numbers corresponding to clusters
 - `opts` : Aviz options
     - `summarize` : plot confidence interval. Defaults to true
@@ -64,7 +64,7 @@ end
 Visualize clustered time series of scenarios.
 
 # Arguments
-- `outcomes` : Matrix of outcomes for several scenarios or sites
+- `outcomes` : Matrix of outcomes for several scenarios or locations
 - `clusters` : Vector of numbers corresponding to clusters
 - `opts` : Aviz options
     - `summarize` : plot confidence interval. Defaults to true
@@ -97,7 +97,7 @@ end
     map(rs::Union{Domain,ResultSet}, data::AbstractMatrix, clusters::AbstractVector{Int64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), fig_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
     map(g, rs, data, clusters; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
-Visualize clustered time series for each site and map.
+Visualize clustered time series for each location and map.
 
 # Arguments
 - `rs` : ResultSet
@@ -161,7 +161,7 @@ end
 Color parameter for current cluster weighted by number of scenarios.
 
 # Arguments
-- `data` : Vector of some metric outcome for each site
+- `data` : Vector of some metric outcome for each location
 - `loc_groups` : Dictionary of (group_names => filter), where filter is a BitVector to
 select locations that belong to each group
 - `group_colors` : Dictionary of (group_names => colors), where colors can be Symbols or

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -204,15 +204,15 @@ function ADRIA.viz.map(
     if opts[:show_management_zones]
         local highlight
         try
-            highlight = Symbol.(lowercase.(rs.site_data.zone_type))
+            highlight = Symbol.(lowercase.(rs.loc_data.zone_type))
         catch
             # Annoyingly, the case of the name may have changed...
-            highlight = Symbol.(lowercase.(rs.site_data.ZONE_TYPE))
+            highlight = Symbol.(lowercase.(rs.loc_data.ZONE_TYPE))
         end
         opts[:highlight] = highlight
     end
 
-    ADRIA.viz.map!(g, rs, rs.site_data.k * 100.0; opts, axis_opts)
+    ADRIA.viz.map!(g, rs, rs.loc_data.k * 100.0; opts, axis_opts)
 
     return f
 end
@@ -223,7 +223,7 @@ function ADRIA.viz.map!(
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
-    geodata = _get_geoms(rs.site_data)
+    geodata = _get_geoms(rs.loc_data)
     data = Observable(collect(y))
 
     highlight = get(opts, :highlight, nothing)
@@ -232,8 +232,8 @@ function ADRIA.viz.map!(
     show_colorbar = get(opts, :show_colorbar, true)
     color_map = get(opts, :color_map, :grayC)
     if !(:dest in keys(axis_opts))
-        col = _get_geom_col(rs.site_data)
-        axis_opts[:dest] = ADRIA.AG.toPROJ4(ADRIA.AG.getspatialref(rs.site_data[1, col]))
+        col = _get_geom_col(rs.loc_data)
+        axis_opts[:dest] = ADRIA.AG.toPROJ4(ADRIA.AG.getspatialref(rs.loc_data[1, col]))
     end
 
     return create_map!(
@@ -440,7 +440,7 @@ function ADRIA.viz.connectivity!(
         axis_opts...
     )
 
-    geodata = _get_geoms(dom.site_data)
+    geodata = _get_geoms(dom.loc_data)
 
     spatial.yticklabelpad = 50
     spatial.ytickalign = 10

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -89,7 +89,7 @@ export
     run_scenario, coral_spec,
     create_coral_struct, Intervention, SimConstants,
     SeedCriteriaWeights, FogCriteriaWeights,
-    site_area, site_k_area,
+    loc_area, site_k_area,
     Domain, ADRIADomain,
     metrics, select, timesteps, env_stats, viz
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -30,8 +30,8 @@ function load_domain(path::String)::Domain
     return load_domain(path, "")
 end
 
-function unique_sites(d::Domain)::Vector{String}
-    return d.site_data[:, d.cluster_id_col]
+function unique_loc_ids(d::Domain)::Vector{String}
+    return d.site_data[:, d.site_id_col]
 end
 
 """

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -7,8 +7,8 @@ Store environmental data layers used for scenario
 """
 mutable struct EnvLayer{S<:AbstractString,TF}
     dpkg_path::S
-    site_data_fn::S
-    const site_id_col::S
+    loc_data_fn::S
+    const loc_id_col::S
     const cluster_id_col::S
     init_coral_cov_fn::S
     connectivity_fn::S
@@ -31,7 +31,7 @@ function load_domain(path::String)::Domain
 end
 
 function unique_loc_ids(d::Domain)::Vector{String}
-    return d.site_data[:, d.site_id_col]
+    return d.loc_data[:, d.loc_id_col]
 end
 
 """
@@ -168,12 +168,12 @@ function _convert_abs_to_k(
 end
 
 """
-    site_area(domain::Domain)::Vector{Float64}
+    loc_area(domain::Domain)::Vector{Float64}
 
 Get site area for the given domain.
 """
-function site_area(domain::Domain)::Vector{Float64}
-    return domain.site_data.area
+function loc_area(domain::Domain)::Vector{Float64}
+    return domain.loc_data.area
 end
 
 """
@@ -182,7 +182,7 @@ end
 Get maximum coral cover area for the given domain in absolute area.
 """
 function site_k_area(domain::Domain)::Vector{Float64}
-    return location_k(domain) .* site_area(domain)
+    return location_k(domain) .* loc_area(domain)
 end
 
 """
@@ -191,7 +191,7 @@ end
 Returns the number of locations (sites/reefs/clusters) represented within the domain.
 """
 function n_locations(domain::Domain)::Int64
-    return size(domain.site_data, 1)
+    return size(domain.loc_data, 1)
 end
 
 """
@@ -218,7 +218,7 @@ end
 Get maximum coral habitable area as a proportion of a location's area (\$k ∈ [0, 1]\$).
 """
 function location_k(domain::Domain)
-    return domain.site_data.k
+    return domain.loc_data.k
 end
 
 """Extract the time steps represented in the data package."""

--- a/src/ExtInterface/ADRIA/Domain.jl
+++ b/src/ExtInterface/ADRIA/Domain.jl
@@ -18,13 +18,13 @@ mutable struct ADRIADomain <: Domain
     env_layer_md::EnvLayer  # Layers used
     scenario_invoke_time::String  # time latest set of scenarios were run
     const conn::YAXArray  # connectivity data
-    site_data::DataFrame  # table of site data (depth, carrying capacity, etc)
-    const site_id_col::String  # column to use as site ids, also used by the connectivity dataset (indicates order of `conn`)
-    const cluster_id_col::String  # column of unique site ids
+    site_data::DataFrame  # table of location data (depth, carrying capacity, etc)
+    const site_id_col::String  # column to use as location ids, also used by the connectivity dataset (indicates order of `conn`)
+    const cluster_id_col::String  # column of unique cluster ids
     init_coral_cover::YAXArray  # initial coral cover dataset
     const coral_growth::CoralGrowth  # coral
-    const site_ids::Vector{String}  # Site IDs that are represented (i.e., subset of site_data[:, site_id_col], after missing sites are filtered)
-    const removed_sites::Vector{String}  # indices of sites that were removed. Used to align site_data, DHW, connectivity, etc.
+    const site_ids::Vector{String}  # Location IDs that are represented (i.e., subset of site_data[:, location_id_col], after missing locations are filtered)
+    const removed_sites::Vector{String}  # indices of locations that were removed. Used to align site_data, DHW, connectivity, etc.
     dhw_scens::YAXArray  # DHW scenarios
     wave_scens::YAXArray  # wave scenarios
     cyclone_mortality_scens::Union{Matrix{<:Real},YAXArray}  # Cyclone mortality scenarios
@@ -42,13 +42,13 @@ function Domain(
     rcp::String,
     env_layers::EnvLayer,
     TP_base::YAXArray{T},
-    site_data::DataFrame,
-    site_id_col::String,
+    location_data::DataFrame,
+    location_id_col::String,
     cluster_id_col::String,
     init_coral_cover::YAXArray,
     coral_growth::CoralGrowth,
-    site_ids::Vector{String},
-    removed_sites::Vector{String},
+    location_ids::Vector{String},
+    removed_locations::Vector{String},
     DHW::YAXArray,
     wave::YAXArray,
     cyclone_mortality::YAXArray
@@ -72,13 +72,13 @@ function Domain(
         env_layers,
         "",
         TP_base,
-        site_data,
-        site_id_col,
+        location_data,
+        location_id_col,
         cluster_id_col,
         init_coral_cover,
         coral_growth,
-        site_ids,
-        removed_sites,
+        location_ids,
+        removed_locations,
         DHW,
         wave,
         cyclone_mortality,
@@ -88,7 +88,7 @@ function Domain(
 end
 
 """
-    Domain(name::String, rcp::String, timeframe::Vector, site_data_fn::String, site_id_col::String, cluster_id_col::String, init_coral_fn::String, conn_path::String, dhw_fn::String, wave_fn::String, cyclone_mortality_fn::String)::Domain
+    Domain(name::String, rcp::String, timeframe::Vector, location_data_fn::String, location_id_col::String, cluster_id_col::String, init_coral_fn::String, conn_path::String, dhw_fn::String, wave_fn::String, cyclone_mortality_fn::String)::Domain
 
 Convenience constructor for Domain.
 
@@ -97,9 +97,9 @@ Convenience constructor for Domain.
 - `dpkg_path` : location of data package
 - `rcp` : RCP scenario represented
 - `timeframe` : Time steps represented
-- `site_data_fn` : File name of spatial data used
-- `site_id_col` : Column holding name of reef the site is associated with (non-unique)
-- `cluster_id_col` : Column holding unique site names/ids
+- `location_data_fn` : File name of spatial data used
+- `location_id_col` : Column holding name of reef the location is associated with (non-unique)
+- `cluster_id_col` : Column holding unique cluster names/ids
 - `init_coral_fn` : Name of file holding initial coral cover values
 - `conn_path` : Path to directory holding connectivity data
 - `dhw_fn` : Filename of DHW data cube in use
@@ -111,8 +111,8 @@ function Domain(
     dpkg_path::String,
     rcp::String,
     timeframe::Vector,
-    site_data_fn::String,
-    site_id_col::String,
+    location_data_fn::String,
+    location_id_col::String,
     cluster_id_col::String,
     init_coral_fn::String,
     conn_path::String,
@@ -120,29 +120,32 @@ function Domain(
     wave_fn::String,
     cyclone_mortality_fn::String
 )::ADRIADomain
-    local site_data::DataFrame
+    local location_data::DataFrame
     try
-        site_data = GDF.read(site_data_fn)
+        location_data = GDF.read(location_data_fn)
     catch err
-        if !isfile(site_data_fn)
-            error("Provided site data path is not valid or missing: $(site_data_fn).")
+        if !isfile(location_data_fn)
+            error(
+                "Provided location data path is not valid or missing: $(location_data_fn)."
+            )
         else
             rethrow(err)
         end
     end
 
-    if cluster_id_col ∉ names(site_data)
+    if cluster_id_col ∉ names(location_data)
         @warn "Cluster ID column $(cluster_id_col) not found. Defaulting to UNIQUE_ID."
         cluster_id_col = "UNIQUE_ID"
     end
-    if typeof(site_data[:, cluster_id_col][1]) != String
-        site_data[!, cluster_id_col] .= string.(Int64.(site_data[:, cluster_id_col]))
+    if typeof(location_data[:, cluster_id_col][1]) != String
+        location_data[!, cluster_id_col] .=
+            string.(Int64.(location_data[:, cluster_id_col]))
     end
 
     env_layer_md::EnvLayer = EnvLayer(
         dpkg_path,
-        site_data_fn,
-        site_id_col,
+        location_data_fn,
+        location_id_col,
         cluster_id_col,
         init_coral_fn,
         conn_path,
@@ -152,23 +155,27 @@ function Domain(
     )
 
     # Sort data to maintain consistent order
-    sort!(site_data, Symbol[Symbol(site_id_col)])
-    u_sids::Vector{String} = string.(collect(site_data[!, site_id_col]))
-    # If site id column is missing then derive it from the Unique IDs
-    if !in(site_id_col, names(site_data))
-        site_data[!, site_id_col] .= String[d[2] for d in split.(u_sids, "_"; limit=2)]
+    sort!(location_data, Symbol[Symbol(location_id_col)])
+    u_sids::Vector{String} = string.(collect(location_data[!, location_id_col]))
+    # If location id column is missing then derive it from the Unique IDs
+    if !in(location_id_col, names(location_data))
+        location_data[!, location_id_col] .= String[
+            d[2] for d in split.(u_sids, "_"; limit=2)
+        ]
     end
 
-    site_data.row_id = 1:nrow(site_data)
+    location_data.row_id = 1:nrow(location_data)
 
     conn_ids::Vector{String} = u_sids
     connectivity::NamedTuple = site_connectivity(conn_path, u_sids)
 
     # Filter out missing entries
-    site_data = site_data[coalesce.(in.(conn_ids, [connectivity.site_ids]), false), :]
-    site_data.k .= site_data.k / 100.0  # Make `k` non-dimensional (provided as a percent)
+    location_data = location_data[
+        coalesce.(in.(conn_ids, [connectivity.site_ids]), false), :
+    ]
+    location_data.k .= location_data.k / 100.0  # Make `k` non-dimensional (provided as a percent)
 
-    n_locs::Int64 = nrow(site_data)
+    n_locs::Int64 = nrow(location_data)
     n_groups::Int64, n_sizes::Int64 = size(linear_extensions())
     coral_growth::CoralGrowth = CoralGrowth(n_locs, n_groups, n_sizes)
     n_group_and_size = coral_growth.n_group_and_size
@@ -184,7 +191,7 @@ function Domain(
     waves = load_env_data(waves_params...)
 
     cyc_params =
-        ispath(cyclone_mortality_fn) ? (cyclone_mortality_fn,) : (timeframe, site_data)
+        ispath(cyclone_mortality_fn) ? (cyclone_mortality_fn,) : (timeframe, location_data)
     cyclone_mortality = load_cyclone_mortality(cyc_params...)
 
     # Add compatability with non-migrated datasets but always default current coral spec
@@ -207,8 +214,8 @@ function Domain(
         rcp,
         env_layer_md,
         connectivity.conn,
-        site_data,
-        site_id_col,
+        location_data,
+        location_id_col,
         cluster_id_col,
         init_coral_cover,
         coral_growth,
@@ -255,7 +262,7 @@ function load_domain(::Type{ADRIADomain}, path::String, rcp::String)::ADRIADomai
         timeframe = parse.(Int64, md_timeframe)
     end
 
-    site_id_col::String = "reef_siteid"
+    location_id_col::String = "reef_siteid"
     cluster_id_col::String = "cluster_id"
 
     conn_path::String = joinpath(path, "connectivity/")
@@ -274,7 +281,7 @@ function load_domain(::Type{ADRIADomain}, path::String, rcp::String)::ADRIADomai
         rcp,
         timeframe,
         gpkg_path,
-        site_id_col,
+        location_id_col,
         cluster_id_col,
         init_coral_cov,
         conn_path,
@@ -321,8 +328,8 @@ function Base.show(io::IO, mime::MIME"text/plain", d::ADRIADomain)::Nothing
     println("""
         Domain: $(d.name)
 
-        Number of sites: $(n_locations(d))
-        Site data file: $(d.env_layer_md.site_data_fn)
+        Number of locations: $(n_locations(d))
+        Location data file: $(d.env_layer_md.site_data_fn)
         Connectivity file: $(d.env_layer_md.connectivity_fn)
         DHW file: $(d.env_layer_md.DHW_fn)
         Wave file: $(d.env_layer_md.wave_fn)

--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -21,12 +21,12 @@ mutable struct RMEDomain <: AbstractReefModDomain
     env_layer_md::ADRIA.EnvLayer
     scenario_invoke_time::String  # time latest set of scenarios were run
     const conn::YAXArray{Float64}
-    const site_data::DataFrames.DataFrame
-    const site_id_col::String
+    const loc_data::DataFrames.DataFrame
+    const loc_id_col::String
     const cluster_id_col::String
     init_coral_cover::YAXArray{Float64}
     const coral_growth::CoralGrowth
-    const site_ids::Vector{String}
+    const loc_ids::Vector{String}
     dhw_scens::YAXArray{Float64}
 
     # `wave_scens` holds empty wave data to maintain compatibility with
@@ -427,7 +427,7 @@ function load_cyclones(
 end
 
 """
-    load_initial_cover(::Type{RMEDomain}, data_path::String, loc_ids::Vector{String}, site_data::DataFrame)::YAXArray
+    load_initial_cover(::Type{RMEDomain}, data_path::String, loc_ids::Vector{String}, loc_data::DataFrame)::YAXArray
 
 # Arguments
 - `RMEDomain`
@@ -438,7 +438,7 @@ end
 YAXArray[locs, species]
 """
 function load_initial_cover(
-    ::Type{RMEDomain}, data_path::String, loc_ids::Vector{String}, site_data::DataFrame
+    ::Type{RMEDomain}, data_path::String, loc_ids::Vector{String}, loc_data::DataFrame
 )::YAXArray
     icc_path = joinpath(data_path, "initial")
     icc_files = _get_relevant_files(icc_path, "coral_")
@@ -488,7 +488,7 @@ function load_initial_cover(
     )
 
     # Convert values relative to absolute area to values relative to k area
-    icc_data = _convert_abs_to_k(icc_data, site_data)
+    icc_data = _convert_abs_to_k(icc_data, loc_data)
 
     return DataCube(
         icc_data;

--- a/src/ExtInterface/ReefMod/ReefModDomain.jl
+++ b/src/ExtInterface/ReefMod/ReefModDomain.jl
@@ -18,12 +18,12 @@ mutable struct ReefModDomain <: AbstractReefModDomain
     env_layer_md
     scenario_invoke_time::String  # time latest set of scenarios were run
     const conn
-    const site_data
-    const site_id_col
+    const loc_data
+    const loc_id_col
     const cluster_id_col
     init_coral_cover
     const coral_growth::CoralGrowth
-    const site_ids
+    const loc_ids
     dhw_scens
 
     # `wave_scens` holds empty wave data to maintain compatibility with
@@ -273,7 +273,7 @@ function switch_RCPs!(d::ReefModDomain, RCP::String)::ReefModDomain
 )[timestep=At(d.env_layer_md.timeframe)].data[:, :, :]
 
     scens = 1:size(dhws)[3]
-    loc_ids = d.site_ids
+    loc_ids = d.loc_ids
 
     d.dhw_scens = DataCube(
         dhws;

--- a/src/analysis/intervention.jl
+++ b/src/analysis/intervention.jl
@@ -43,7 +43,7 @@ function intervention_frequency(
     rcps = collect(Symbol.(keys(scen_indices)))
     n_locs = n_locations(rs)
 
-    interv_freq = ZeroDataCube(; T=Float64, locations=rs.site_ids, rcps=rcps)
+    interv_freq = ZeroDataCube(; T=Float64, locations=rs.loc_ids, rcps=rcps)
     for rcp in rcps
         # Select scenarios satisfying condition and tally selection for each location
         logged_data = dropdims(

--- a/src/decision/Criteria/SeedCriteria.jl
+++ b/src/decision/Criteria/SeedCriteria.jl
@@ -150,9 +150,9 @@ dom = ADRIA.load_domain("... path to domain ...")
 seed_pref = ADRIA.SeedPreferences(dom)
 
 location_names = cluster_ids
-cluster_ids = dom.site_data.cluster_id
+cluster_ids = dom.loc_data.cluster_id
 dm = ADRIA.decision_matrix(location_names, seed_pref.names, rand(3806, 6))
-available_space = dom.site_data.k .* dom.site_data.area
+available_space = dom.loc_data.k .* dom.loc_data.area
 mcda_method = ADRIA.mcda_methods()[1]
 min_locs = 5
 max_members = 2

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -3,15 +3,14 @@ module decision
 using InteractiveUtils: subtypes
 using StatsBase
 using YAXArrays
-using ADRIA: DataCube, Domain, EcoModel, n_locations, site_area, site_k_area
-
 using ADRIA:
+    component_params,
+    DataCube,
     Domain,
     EcoModel,
     n_locations,
-    site_area,
-    site_k_area,
-    component_params
+    loc_area,
+    site_k_area
 
 using ADRIA:
     DiscreteOrderedUniformDist,
@@ -71,8 +70,8 @@ Align a vector of site rankings to match the indicated order in `s_order`.
 """
 function align_rankings!(rankings::Array, s_order::Matrix, col::Int64)::Nothing
     # Fill target ranking column
-    for (i, site_id) in enumerate(s_order[:, 1])
-        rankings[rankings[:, 1] .== site_id, col] .= i
+    for (i, loc_id) in enumerate(s_order[:, 1])
+        rankings[rankings[:, 1] .== loc_id, col] .= i
     end
 
     return nothing

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -1,5 +1,5 @@
 """
-site_connectivity(file_loc::String, unique_site_ids::Vector{String};
+location_connectivity(file_loc::String, unique_loc_ids::Vector{String};
                   con_cutoff::Float64=1e-6, agg_func::Function=mean, swap::Bool=false)::NamedTuple
 
 Create transitional probability matrix indicating connectivity between
@@ -11,8 +11,8 @@ NOTE: Transposes transitional probability matrix if `swap == true`
 
 # Examples
 ```julia
-    site_connectivity("MooreTPmean.csv", site_order)
-    site_connectivity("MooreTPmean.csv", site_order; con_cutoff=0.02, agg_func=mean, swap=true)
+    location_connectivity("MooreTPmean.csv", site_order)
+    location_connectivity("MooreTPmean.csv", site_order; con_cutoff=0.02, agg_func=mean, swap=true)
 ```
 
 # Arguments
@@ -29,9 +29,9 @@ NamedTuple:
 - `conn` : Matrix, containing the connectivity for all locations.
            Accounts for larvae which do not settle, so rows are not required to sum to 1
 - `truncated` : ID of locations removed
-- `site_ids` : ID of locations kept
+- `loc_ids` : ID of locations kept
 """
-function site_connectivity(
+function location_connectivity(
     file_path::String,
     loc_ids::Vector{String};
     conn_cutoff::Float64=1e-6,
@@ -134,27 +134,27 @@ function site_connectivity(
 
     @assert all(0.0 .<= conn .<= 1.0) "Connectivity data not scaled between 0 - 1"
 
-    return (conn=conn, truncated=invalid_ids, site_ids=loc_ids)
+    return (conn=conn, truncated=invalid_ids, loc_ids=loc_ids)
 end
-function site_connectivity(
+function location_connectivity(
     file_loc::String,
-    unique_site_ids::Vector{Union{Missing,String}};
+    unique_loc_ids::Vector{Union{Missing,String}};
     con_cutoff::Float64=1e-6,
     agg_func::Function=mean,
     swap::Bool=false
 )::NamedTuple
 
     # Remove any row marked as missing
-    if any(ismissing.(unique_site_ids))
+    if any(ismissing.(unique_loc_ids))
         @warn "Removing entries marked as `missing` from provided list of sites."
-        unique_site_ids::Vector{String} =
-            String.(unique_site_ids[.!ismissing.(unique_site_ids)])
+        unique_loc_ids::Vector{String} =
+            String.(unique_loc_ids[.!ismissing.(unique_loc_ids)])
     else
-        unique_site_ids = String.(unique_site_ids)
+        unique_loc_ids = String.(unique_loc_ids)
     end
 
-    return site_connectivity(
-        file_loc, unique_site_ids; con_cutoff=con_cutoff, agg_func=agg_func, swap=swap
+    return location_connectivity(
+        file_loc, unique_loc_ids; con_cutoff=con_cutoff, agg_func=agg_func, swap=swap
     )
 end
 

--- a/src/ecosystem/corals/CoralGrowth.jl
+++ b/src/ecosystem/corals/CoralGrowth.jl
@@ -13,7 +13,7 @@ struct CoralGrowth{A<:Integer,T<:NamedTuple}
 end
 
 """
-    CoralGrowth(n_sites)
+    CoralGrowth(n_locs)
 
 Implements temporary hardcoded caches for a scenario with 35 'species' (split into 5 groups).
 """

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -116,8 +116,8 @@ of the bin. See `coral_spec()` for further detail.
 Note that recruitment pertains to coral groups (\$n = 6\$) and represents
 the contribution to the cover of the smallest size class within each
 group.  While growth and mortality metrics pertain to groups (6) as well
-as size classes (6) across all sites (total of 36 by \$n_sites\$), recruitment is
-a 6 by \$n_sites\$ array.
+as size classes (6) across all sites (total of 36 by \$n_locs\$), recruitment is
+a 6 by \$n_locs\$ array.
 """
 function growthODE(du::Matrix{Float64}, X::Matrix{Float64}, p::NamedTuple, t::Real)::Nothing
     # Indices
@@ -726,7 +726,7 @@ end
 
     fecundity_scope!(fec_groups::AbstractMatrix{T}, fec_all::AbstractArray{T, 3},
                      fec_params::AbstractMatrix{T}, C_cover_t::AbstractArray{T, 3},
-                     site_area::AbstractMatrix{T})::Nothing where {T<:Float64}
+                     loc_area::AbstractMatrix{T})::Nothing where {T<:Float64}
 
 The scope that different coral groups and size classes have for
 producing larvae without consideration of environment.
@@ -738,24 +738,24 @@ Total relative fecundity of a group is then calculated as the sum of
 fecundities across size classes.
 
 # Arguments
-- `fec_groups` : Matrix[n_classes, n_sites], memory cache to place results into
-- `fec_all` : Matrix[n_taxa, n_sites], temporary cache to place intermediate fecundity values into
+- `fec_groups` : Matrix[n_classes, n_locs], memory cache to place results into
+- `fec_all` : Matrix[n_taxa, n_locs], temporary cache to place intermediate fecundity values into
 - `fec_params` : Vector, coral fecundity parameters (in per m²) for each species/size class
-- `C_cover_t` : Matrix[n_taxa, n_sites], of coral cover values for the previous time step
-- `site_area` : Vector[n_sites], total site area in m²
+- `C_cover_t` : Matrix[n_taxa, n_locs], of coral cover values for the previous time step
+- `loc_area` : Vector[n_locs], total site area in m²
 """
 function fecundity_scope!(
     fec_groups::AbstractMatrix{T},
     fec_all::AbstractMatrix{T},
     fec_params::AbstractVector{T},
     C_cover_t::AbstractMatrix{T},
-    site_area::AbstractMatrix{T}
+    loc_area::AbstractMatrix{T}
 )::Nothing where {T<:Float64}
     n_groups::Int64 = size(fec_groups, 1)   # number of coral groups: 5
     n_group_and_size::Int64 = size(fec_params, 1)  # number of coral size classes: 35
     n_classes::Int64 = Int64(n_group_and_size / n_groups)
 
-    fec_all .= fec_params .* C_cover_t .* site_area
+    fec_all .= fec_params .* C_cover_t .* loc_area
     for (i, (s, e)) in enumerate(
         zip(1:n_classes:n_group_and_size, n_classes:n_classes:(n_group_and_size + 1))
     )
@@ -769,11 +769,11 @@ function fecundity_scope!(
     fec_all::AbstractArray{T,3},
     fec_params::AbstractMatrix{T},
     C_cover_t::AbstractArray{T,3},
-    site_area::AbstractMatrix{T}
+    loc_area::AbstractMatrix{T}
 )::Nothing where {T<:Float64}
 
     # Dimensions of fec all are [groups ⋅ sizes ⋅ locations]
-    fec_all .= fec_params .* C_cover_t .* reshape(site_area, (1, size(site_area)...))
+    fec_all .= fec_params .* C_cover_t .* reshape(loc_area, (1, size(loc_area)...))
     # Sum over size classes
     @views fec_groups[:, :] .= dropdims(sum(fec_all; dims=2); dims=2)
 

--- a/src/ecosystem/corals/growth_expanded.jl
+++ b/src/ecosystem/corals/growth_expanded.jl
@@ -13,7 +13,7 @@ t : time, unused, so marking with `_`
 function growthODE_expanded(
     du::Array{Float64,2}, X::Array{Float64,2}, p::NamedTuple, _::Real
 )::Nothing
-    # `s` refers to sigma holding leftover space for each site in form of: 1 x n_sites
+    # `s` refers to sigma holding leftover space for each site in form of: 1 x n_locs
     s = p.sigma[:, :]
 
     s .= max.(p.k' .- sum(X; dims=1), 0.0)  # Make relative to k (max. carrying capacity)
@@ -31,7 +31,7 @@ function growthODE_expanded(
     du[5, :] .= (s .* X[4, :] .* r[4]) .- (s .* X[5, :] .* r[5]) .- X_mb[5, :]
     du[6, :] .= (s .* X[5, :] .* r[5]) .+ (s .* X[6, :] .* r[6]) .- X_mb[6, :]
 
-    # Tabular Acropora 
+    # Tabular Acropora
     du[7, :] .= rec[2, :] .- (s .* X[7, :] .* r[7]) .- X_mb[2, :]
     du[8, :] .= (s .* X[7, :] .* r[7]) .- (s .* X[8, :] .* r[8]) .- X_mb[8, :]
     du[9, :] .= (s .* X[8, :] .* r[8]) .- (s .* X[9, :] .* r[9]) .- X_mb[9, :]
@@ -39,7 +39,7 @@ function growthODE_expanded(
     du[11, :] .= (s .* X[10, :] .* r[10]) .- (s .* X[11, :] .* r[11]) .- X_mb[11, :]
     du[12, :] .= (s .* X[11, :] .* r[11]) .+ (s .* X[11, :] * r[11]) .- X_mb[12, :]
 
-    # Corymbose Acropora 
+    # Corymbose Acropora
     du[13, :] .= rec[3, :] .- s .* X[13, :] .* r[13] .- X_mb[13, :]
     du[14, :] .= (s .* X[13, :] .* r[13]) .- (s .* X[14, :] .* r[14]) .- X_mb[14, :]
     du[15, :] .= (s .* X[14, :] .* r[14]) .- (s .* X[15, :] .* r[15]) .- X_mb[15, :]
@@ -63,7 +63,7 @@ function growthODE_expanded(
     du[29, :] .= (s .* X[28, :] .* r[28]) .- (s .* X[29, :] .* r[29]) .- X_mb[29, :]
     du[30, :] .= (s .* X[29, :] .* r[29]) .+ (s .* X[30, :] .* r[30]) .- X_mb[30, :]
 
-    # Large massives 
+    # Large massives
     du[31, :] .= rec[6, :] .- s .* X[31, :] .* r[31] .- X_mb[6, :]
     du[32, :] .= (s .* X[31, :] .* r[31]) .- (s .* X[32, :] .* r[32]) .- X_mb[32, :]
     du[33, :] .= (s .* X[32, :] .* r[32]) .- (s .* X[33, :] .* r[33]) .- X_mb[33, :]

--- a/src/io/initial_coral_cover.jl
+++ b/src/io/initial_coral_cover.jl
@@ -4,7 +4,7 @@ using Distributions,
 
 """
     load_initial_cover(data_fn::String)::YAXArray
-    load_initial_cover(n_species::Int64, n_sites::Int64)::YAXArray
+    load_initial_cover(n_species::Int64, n_locs::Int64)::YAXArray
 
 Load initial coral cover data from netCDF.
 """
@@ -14,10 +14,10 @@ function load_initial_cover(data_fn::String)::YAXArray
         load_nc_data(data_fn, "covers"; dim_names_replace=_dim_names_replace)
     )
 end
-function load_initial_cover(n_group_and_size::Int64, n_sites::Int64)::YAXArray
+function load_initial_cover(n_group_and_size::Int64, n_locs::Int64)::YAXArray
     @warn "Using random initial coral cover"
-    random_cover_data = rand(Float32, n_group_and_size, n_sites)
-    return DataCube(random_cover_data; species=1:n_group_and_size, sites=1:n_sites)
+    random_cover_data = rand(Float32, n_group_and_size, n_locs)
+    return DataCube(random_cover_data; species=1:n_group_and_size, sites=1:n_locs)
 end
 
 """

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -103,7 +103,7 @@ function store_conn(
 end
 
 """
-    scenario_attributes(name, RCP, input_cols, invoke_time, env_layer, sim_constants, unique_sites, area, k)
+    scenario_attributes(name, RCP, input_cols, invoke_time, env_layer, sim_constants, unique_loc_ids, area, k, centroids)
     scenario_attributes(domain::Domain, param_df::DataFrame)
 
 Generate dictionary of scenario attributes.
@@ -115,11 +115,11 @@ function scenario_attributes(
     invoke_time,
     env_layer,
     sim_constants,
-    unique_sites,
+    unique_loc_ids,
     area,
     k,
     centroids
-)::Dict
+)::Dict{Symbol,Any}
     attrs::Dict{Symbol,Any} = Dict(
         :name => name,
         :RCP => RCP,
@@ -135,7 +135,7 @@ function scenario_attributes(
         :wave_file => env_layer.wave_fn,
         :timeframe => env_layer.timeframe,
         :sim_constants => sim_constants,
-        :site_ids => unique_sites,
+        :site_ids => unique_loc_ids,
         :site_area => area,
         :site_max_coral_cover => k,
         :site_centroids => centroids
@@ -143,43 +143,53 @@ function scenario_attributes(
 
     return attrs
 end
-function scenario_attributes(domain::Domain, param_df::DataFrame)
-    return scenario_attributes(domain.name, domain.RCP, names(param_df),
+function scenario_attributes(domain::Domain, param_df::DataFrame)::Dict{Symbol,Any}
+    return scenario_attributes(
+        domain.name,
+        domain.RCP,
+        names(param_df),
         domain.scenario_invoke_time,
-        domain.env_layer_md, domain.sim_constants,
-        unique_sites(domain), site_area(domain), domain.site_data.k,
-        centroids(domain.site_data))
+        domain.env_layer_md,
+        domain.sim_constants,
+        unique_loc_ids(domain),
+        site_area(domain),
+        domain.site_data.k,
+        centroids(domain.site_data)
+    )
 end
 
 """
-    setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_size)
+    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_group_and_size)
 
+Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
+
+# Arguments
 - `z_store` : ZArray
-- `unique_sites` : Unique site ids
+- `unique_loc_ids` : Unique location ids
 - `n_scens` : number of scenarios
 - `tf` : timeframe
-- `n_sites` : number of sites
+- `n_locs` : number of location
 - `n_group_and_size` : number of function groups ⋅ number of size classes
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_size)
-    # Set up logs for site ranks, seed/fog log
+function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_group_and_size)
+    # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
 
-    # Store ranked sites
+    # Store ranked location
     n_interventions = length(interventions())
-    rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_sites, n_interventions, n_scens)  # sites, site id and rank, no. scenarios
-    fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_sites, n_scens)  # timeframe, sites, no. scenarios
+    rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, n_interventions, n_scens)  # locations, location id and rank, no. scenarios
+    fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_locs, n_scens)  # timeframe, location, no. scenarios
 
-    # tf, no. species to seed, site id and rank, no. scenarios
-    seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, 3, n_sites, n_scens)
+    # tf, no. species to seed, location id and rank, no. scenarios
+    seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, 3, n_locs, n_scens)
 
     attrs = Dict(
         # Here, "intervention" refers to seeding or shading
-        :structure => ("timesteps", "sites", "intervention", "scenarios"),
-        :unique_site_ids => unique_sites
+        :structure => ("timesteps", "locations", "intervention", "scenarios"),
+        :unique_site_ids => unique_loc_ids
     )
     ranks = zcreate(
         Float32,
@@ -193,8 +203,8 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_siz
     )
 
     attrs = Dict(
-        :structure => ("timesteps", "coral_id", "sites", "scenarios"),
-        :unique_site_ids => unique_sites
+        :structure => ("timesteps", "coral_id", "locations", "scenarios"),
+        :unique_site_ids => unique_loc_ids
     )
     seed_log = zcreate(
         Float32,
@@ -208,8 +218,8 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_siz
     )
 
     attrs = Dict(
-        :structure => ("timesteps", "sites", "scenarios"),
-        :unique_site_ids => unique_sites
+        :structure => ("timesteps", "locations", "scenarios"),
+        :unique_site_ids => unique_loc_ids
     )
     fog_log = zcreate(
         Float32,
@@ -234,15 +244,15 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_siz
 
     # TODO: Could log bleaching mortality
     # attrs = Dict(
-    #     :structure => ("timesteps", "sites", "scenarios"),
-    #     :unique_site_ids => unique_sites,
+    #     :structure => ("timesteps", "locations", "scenarios"),
+    #     :unique_site_ids => unique_loc_ids,
     # )
     # bleach_log = zcreate(Float32, fog_dims...; name="bleaching_mortality", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(fog_dims[1:2]..., 1), attrs=attrs)
 
     # Log for coral DHW thresholds
     attrs = Dict(
-        :structure => ("timesteps", "species", "sites", "scenarios"),
-        :unique_site_ids => unique_sites
+        :structure => ("timesteps", "species", "locations", "scenarios"),
+        :unique_site_ids => unique_loc_ids
     )
 
     local coral_dhw_log
@@ -251,13 +261,13 @@ function setup_logs(z_store, unique_sites, n_scens, tf, n_sites, n_group_and_siz
             Float32,
             tf,
             n_group_and_size,
-            n_sites,
+            n_locs,
             n_scens;
             name="coral_dhw_log",
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, n_sites, 1),
+            chunks=(tf, n_group_and_size, n_locs, 1),
             attrs=attrs
         )
     else
@@ -369,7 +379,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     # Store table of factor values
     inputs[:, :] = Matrix(scen_spec)
 
-    tf, n_sites, _ = size(domain.dhw_scens)
+    tf, n_locations, _ = size(domain.dhw_scens)
+    n_scenarios = nrow(scen_spec)
 
     # Set up stores for each metric
     function dim_lengths(metric_structure)
@@ -379,49 +390,62 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
                 append!(dl, tf)
             elseif d == "species"
                 append!(dl, domain.coral_growth.n_group_and_size)
-            elseif d == "sites"
-                append!(dl, n_sites)
+            elseif d == "locations"
+                append!(dl, n_locations)
             elseif d == "scenarios"
-                append!(dl, nrow(scen_spec))
+                append!(dl, n_scenarios)
             end
         end
 
         return (dl...,)
     end
 
-    met_names = [:relative_cover, :relative_shelter_volume,
-        :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness
+    met_names = [
+        :relative_cover,
+        :relative_shelter_volume,
+        :absolute_shelter_volume,
+        :relative_juveniles,
+        :juvenile_indicator,
+        :coral_evenness
     ]
 
+    _unique_loc_ids = unique_loc_ids(domain)
+
     dim_struct = Dict(
-        :structure => string.((:timesteps, :sites, :scenarios)),
-        :unique_site_ids => unique_sites(domain)
+        :structure => string.((:timesteps, :locations, :scenarios)),
+        :unique_site_ids => _unique_loc_ids
     )
     result_dims::Tuple{Int64,Int64,Int64} = dim_lengths(dim_struct[:structure])
 
     # Create stores for each metric
     stores = [
-        zcreate(Float32, result_dims...;
-            fill_value=nothing, fill_as_missing=false,
+        zcreate(
+            Float32,
+            result_dims...;
+            fill_value=nothing,
+            fill_as_missing=false,
             path=joinpath(z_store.folder, RESULTS, string(m_name)),
             chunks=(result_dims[1:(end - 1)]..., 1),
             attrs=dim_struct,
-            compressor=COMPRESSOR)
-        for m_name in met_names
+            compressor=COMPRESSOR
+        ) for m_name in met_names
     ]
 
     # Handle special case for relative taxa cover
     n_groups::Int64 = domain.coral_growth.n_groups
     push!(
         stores,
-        zcreate(Float32, (result_dims[1], n_groups, result_dims[3])...;
-            fill_value=nothing, fill_as_missing=false,
+        zcreate(
+            Float32,
+            (result_dims[1], n_groups, result_dims[3])...;
+            fill_value=nothing,
+            fill_as_missing=false,
             path=joinpath(z_store.folder, RESULTS, "relative_taxa_cover"),
             chunks=((result_dims[1], n_groups)..., 1),
-            attrs=Dict(
-                :structure => string.(ADRIA.metrics.relative_taxa_cover.dims)
-            ),
-            compressor=COMPRESSOR))
+            attrs=Dict(:structure => string.(ADRIA.metrics.relative_taxa_cover.dims)),
+            compressor=COMPRESSOR
+        )
+    )
     push!(met_names, :relative_taxa_cover)
 
     # dhw and wave zarrays
@@ -476,7 +500,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         wave_stats...,
         connectivity...,
         setup_logs(
-            z_store, unique_sites(domain), nrow(scen_spec), tf, n_sites, n_group_and_size
+            z_store, _unique_loc_ids, nrow(scen_spec), tf, n_locations, n_group_and_size
         )...
     ]
 
@@ -644,7 +668,7 @@ function load_results(result_loc::String)::ResultSet
             for (i, s) in enumerate(res.attrs["structure"])
                 if s == "timesteps"
                     push!(st, input_set.attrs["timeframe"])
-                elseif s == "sites"
+                elseif s == "locations"
                     push!(st, res.attrs["unique_site_ids"])
                 else
                     push!(st, 1:sz[i])

--- a/src/io/rme_result_io.jl
+++ b/src/io/rme_result_io.jl
@@ -9,13 +9,13 @@ struct RMEResultSet{T1,T2,D,G,D1} <: ResultSet
     name::String
     RCP::String
 
-    site_ids::T1
-    site_area::Vector{Float64}
-    site_max_coral_cover::Vector{Float64}
-    site_centroids::T2
+    loc_ids::T1
+    loc_area::Vector{Float64}
+    loc_max_coral_cover::Vector{Float64}
+    loc_centroids::T2
     env_layer_md::EnvLayer
     connectivity_data::D
-    site_data::G
+    loc_data::G
     scenario_groups
     inputs::DataFrame
 
@@ -63,7 +63,7 @@ function load_results(
 
     reef_id_col = "UNIQUE_ID"
     cluster_id_col = "UNIQUE_ID"
-    site_ids = geodata[:, reef_id_col]
+    loc_ids = geodata[:, reef_id_col]
 
     # Load accompanying ID list
     id_list_fn = _find_file(joinpath(data_dir, "id"), Regex("id_list.*.csv"))
@@ -83,7 +83,7 @@ function load_results(
     geodata[:, :k] = 1 .- id_list[:, 3]
 
     # Connectivity is loaded using the same method as the Domain
-    connectivity = load_connectivity(RMEDomain, data_dir, site_ids)
+    connectivity = load_connectivity(RMEDomain, data_dir, loc_ids)
 
     location_max_coral_cover = 1 .- geodata.k ./ 100
     location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
@@ -132,7 +132,7 @@ function load_results(
     return RMEResultSet(
         name,
         netcdf_rcp,
-        site_ids,
+        loc_ids,
         geodata.area,
         location_max_coral_cover,
         location_centroids,

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -32,7 +32,7 @@ Metric(f, d) = Metric(f, d, "")
 Makes Metric types callable with arbitary arguments that are passed to associated function.
 """
 function (f::Metric)(raw, args...; kwargs...)::YAXArray
-    data = DataCube(raw, (:timesteps, :species, :sites, :scenarios)[1:ndims(raw)])
+    data = DataCube(raw, (:timesteps, :species, :locations, :scenarios)[1:ndims(raw)])
     return f.func(data, args...; kwargs...)
 end
 function (f::Metric)(rs::ResultSet, args...; kwargs...)::YAXArray
@@ -58,7 +58,7 @@ end
 function _relative_cover(rs::ResultSet)::AbstractArray{<:Real}
     return rs.outcomes[:relative_cover]
 end
-relative_cover = Metric(_relative_cover, (:timesteps, :sites, :scenarios))
+relative_cover = Metric(_relative_cover, (:timesteps, :locations, :scenarios))
 
 """
     total_absolute_cover(X::AbstractArray{<:Real}, k_area::Vector{<:Real})::AbstractArray{<:Real}
@@ -83,7 +83,9 @@ end
 function _total_absolute_cover(rs::ResultSet)::AbstractArray{<:Real}
     return _total_absolute_cover(rs.outcomes[:relative_cover], site_k_area(rs))
 end
-total_absolute_cover = Metric(_total_absolute_cover, (:timesteps, :sites, :scenarios), "m²")
+total_absolute_cover = Metric(
+    _total_absolute_cover, (:timesteps, :locations, :scenarios), "m²"
+)
 
 """
     relative_taxa_cover(X::AbstractArray{T}, k_area::Vector{T}, n_groups::Int64) where {T<:Real}
@@ -149,7 +151,7 @@ function _relative_loc_taxa_cover(
     n_sc::Int64 = Int64(n_group_and_size / n_groups)
 
     taxa_cover::YAXArray = ZeroDataCube(
-        (:timesteps, :taxa, :sites), (n_steps, n_groups, n_locs)
+        (:timesteps, :taxa, :locations), (n_steps, n_groups, n_locs)
     )
     k_cover = zeros(n_steps, n_sc)
     for (taxa_id, grp) in enumerate([i:(i + (n_sc - 1)) for i in 1:n_sc:n_group_and_size])
@@ -168,7 +170,7 @@ end
 # end
 
 relative_loc_taxa_cover = Metric(
-    _relative_loc_taxa_cover, (:timesteps, :taxa, :sites, :scenarios)
+    _relative_loc_taxa_cover, (:timesteps, :taxa, :locations, :scenarios)
 )
 
 """
@@ -189,7 +191,7 @@ end
 function _relative_juveniles(rs::ResultSet)::AbstractArray
     return rs.outcomes[:relative_juveniles]
 end
-relative_juveniles = Metric(_relative_juveniles, (:timesteps, :sites, :scenarios))
+relative_juveniles = Metric(_relative_juveniles, (:timesteps, :locations, :scenarios))
 
 """
     absolute_juveniles(X::AbstractArray{T}, coral_spec::DataFrame, area::AbstractVector{T})::AbstractArray{T} where {T<:Real}
@@ -205,7 +207,7 @@ end
 function _absolute_juveniles(rs::ResultSet)::AbstractArray
     return rs.outcomes[:relative_juveniles] .* site_k_area(rs)'
 end
-absolute_juveniles = Metric(_absolute_juveniles, (:timesteps, :sites, :scenarios), "m²")
+absolute_juveniles = Metric(_absolute_juveniles, (:timesteps, :locations, :scenarios), "m²")
 
 """
     _max_juvenile_area(coral_params::DataFrame, max_juv_density::Float64=51.8)
@@ -247,7 +249,7 @@ end
 function _juvenile_indicator(rs::ResultSet)::AbstractArray
     return rs.outcomes[:juvenile_indicator]
 end
-juvenile_indicator = Metric(_juvenile_indicator, (:timesteps, :sites, :scenarios))
+juvenile_indicator = Metric(_juvenile_indicator, (:timesteps, :locations, :scenarios))
 
 """
     coral_evenness(r_taxa_cover::AbstractArray{T})::AbstractArray{T} where {T<:Real}
@@ -268,8 +270,8 @@ function _coral_evenness(r_taxa_cover::AbstractArray{T})::AbstractArray{T} where
 
     # Sum across groups represents functional diversity
     # Group evenness (Hill 1973, Ecology 54:427-432)
+    simpsons_diversity::YAXArray = ZeroDataCube((:timesteps, :locations), (n_steps, n_locs))
     loc_cover = dropdims(sum(r_taxa_cover; dims=2); dims=2)
-    simpsons_diversity::YAXArray = ZeroDataCube((:timesteps, :sites), (n_steps, n_locs))
     for loc in axes(loc_cover, 2)
         simpsons_diversity[:, loc] =
             1.0 ./ sum((r_taxa_cover[:, :, loc] ./ loc_cover[:, loc]) .^ 2; dims=2)
@@ -280,7 +282,7 @@ end
 function _coral_evenness(rs::ResultSet)::AbstractArray
     return rs.outcomes[:coral_evenness]
 end
-coral_evenness = Metric(_coral_evenness, (:timesteps, :sites, :scenarios))
+coral_evenness = Metric(_coral_evenness, (:timesteps, :locations, :scenarios))
 
 """
     _colony_Lcm2_to_m3m2(inputs::DataFrame)::Tuple
@@ -361,7 +363,7 @@ function _shelter_species_loop(
     k_area::Array{F}
 )::YAXArray where {T1<:Real,F<:Float64}
     # Calculate absolute shelter volumes first
-    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :sites), size(X))
+    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :locations), size(X))
     _shelter_species_loop!(X, ASV, n_group_and_size, colony_vol_m3_per_m2, k_area)
 
     # Maximum shelter volume
@@ -377,7 +379,7 @@ function _shelter_species_loop(
     # Loop over each taxa group
 
     RSV::YAXArray = ZeroDataCube(
-        (:timesteps, :species, :sites), size(X[species=1:n_groups])
+        (:timesteps, :species, :locations), size(X[species=1:n_groups])
     )
     taxa_max_map = zip(
         [i:(i + n_sizes - 1) for i in 1:n_sizes:n_group_and_size], 1:n_groups
@@ -385,10 +387,11 @@ function _shelter_species_loop(
 
     # Work out RSV for each taxa
     for (sp, sq) in taxa_max_map
-        for site in 1:size(ASV, :sites)
-            RSV[species=At(sq), sites=At(site)] .=
+        for site in 1:size(ASV, :locations)
+            RSV[species=At(sq), locations=At(site)] .=
                 dropdims(
-                    sum(ASV[species=At(sp), sites=At(site)]; dims=:species); dims=:species
+                    sum(ASV[species=At(sp), locations=At(site)]; dims=:species);
+                    dims=:species
                 ) ./ MSV[sq, site]
         end
     end
@@ -480,7 +483,7 @@ function _absolute_shelter_volume(
     nspecies::Int64 = size(X, :species)
 
     # Calculate shelter volume of groups and size classes and multiply with area covered
-    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :sites), size(X))
+    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :locations), size(X))
     colony_vol, _ = _colony_Lcm2_to_m3m2(inputs)
     _shelter_species_loop!(X, ASV, nspecies, colony_vol, k_area)
 
@@ -496,7 +499,7 @@ function _absolute_shelter_volume(
 
     # Calculate shelter volume of groups and size classes and multiply with area covered
     nscens::Int64 = size(X, :scenarios)
-    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :sites, :scenarios), size(X))
+    ASV::YAXArray = ZeroDataCube((:timesteps, :species, :locations, :scenarios), size(X))
     for scen::Int64 in 1:nscens
         colony_vol, _ = _colony_Lcm2_to_m3m2(inputs[scen, :])
         _shelter_species_loop!(X[scenarios=scen], ASV, nspecies, colony_vol, k_area)
@@ -508,7 +511,9 @@ end
 function _absolute_shelter_volume(rs::ResultSet)::AbstractArray
     return rs.outcomes[:absolute_shelter_volume]
 end
-absolute_shelter_volume = Metric(_absolute_shelter_volume, (:timesteps, :sites, :scenarios))
+absolute_shelter_volume = Metric(
+    _absolute_shelter_volume, (:timesteps, :locations, :scenarios)
+)
 
 """
     relative_shelter_volume(X::AbstractArray{T,3}, k_area::Vector{T}, inputs::DataFrame)::AbstractArray{T} where {T<:Real}
@@ -620,7 +625,7 @@ function _relative_shelter_volume(
     # Result template - six entries, one for each taxa
     n_groups::Int64 = length(coral_spec().taxa_names)
     RSV::YAXArray = ZeroDataCube(
-        (:timesteps, :species, :sites, :scenarios), size(X[:, 1:n_groups, :, :])
+        (:timesteps, :species, :locations, :scenarios), size(X[:, 1:n_groups, :, :])
     )
     for scen::Int64 in 1:nscens
         colony_vol, max_colony_vol = _colony_Lcm2_to_m3m2(inputs[scen, :])
@@ -639,7 +644,9 @@ end
 function _relative_shelter_volume(rs::ResultSet)::YAXArray
     return rs.outcomes[:relative_shelter_volume]
 end
-relative_shelter_volume = Metric(_relative_shelter_volume, (:timesteps, :sites, :scenarios))
+relative_shelter_volume = Metric(
+    _relative_shelter_volume, (:timesteps, :locations, :scenarios)
+)
 
 include("pareto.jl")
 include("ranks.jl")

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -13,7 +13,7 @@ using ADRIA: DataCube, ZeroDataCube, axes_names, axis_labels, axis_index
 using FLoops
 using DataFrames
 
-using ADRIA: coral_spec, colony_mean_area, ResultSet, timesteps, site_k_area, site_area,
+using ADRIA: coral_spec, colony_mean_area, ResultSet, timesteps, site_k_area, loc_area,
     planar_area_params
 
 abstract type Outcome end
@@ -441,8 +441,8 @@ shelter volume (a 3D metric).
 
 # Arguments
 - `X` : raw results
-- `site_area` : area in m^2 for each site
-- `max_cover` : maximum possible coral cover for each site (in percentage of site_area)
+- `k_area` : area in m^2 for each site
+- `max_cover` : maximum possible coral cover for each site (in percentage of loc_area)
 - `inputs` : DataFrame of scenario inputs
 
 # References
@@ -670,9 +670,9 @@ include("utils.jl")
 
 # ```julia
 # using ADRIA.metrics: total_absolute_cover
-# extended_metric = @extend_metric(example_func, total_absolute_cover, [site_area(domain)])
+# extended_metric = @extend_metric(example_func, total_absolute_cover, [loc_area(domain)])
 
-# Y = extended_metric(raw_results)  # Equivalent to total_absolute_cover(raw_results, site_area(domain))
+# Y = extended_metric(raw_results)  # Equivalent to total_absolute_cover(raw_results, loc_area(domain))
 # ```
 # """
 # macro extend_metric(name, m, args)

--- a/src/metrics/ranks.jl
+++ b/src/metrics/ranks.jl
@@ -13,17 +13,17 @@ end
 Collates ranks into seed/fog ranking results into a common structure.
 """
 function _collate_ranks(rs::ResultSet, selected; kwargs...)::YAXArray
-    n_steps, n_sites = size(selected)
+    n_steps, n_locs = size(selected)
 
     ts = timesteps(rs)
     @assert length(ts) == n_steps
 
-    r_ids = rs.site_data.reef_siteid
+    r_ids = rs.loc_data.reef_siteid
     if haskey(kwargs, :sites)
         r_ids = r_ids[kwargs[:sites]]
     end
 
-    if length(r_ids) != n_sites
+    if length(r_ids) != n_locs
         @warn "Length of reef ids do not match number of sites"
     end
 
@@ -151,7 +151,7 @@ YAXArray[locations, [loc_id, loc_name, rank], scenarios]
 function top_n_seeded_sites(rs::ResultSet, n::Int64; kwargs...)::YAXArray
     ranked_locs = seed_ranks(rs; kwargs...)
 
-    r_ids = rs.site_data.reef_siteid
+    r_ids = rs.loc_data.reef_siteid
     min_rank = length(r_ids) + 1
 
     c_ranks = collect(dropdims(mean(ranked_locs; dims=1); dims=1))

--- a/src/metrics/ranks.jl
+++ b/src/metrics/ranks.jl
@@ -3,8 +3,8 @@
 
 Extracts results for a specific intervention (seeding [1] or shading [2])
 """
-function _get_ranks(rs::ResultSet, intervention::Int64; kwargs...)
-    return slice_results(rs.ranks[intervention=intervention]; kwargs...)
+function _get_ranks(rs::ResultSet, intervention::Symbol; kwargs...)
+    return slice_results(rs.ranks[intervention=At(intervention)]; kwargs...)
 end
 
 """
@@ -51,7 +51,7 @@ ADRIA.metrics.seed_ranks(rs; timesteps=1:10, scenarios=3:5)
 ```
 """
 function seed_ranks(rs::ResultSet; kwargs...)
-    selected = _get_ranks(rs, 1; kwargs...)
+    selected = _get_ranks(rs, :seed; kwargs...)
     return _collate_ranks(rs, selected; kwargs...)
 end
 
@@ -71,7 +71,7 @@ ADRIA.metrics.fog_ranks(rs; timesteps=1:10, scenarios=3:5)
 ```
 """
 function fog_ranks(rs::ResultSet; kwargs...)
-    selected = _get_ranks(rs, 2; kwargs...)
+    selected = _get_ranks(rs, :fog; kwargs...)
     return _collate_ranks(rs, selected; kwargs...)
 end
 
@@ -156,9 +156,8 @@ function top_n_seeded_sites(rs::ResultSet, n::Int64; kwargs...)::YAXArray
 
     c_ranks = collect(dropdims(mean(ranked_locs; dims=1); dims=1))
 
-    top_sites = Array{Union{String,Int32,Float32,Missing}}(
-        undef, n, 3, size(ranked_locs, 3)
-    )
+    n_scenarios = size(ranked_locs, 3)
+    top_sites = Array{Union{String,Int32,Float32,Missing}}(undef, n, 3, n_scenarios)
     for scen in axes(ranked_locs, 3)
         flat = vec(c_ranks[:, scen])
         flat[flat .== 0.0] .= min_rank
@@ -178,9 +177,9 @@ function top_n_seeded_sites(rs::ResultSet, n::Int64; kwargs...)::YAXArray
 
     return DataCube(
         top_sites;
-        ranks=collect(1:n),
+        ranks=1:n,
         locations=[:loc_id, :loc_name, :rank],
-        scenarios=1:size(ranked_locs, 3)
+        scenarios=1:n_scenarios
     )
 end
 
@@ -199,10 +198,11 @@ YAXArray[timesteps, sites, scenarios]
 ADRIA.metrics.shade_ranks(rs; timesteps=1:10, scenarios=3:5)
 ```
 """
-function shade_ranks(rs::ResultSet; kwargs...)
-    selected = _get_ranks(rs, 2; kwargs...)
-    return _collate_ranks(rs, selected; kwargs...)
-end
+# There is no shade rank
+# function shade_ranks(rs::ResultSet; kwargs...)
+#     selected = _get_ranks(rs, 2; kwargs...)
+#     return _collate_ranks(rs, selected; kwargs...)
+# end
 
 """
     top_N_sites(rs::ResultSet; N::Int64; metric::relative_cover)

--- a/src/metrics/ranks.jl
+++ b/src/metrics/ranks.jl
@@ -1,7 +1,7 @@
 """
     _get_ranks(rs::ResultSet, intervention::Int64; kwargs...)
 
-Extracts results for a specific intervention (seeding [1] or shading [2])
+Extracts results for a specific intervention (:seed or :fog)
 """
 function _get_ranks(rs::ResultSet, intervention::Symbol; kwargs...)
     return slice_results(rs.ranks[intervention=At(intervention)]; kwargs...)
@@ -10,7 +10,7 @@ end
 """
     _collate_ranks(rs, selected)
 
-Collates ranks into seed/shade ranking results into a common structure.
+Collates ranks into seed/fog ranking results into a common structure.
 """
 function _collate_ranks(rs::ResultSet, selected; kwargs...)::YAXArray
     n_steps, n_sites = size(selected)
@@ -182,27 +182,6 @@ function top_n_seeded_sites(rs::ResultSet, n::Int64; kwargs...)::YAXArray
         scenarios=1:n_scenarios
     )
 end
-
-"""
-    shade_ranks(rs::ResultSet; kwargs...)
-
-# Arguments
-- rs : ResultSet
-- kwargs : named dimensions to slice across
-
-# Returns
-YAXArray[timesteps, sites, scenarios]
-
-# Example
-```julia
-ADRIA.metrics.shade_ranks(rs; timesteps=1:10, scenarios=3:5)
-```
-"""
-# There is no shade rank
-# function shade_ranks(rs::ResultSet; kwargs...)
-#     selected = _get_ranks(rs, 2; kwargs...)
-#     return _collate_ranks(rs, selected; kwargs...)
-# end
 
 """
     top_N_sites(rs::ResultSet; N::Int64; metric::relative_cover)

--- a/src/metrics/reef_indices.jl
+++ b/src/metrics/reef_indices.jl
@@ -103,7 +103,7 @@ function _reef_condition_index(rs::ResultSet)::AbstractArray{<:Real}
 
     return _reef_condition_index(rc, evenness, sv, juves)
 end
-reef_condition_index = Metric(_reef_condition_index, (:timesteps, :sites, :scenarios))
+reef_condition_index = Metric(_reef_condition_index, (:timesteps, :locations, :scenarios))
 
 """
     scenario_rci(rci::YAXArray, tac::YAXArray; kwargs...)
@@ -163,7 +163,18 @@ function _reef_tourism_index(
                 (0.31946 .* evenness[:, :, axe]) .+
                 (0.11676 .* sv[:, :, axe]) .+
                 (-0.0036065 .* juves[:, :, axe])
-            ), axes(rc, 3))...; dims=3)
+            ),
+            axes(rc, 3)
+        )...;
+        dims=3
+    )
+
+    timesteps = rti.timesteps.val.data
+    locations = rti.locations.val.data
+    n_scenarios = size(rti, 3)
+    rti = DataCube(
+        rti.data; timesteps=timesteps, locations=locations, scenarios=1:n_scenarios
+    )
 
     return round.(clamp.(rti, 0.1, 0.9), digits=2)
 end
@@ -178,7 +189,7 @@ function _reef_tourism_index(rs::ResultSet; intcp_u::Bool=false)::AbstractArray
 
     return _reef_tourism_index(rc, evenness, sv, juves, intcp)
 end
-reef_tourism_index = Metric(_reef_tourism_index, (:timesteps, :sites, :scenarios))
+reef_tourism_index = Metric(_reef_tourism_index, (:timesteps, :locations, :scenarios))
 
 """
     scenario_rti(rti::YAXArray; kwargs...)
@@ -241,6 +252,13 @@ function _reef_fish_index(rc::AbstractArray, intcp_u1, intcp_u2)
             axes(rc, 3))...;
         dims=3)
 
+    timesteps = rfi.timesteps.val.data
+    locations = rfi.locations.val.data
+    n_scenarios = size(rfi, 3)
+    rfi = DataCube(
+        rfi.data; timesteps=timesteps, locations=locations, scenarios=1:n_scenarios
+    )
+
     # Calculate total fish biomass, kg km2
     # 0.01 coefficient is to convert from kg ha to kg km2
     return round.(rfi, digits=2)
@@ -253,7 +271,7 @@ function _reef_fish_index(rs::ResultSet; intcp_u1::Bool=false, intcp_u2::Bool=fa
 
     return _reef_fish_index(rc, icp1, icp2)
 end
-reef_fish_index = Metric(_reef_fish_index, (:timesteps, :sites, :scenarios))
+reef_fish_index = Metric(_reef_fish_index, (:timesteps, :locations, :scenarios))
 
 """
 scenario_rfi(rfi::YAXArray; kwargs...)

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -24,7 +24,9 @@ function scenario_trajectory(data::AbstractArray; metric=mean)::YAXArray{<:Real}
 
     s::Matrix{eltype(data)} =
         metric.(
-            JuliennedArrays.Slices(data[timesteps=At(tf_labels)], axis_index(data, :sites))
+            JuliennedArrays.Slices(
+                data[timesteps=At(tf_labels)], axis_index(data, :locations)
+            )
         )
 
     return DataCube(s; timesteps=tf_labels, scenarios=1:size(s, 2))
@@ -36,11 +38,11 @@ end
 Calculate the mean absolute coral for each scenario for the entire domain.
 """
 function _scenario_total_cover(X::AbstractArray; kwargs...)::AbstractArray{<:Real}
-    return dropdims(sum(slice_results(X; kwargs...); dims=:sites); dims=:sites)
+    return dropdims(sum(slice_results(X; kwargs...); dims=:locations); dims=:locations)
 end
 function _scenario_total_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     tac = total_absolute_cover(rs)
-    return dropdims(sum(slice_results(tac; kwargs...); dims=:sites); dims=:sites)
+    return dropdims(sum(slice_results(tac; kwargs...); dims=:locations); dims=:locations)
 end
 scenario_total_cover = Metric(_scenario_total_cover, (:timesteps, :scenarios), "m²")
 
@@ -50,7 +52,7 @@ scenario_total_cover = Metric(_scenario_total_cover, (:timesteps, :scenarios), "
 Calculate the mean relative coral cover for each scenario for the entire domain.
 """
 function _scenario_relative_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
-    target_sites = haskey(kwargs, :sites) ? kwargs[:sites] : (:)
+    target_sites = haskey(kwargs, :locations) ? kwargs[:locations] : (:)
     target_area = sum(site_k_area(rs)[target_sites])
 
     return _scenario_total_cover(rs; kwargs...) ./ target_area
@@ -70,12 +72,12 @@ function _scenario_relative_juveniles(
     kwargs...
 )::AbstractArray{<:Real}
     ajuv = call_metric(absolute_juveniles, data, coral_spec; kwargs...)
-    return dropdims(sum(ajuv; dims=:sites); dims=:sites) / sum(k_area)
+    return dropdims(sum(ajuv; dims=:locations); dims=:locations) / sum(k_area)
 end
 function _scenario_relative_juveniles(rs::ResultSet; kwargs...)::YAXArray
     # Calculate relative domain-wide cover based on absolute values
     aj = absolute_juveniles(rs)
-    return dropdims(sum(aj; dims=:sites); dims=:sites) ./ sum(site_k_area(rs))
+    return dropdims(sum(aj; dims=:locations); dims=:locations) ./ sum(site_k_area(rs))
 end
 scenario_relative_juveniles = Metric(_scenario_relative_juveniles, (:timesteps, :scenarios))
 
@@ -92,11 +94,11 @@ function _scenario_absolute_juveniles(
     kwargs...
 )::AbstractArray{<:Real}
     juv = call_metric(absolute_juveniles, data, coral_spec; kwargs...)
-    return dropdims(sum(juv; dims=:sites); dims=:sites) / sum(k_area)
+    return dropdims(sum(juv; dims=:locations); dims=:locations) / sum(k_area)
 end
 function _scenario_absolute_juveniles(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     # Calculate relative domain-wide cover based on absolute values
-    return dropdims(sum(absolute_juveniles(rs); dims=:sites); dims=:sites)
+    return dropdims(sum(absolute_juveniles(rs); dims=:locations); dims=:locations)
 end
 scenario_absolute_juveniles = Metric(_scenario_absolute_juveniles, (:timesteps, :scenarios))
 
@@ -113,10 +115,10 @@ function _scenario_juvenile_indicator(
     kwargs...
 )::AbstractArray{<:Real}
     juv = call_metric(juvenile_indicator, data, coral_spec, k_area; kwargs...)
-    return dropdims(mean(juv; dims=:sites); dims=:sites) / sum(k_area)
+    return dropdims(mean(juv; dims=:locations); dims=:locations) / sum(k_area)
 end
 function _scenario_juvenile_indicator(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
-    return dropdims(mean(juvenile_indicator(rs); dims=:sites); dims=:sites)
+    return dropdims(mean(juvenile_indicator(rs); dims=:locations); dims=:locations)
 end
 scenario_juvenile_indicator = Metric(_scenario_juvenile_indicator, (:timesteps, :scenarios))
 
@@ -128,7 +130,7 @@ Calculate the mean absolute shelter volumes for each scenario for the entire dom
 """
 function _scenario_asv(sv::YAXArray; kwargs...)::AbstractArray{<:Real}
     sv_sliced = slice_results(sv; kwargs...)
-    return dropdims(sum(sv_sliced; dims=:sites); dims=:sites)
+    return dropdims(sum(sv_sliced; dims=:locations); dims=:locations)
 end
 function _scenario_asv(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_asv(rs.outcomes[:absolute_shelter_volume]; kwargs...)
@@ -143,7 +145,7 @@ Calculate the mean relative shelter volumes for each scenario for the entire dom
 """
 function _scenario_rsv(sv::YAXArray; kwargs...)::AbstractArray{<:Real}
     sv_sliced = slice_results(sv; kwargs...)
-    return dropdims(mean(sv_sliced; dims=:sites); dims=:sites)
+    return dropdims(mean(sv_sliced; dims=:locations); dims=:locations)
 end
 function _scenario_rsv(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_rsv(rs.outcomes[:relative_shelter_volume]; kwargs...)

--- a/src/metrics/site_level.jl
+++ b/src/metrics/site_level.jl
@@ -12,7 +12,7 @@ the location-level at indicated time (or across timesteps).
 - timesteps : timesteps to apply `metric` across
 
 # Returns
-Named Vector of \$N\$ elements, where \$N\$ is the number of sites.
+Named Vector of \$N\$ elements, where \$N\$ is the number of locations.
 """
 function per_loc(metric, data::YAXArray{D,T,N,A})::YAXArray where {D,T,N,A}
     return summarize(data, [:scenarios, :timesteps], metric)
@@ -39,14 +39,14 @@ tac = ADRIA.metrics.total_absolute_cover(rs)
 ADRIA.metrics.loc_trajectory(median, tac)
 #75×216 YAXArray{Float64,2} with dimensions:
 #  Dim{:timesteps} Categorical{Any} Any[1, 2, …, 74, 75] Unordered,
-#  Dim{:sites} Categorical{Any} Any[1, 2, …, 215, 216] Unordered
+#  Dim{:locations} Categorical{Any} Any[1, 2, …, 215, 216] Unordered
 #Total size: 126.56 KB
 
 # Get upper 95% CI for each site
 ADRIA.metrics.loc_trajectory(x -> quantile(x, 0.975), tac)
 #75×216 YAXArray{Float64,2} with dimensions:
 #  Dim{:timesteps} Categorical{Any} Any[1, 2, …, 74, 75] Unordered,
-#  Dim{:sites} Categorical{Any} Any[1, 2, …, 215, 216] Unordered
+#  Dim{:locations} Categorical{Any} Any[1, 2, …, 215, 216] Unordered
 #Total size: 126.56 KB
 ```
 
@@ -55,7 +55,7 @@ ADRIA.metrics.loc_trajectory(x -> quantile(x, 0.975), tac)
 - data : Data set to apply metric to
 
 # Returns
-2D array of \$T ⋅ S\$, where \$T\$ is total number of time steps and \$S\$ is number of sites
+2D array of \$T ⋅ S\$, where \$T\$ is total number of time steps and \$S\$ is number of locations
 """
 function loc_trajectory(
     metric, data::YAXArray{D,T,N,A}

--- a/src/metrics/temporal.jl
+++ b/src/metrics/temporal.jl
@@ -7,8 +7,8 @@ import Interpolations: GriddedInterpolation
 
 function summarize_trajectory(data::YAXArray)::Dict{Symbol,AbstractArray{<:Real}}
     squash = nothing
-    if :sites in axes_names(data)
-        squash = (:scenarios, :sites)
+    if :locations in axes_names(data)
+        squash = (:scenarios, :locations)
     elseif :scenarios in axes_names(data) && (size(data, :scenarios) > 1)
         squash = (:scenarios,)
     end
@@ -56,8 +56,8 @@ end
 # function summarize_rci(rs::ResultSet; kwargs...)
 #     rc::AbstractArray{<:Real} = call_metric(relative_cover, rs.inputs; kwargs...)
 
-#     # Divide across sites by the max possible proportional coral cover
-#     rc .= mapslices((s) -> s ./ (rs.site_max_coral_cover / 100.0), rc, dims=:sites)
+#     # Divide across locations by the max possible proportional coral cover
+#     rc .= mapslices((s) -> s ./ (rs.site_max_coral_cover / 100.0), rc, dims=:locations)
 
 #     # Empty representation of evenness - currently ignored
 #     E::AbstractArray{<:Real} = Array(Float32[])
@@ -80,14 +80,15 @@ Calculate summarized total absolute cover.
 function summarize_total_cover(
     raw::YAXArray, areas::AbstractArray{<:Real}; kwargs...
 )::Dict{Symbol,AbstractArray{<:Real}}
-    sites = haskey(kwargs, :sites) ? kwargs[:sites] : (:)
-    tac = call_metric(total_absolute_cover, raw, areas[sites]; kwargs...)
-    tac = dropdims(sum(tac; dims=:sites); dims=:sites)
+    locations = haskey(kwargs, :locations) ? kwargs[:locations] : (:)
+    tac = call_metric(total_absolute_cover, raw, areas[locations]; kwargs...)
+    tac = dropdims(sum(tac; dims=:locations); dims=:locations)
     return summarize_trajectory(tac)
 end
 function summarize_total_cover(rs::ResultSet; kwargs...)::Dict{Symbol,AbstractArray{<:Real}}
     tac = dropdims(
-        sum(slice_results(_total_absolute_cover(rs); kwargs...); dims=:sites); dims=:sites
+        sum(slice_results(_total_absolute_cover(rs); kwargs...); dims=:locations);
+        dims=:locations
     )
     return summarize_trajectory(tac)
 end

--- a/src/metrics/temporal.jl
+++ b/src/metrics/temporal.jl
@@ -57,7 +57,7 @@ end
 #     rc::AbstractArray{<:Real} = call_metric(relative_cover, rs.inputs; kwargs...)
 
 #     # Divide across locations by the max possible proportional coral cover
-#     rc .= mapslices((s) -> s ./ (rs.site_max_coral_cover / 100.0), rc, dims=:locations)
+#     rc .= mapslices((s) -> s ./ (rs.loc_max_coral_cover / 100.0), rc, dims=:locations)
 
 #     # Empty representation of evenness - currently ignored
 #     E::AbstractArray{<:Real} = Array(Float32[])

--- a/src/metrics/utils.jl
+++ b/src/metrics/utils.jl
@@ -82,14 +82,16 @@ function call_metric(metric::Union{Function,Metric}, data::YAXArray, args...; kw
 end
 
 """
-    slice_results(data::YAXArray; timesteps=(:), species=(:), sites=(:), scenarios=(:))
+    slice_results(data::YAXArray; timesteps=(:), species=(:), locations=(:), scenarios=(:))
 
 Slice data as indicated. Dimensions not found in target data are ignored.
 """
 function slice_results(
-    data::YAXArray; timesteps=(:), species=(:), sites=(:), scenarios=(:)
+    data::YAXArray; timesteps=(:), species=(:), locations=(:), scenarios=(:)
 )::YAXArray
-    f_dims = (timesteps=timesteps, species=species, sites=sites, scenarios=scenarios)
+    f_dims = (
+        timesteps=timesteps, species=species, locations=locations, scenarios=scenarios
+    )
 
     s_names = keys(f_dims)
     d_names = axes_names(data)

--- a/src/spatial/spatial.jl
+++ b/src/spatial/spatial.jl
@@ -39,9 +39,9 @@ Extract and return long/lat from a GeoDataFrame.
 Array of tuples (x, y), where x and y relate to long and lat respectively.
 """
 function centroids(df::DataFrame)::Vector{Tuple{Float64,Float64}}
-    site_centroids::Vector = AG.centroid.(get_geometry(df))
-    return collect(zip(AG.getx.(site_centroids, 0), AG.gety.(site_centroids, 0)))
+    loc_centroids::Vector = AG.centroid.(get_geometry(df))
+    return collect(zip(AG.getx.(loc_centroids, 0), AG.gety.(loc_centroids, 0)))
 end
 function centroids(ds::Union{Domain,ResultSet})::Vector{Tuple{Float64,Float64}}
-    return centroids(ds.site_data)
+    return centroids(ds.loc_data)
 end

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -2,12 +2,12 @@ using ADRIA, ADRIA.DataFrames, ADRIA.CSV
 import ADRIA.GeoDataFrames as GDF
 
 @testset "Connectivity loading" begin
-    site_data = GDF.read(
+    loc_data = GDF.read(
         joinpath(@__DIR__, "..", "examples", "Test_domain", "spatial", "Test_domain.gpkg")
     )
-    sort!(site_data, [:reef_siteid])
+    sort!(loc_data, [:reef_siteid])
 
-    unique_site_ids = site_data.reef_siteid
+    unique_loc_ids = loc_data.reef_siteid
     conn_files = joinpath(@__DIR__, "..", "examples", "Test_domain", "connectivity")
     conn_data = CSV.read(
         joinpath(conn_files, "2000", "test_conn_data.csv"),
@@ -17,9 +17,9 @@ import ADRIA.GeoDataFrames as GDF
         types=Float64
     )
 
-    conn_details = ADRIA.site_connectivity(conn_files, unique_site_ids)
+    conn_details = ADRIA.location_connectivity(conn_files, unique_loc_ids)
 
     conn = conn_details.conn
-    @test all(names(conn, 2) .== site_data.reef_siteid) ||
+    @test all(names(conn, 2) .== loc_data.reef_siteid) ||
         "Sites do not match expected order!"
 end

--- a/test/data_loading.jl
+++ b/test/data_loading.jl
@@ -19,10 +19,10 @@ end
 end
 
 @testset "Connectivity loading" begin
-    site_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
-    sort!(site_data, :reef_siteid)
+    loc_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
+    sort!(loc_data, :reef_siteid)
 
-    unique_site_ids = site_data.reef_siteid
+    unique_loc_ids = loc_data.reef_siteid
 
     conn_files = joinpath(TEST_DOMAIN_PATH, "connectivity")
     conn_data = CSV.read(
@@ -33,46 +33,46 @@ end
         types=Float64
     )
 
-    conn_details = ADRIA.site_connectivity(conn_files, unique_site_ids)
+    conn_details = ADRIA.location_connectivity(conn_files, unique_loc_ids)
 
     conn = conn_details.conn
     d1, d2 = axes(conn)
     @test all(d1.dim .== d2.dim) || "Site order does not match between rows/columns."
-    @test all(d2.dim .== site_data.reef_siteid) || "Sites do not match expected order."
-    @test all(unique_site_ids .== conn_details.site_ids) ||
+    @test all(d2.dim .== loc_data.reef_siteid) || "Sites do not match expected order."
+    @test all(unique_loc_ids .== conn_details.loc_ids) ||
         "Included site ids do not match length/order in geospatial file."
 end
 
 @testset "Environmental data" begin
-    site_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
+    loc_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
 
-    sort!(site_data, :reef_siteid)
+    sort!(loc_data, :reef_siteid)
 
     wave_fn = joinpath(TEST_DOMAIN_PATH, "waves", "wave_RCP45.nc")
     waves = ADRIA.load_env_data(wave_fn, "Ub")
-    @test all(axes(waves, 2).dim .== site_data.reef_siteid) ||
+    @test all(axes(waves, 2).dim .== loc_data.reef_siteid) ||
         "Wave data not aligned with order specified in geospatial data"
 
     dhw_fn = joinpath(TEST_DOMAIN_PATH, "DHWs", "dhwRCP45.nc")
     dhw = ADRIA.load_env_data(dhw_fn, "dhw")
-    @test all(axes(dhw, 2).dim .== site_data.reef_siteid) ||
+    @test all(axes(dhw, 2).dim .== loc_data.reef_siteid) ||
         "Wave data not aligned with order specified in geospatial data"
 end
 
 @testset "Initial covers" begin
-    site_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
-    sort!(site_data, :reef_siteid)
+    loc_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
+    sort!(loc_data, :reef_siteid)
 
     coral_cover_fn = joinpath(TEST_DOMAIN_PATH, "spatial", "coral_cover.nc")
     coral_covers = ADRIA.load_initial_cover(coral_cover_fn)
 
-    @test all(axes(coral_covers, 2).dim .== site_data.reef_siteid) ||
+    @test all(axes(coral_covers, 2).dim .== loc_data.reef_siteid) ||
         "Coral cover data not aligned with order specified in geospatial data"
 end
 
 @testset "Cyclone mortality data" begin
-    site_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
-    sort!(site_data, :reef_siteid)
+    loc_data = GDF.read(joinpath(TEST_DOMAIN_PATH, "spatial", "Test_domain.gpkg"))
+    sort!(loc_data, :reef_siteid)
 
     cyclone_mortality_fn = joinpath(TEST_DOMAIN_PATH, "cyclones", "cyclone_mortality.nc")
     cyclone_mortality = ADRIA.load_cyclone_mortality(cyclone_mortality_fn)
@@ -86,7 +86,7 @@ end
         "large_massives"
     ]
 
-    @test all(axes(cyclone_mortality, 2).dim .== site_data.reef_siteid) ||
+    @test all(axes(cyclone_mortality, 2).dim .== loc_data.reef_siteid) ||
         "Cyclone mortality locations do not align with location order specified in geospatial data"
     @test all(axes(cyclone_mortality, 3).dim .== expected_species_order) ||
         "Cyclone mortality data does not list species in expected order"

--- a/test/growth.jl
+++ b/test/growth.jl
@@ -83,7 +83,7 @@ end
     ]
 
     C_cover_t = rand(Uniform(0.0, 0.01), 36, 216)
-    total_site_area = [
+    total_loc_area = [
         76997.8201778261,
         38180.997513339855,
         334269.6228868989,
@@ -303,7 +303,7 @@ end
     ]
 
     ADRIA.fecundity_scope!(
-        fec_groups, fec_all, fec_params, C_cover_t, Matrix(total_site_area')
+        fec_groups, fec_all, fec_params, C_cover_t, Matrix(total_loc_area')
     )
 
     @test any(fec_groups .> 1e8) ||
@@ -335,20 +335,20 @@ end
 end
 
 @testset "Recruitment" begin
-    n_sites = 334
+    n_locs = 334
     n_groups = 5
 
-    total_site_area = rand(n_sites) .* 1e6
-    max_cover = rand(n_sites)
-    avail_area = rand(n_sites)
-    larval_pool = rand(n_groups, n_sites) .* 1e8
+    total_loc_area = rand(n_locs) .* 1e6
+    max_cover = rand(n_locs)
+    avail_area = rand(n_locs)
+    larval_pool = rand(n_groups, n_locs) .* 1e8
 
     recruits_per_m² = ADRIA.recruitment_rate(larval_pool, avail_area)
-    abs_recruits = recruits_per_m² .* (avail_area .* max_cover .* total_site_area)'
+    abs_recruits = recruits_per_m² .* (avail_area .* max_cover .* total_loc_area)'
 
     @test any(abs_recruits .> 10^4) || "At least some recruitment values should be > 10,000"
 
-    theoretical_max = ((avail_area .* max_cover .* total_site_area)' * 51.8)
+    theoretical_max = ((avail_area .* max_cover .* total_loc_area)' * 51.8)
     for (i, rec) in enumerate(eachrow(abs_recruits))
         @test all(rec' .<= theoretical_max) ||
             "Species group $i exceeded maximum theoretical number of settlers"

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -50,7 +50,7 @@ end
 
 # @testset "metric modifications" begin
 #     dom = ADRIA.load_domain(joinpath(@__DIR__, "..", "examples", "Example_domain"), 45)
-#     sa = site_area(dom)
+#     sa = loc_area(dom)
 #     tac_metric = @extend_metric(TAC, total_absolute_cover, [sa])
 
 #     @test tac_metric(rand(5, 26, 5, 5))

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -15,12 +15,12 @@ end
     dom = ADRIA.load_domain(TEST_DOMAIN_PATH, 45)
 
     # extract inputs for function
-    total_site_area = site_area(dom)
+    total_loc_area = loc_area(dom)
     k = location_k(dom)
-    current_cover = zeros(size(total_site_area))
+    current_cover = zeros(size(total_loc_area))
 
     # calculate available space
-    available_space = vec((total_site_area .* k) .- current_cover)
+    available_space = vec((total_loc_area .* k) .- current_cover)
 
     # Randomly generate seeded area
     seeded_area = ADRIA.DataCube(
@@ -28,15 +28,15 @@ end
     )
 
     @testset "Check coral seed distribution ($i)" for i in 1:10
-        seed_locs = rand(1:length(total_site_area), 5)
+        seed_locs = rand(1:length(total_loc_area), 5)
 
         # evaluate seeding distributions
         seed_dist = distribute_seeded_corals(
-            total_site_area[seed_locs], available_space[seed_locs], seeded_area
+            total_loc_area[seed_locs], available_space[seed_locs], seeded_area
         )
 
         # Area to be seeded for each site
-        total_area_seed = seed_dist .* total_site_area[seed_locs]'
+        total_area_seed = seed_dist .* total_loc_area[seed_locs]'
 
         # total area of seeded corals
         total_area_coral_out = sum(total_area_seed; dims=2)
@@ -46,7 +46,7 @@ end
 
         # Index of max proportion for available space
         # The selected location (row number) should match
-        abs_seed_area = seed_dist' .* total_site_area[seed_locs]
+        abs_seed_area = seed_dist' .* total_loc_area[seed_locs]
         max_ind_out = argmax(abs_seed_area)[1]
         max_ind = argmax(selected_avail_space)
 

--- a/test/site_selection.jl
+++ b/test/site_selection.jl
@@ -18,9 +18,9 @@ end
 end
 
 @testset "Unguided site selection" begin
-    n_intervention_sites = 5
-    pref_seed_sites = zeros(Int64, n_intervention_sites)
-    pref_fog_sites = zeros(Int64, n_intervention_sites)
+    n_intervention_locs = 5
+    pref_seed_sites = zeros(Int64, n_intervention_locs)
+    pref_fog_sites = zeros(Int64, n_intervention_locs)
     seed_years = true
     fog_years = true
     max_cover = [0.0, 3000.0, 5000.0, 0.0, 0.0]
@@ -56,7 +56,7 @@ end
 
     @test length(ranks.scenarios) == sum(scens.guided .> 0) ||
         "Specified number of scenarios was not carried out."
-    @test length(ranks.sites) == length(dom.site_ids) ||
+    @test length(ranks.sites) == length(dom.loc_ids) ||
         "Ranks storage is not correct size for this domain."
 
     sel_sites = unique(ranks)
@@ -69,16 +69,16 @@ end
 @testset "Test ranks line up with ordering" begin
     supported_methods = ADRIA.decision.mcda_methods()
     mcda_func = supported_methods[rand(1:length(supported_methods))]
-    n_sites = 20
+    n_locs = 20
 
-    S = ADRIA.decision.mcda_normalize(rand(Uniform(0, 1), n_sites, 6))
+    S = ADRIA.decision.mcda_normalize(rand(Uniform(0, 1), n_locs, 6))
 
     weights = ADRIA.decision.mcda_normalize(rand(Uniform(0, 1), 6))
     n_site_int = 5
-    site_ids = collect(1:n_sites)
-    S = hcat(site_ids, S)
+    loc_ids = collect(1:n_locs)
+    S = hcat(loc_ids, S)
 
-    rankings = Int64[site_ids zeros(Int64, n_sites) zeros(Int64, n_sites)]
+    rankings = Int64[loc_ids zeros(Int64, n_locs) zeros(Int64, n_locs)]
 
     prefsites, s_order = ADRIA.decision.rank_sites!(
         S, weights, rankings, n_site_int, mcda_func, 2

--- a/test/spatial_clustering.jl
+++ b/test/spatial_clustering.jl
@@ -5,10 +5,10 @@ using Random
 using Statistics
 
 @testset "Constrain spatial groups" begin
-    n_sites = 30
-    site_ids = collect(1:n_sites)
+    n_locs = 30
+    loc_ids = collect(1:n_locs)
     area_to_seed = 695.11
-    orig_site_order = shuffle(Vector(1:n_sites))
+    orig_site_order = shuffle(Vector(1:n_locs))
     site_order = copy(orig_site_order)
     available_space = rand(Uniform(area_to_seed + 100.0, area_to_seed + 1000.0), 30)
     n_iv_locs = 5
@@ -16,11 +16,11 @@ using Statistics
     prefsites = site_order[1:5]
     reef_locs = [fill("1", 10)..., fill("2", 10)..., fill("3", 10)...]
 
-    s_order = Union{Float64,Int64}[Int64.(site_order) rand(n_sites)]
+    s_order = Union{Float64,Int64}[Int64.(site_order) rand(n_locs)]
     # All selected sites are in the same reef, so 2 should be replaced
     reef_locs[prefsites] .= "2"
     # Empty ranking just for testing
-    rankings = Int64[site_ids zeros(Int64, n_sites) zeros(Int64, n_sites)]
+    rankings = Int64[loc_ids zeros(Int64, n_locs) zeros(Int64, n_locs)]
 
     new_prefsites, rankings = constrain_reef_cluster(
         reef_locs,
@@ -44,8 +44,8 @@ using Statistics
     # Set no 3 sites to be in the same reef and check none are replaced
     reef_locs[prefsites] .= ["1", "2", "3", "4", "1"]
 
-    s_order = Union{Float64,Int64}[Int64.(orig_site_order) rand(n_sites)]
-    rankings = Int64[site_ids zeros(Int64, n_sites) zeros(Int64, n_sites)]
+    s_order = Union{Float64,Int64}[Int64.(orig_site_order) rand(n_locs)]
+    rankings = Int64[loc_ids zeros(Int64, n_locs) zeros(Int64, n_locs)]
 
     new_prefsites, rankings = constrain_reef_cluster(
         reef_locs,
@@ -64,8 +64,8 @@ using Statistics
     available_space[prefsites] .= (area_to_seed - 100.0) / n_iv_locs
     available_space[s_order[n_iv_locs + 1, 1]] = area_to_seed
 
-    s_order = Union{Float64,Int64}[Int64.(orig_site_order) rand(n_sites)]
-    rankings = Int64[site_ids zeros(Int64, n_sites) zeros(Int64, n_sites)]
+    s_order = Union{Float64,Int64}[Int64.(orig_site_order) rand(n_locs)]
+    rankings = Int64[loc_ids zeros(Int64, n_locs) zeros(Int64, n_locs)]
 
     new_prefsites, rankings = constrain_reef_cluster(
         reef_locs, s_order, rankings, area_to_seed, available_space, n_iv_locs, 3


### PR DESCRIPTION
I took the opportunity to update some variables that used the word "site" to use "location". That will help us migrate completely from `site`/`sites` to `location`/`locations` in the future.

Note: This is a first step before adding metadata to the metrics generated by Metrics module