### PR TITLE
Fix docs errors

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -272,12 +272,6 @@ git-tree-sha1 = "6c834533dc1fabd820c1db03c839bf97e45a3fab"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 version = "0.10.14"
 
-[[deps.Calculus]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
-uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
-version = "0.5.1"
-
 [[deps.CategoricalArrays]]
 deps = ["DataAPI", "Future", "Missings", "Printf", "Requires", "Statistics", "Unicode"]
 git-tree-sha1 = "1568b28f91293458345dabba6a5ea3f183250a61"
@@ -369,10 +363,10 @@ uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 version = "0.2.4"
 
 [[deps.CommonSubexpressions]]
-deps = ["MacroTools", "Test"]
-git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
-version = "0.3.0"
+version = "0.3.1"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -416,9 +410,9 @@ version = "2.4.2"
 
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "d8a9c0b6ac2d9081bf76324b39c78ca3ce4f0c98"
+git-tree-sha1 = "a33b7ced222c6165f624a3f2b55945fac5a598d9"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-version = "1.5.6"
+version = "1.5.7"
 weakdeps = ["IntervalSets", "StaticArrays"]
 
     [deps.ConstructionBase.extensions]
@@ -505,9 +499,9 @@ version = "1.15.1"
 
 [[deps.DimensionalData]]
 deps = ["Adapt", "ArrayInterface", "ConstructionBase", "DataAPI", "Dates", "Extents", "Interfaces", "IntervalSets", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "PrecompileTools", "Random", "RecipesBase", "SparseArrays", "Statistics", "TableTraits", "Tables"]
-git-tree-sha1 = "18f0771430553c811bfc05f3f54030b34d6737e9"
+git-tree-sha1 = "ed5fe2063fbf76cc9863faa01e2517acdb742dfe"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
-version = "0.27.7"
+version = "0.27.8"
 
     [deps.DimensionalData.extensions]
     DimensionalDataCategoricalArraysExt = "CategoricalArrays"
@@ -568,9 +562,9 @@ version = "0.8.6"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "76deb8c15f37a3853f13ea2226b8f2577652de05"
+git-tree-sha1 = "9d29b99b6b2b6bc2382a4c8dbec6eb694f389853"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.DocumenterTools]]
 deps = ["Base64", "DocStringExtensions", "LibGit2"]
@@ -582,12 +576,6 @@ version = "0.1.2"
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
-
-[[deps.DualNumbers]]
-deps = ["Calculus", "NaNMath", "SpecialFunctions"]
-git-tree-sha1 = "5837a837389fccf076445fce071c8ddaea35a566"
-uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.8"
 
 [[deps.EarCut_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -687,9 +675,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "0653c0a2396a6da5bc4766c43041ef5fd3efbe57"
+git-tree-sha1 = "fd0002c0b5362d7eb952450ad5eb742443340d6e"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.11.0"
+version = "1.12.0"
 weakdeps = ["PDMats", "SparseArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
@@ -747,9 +735,9 @@ version = "1.8.0"
 
 [[deps.GDAL_jll]]
 deps = ["Arrow_jll", "Artifacts", "Blosc_jll", "Expat_jll", "GEOS_jll", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "LibPQ_jll", "Libdl", "Libtiff_jll", "Lz4_jll", "NetCDF_jll", "OpenJpeg_jll", "PCRE2_jll", "PROJ_jll", "Qhull_jll", "SQLite_jll", "XML2_jll", "XZ_jll", "Zlib_jll", "Zstd_jll", "libgeotiff_jll", "libpng_jll", "libwebp_jll"]
-git-tree-sha1 = "1a607f3fb5c0ef3b5149692e615086f487af1d89"
+git-tree-sha1 = "f1a5ace73ff130427b7816b13cd4bc905ace16ca"
 uuid = "a7073274-a066-55f0-b90d-d619367d196c"
-version = "301.901.101+0"
+version = "301.901.200+0"
 
 [[deps.GEOS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -887,10 +875,10 @@ uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
 version = "2.11.1+0"
 
 [[deps.HypergeometricFunctions]]
-deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
-git-tree-sha1 = "f218fe3736ddf977e0e772bc9a586b2383da2685"
+deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "7c4195be1649ae622304031ed46a2f4df989f1eb"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.23"
+version = "0.3.24"
 
 [[deps.HypothesisTests]]
 deps = ["Combinatorics", "Distributions", "LinearAlgebra", "Printf", "Random", "Rmath", "Roots", "Statistics", "StatsAPI", "StatsBase"]
@@ -989,9 +977,9 @@ weakdeps = ["ArrowTypes", "Parsers"]
     ParsersExt = "Parsers"
 
 [[deps.InputBuffers]]
-git-tree-sha1 = "56451eb3a91eb5b1cf08e19e53b0f507c4c700d4"
+git-tree-sha1 = "d5c278bee2efd4fda62725a4a794d7e5f55e14f1"
 uuid = "0c81fc1b-5583-44fc-8770-48be1e1cca08"
-version = "0.2.0"
+version = "1.0.0"
 
 [[deps.IntegerMathUtils]]
 git-tree-sha1 = "b8ffb903da9f7b8cf695a8bead8e01814aa24b30"
@@ -1442,9 +1430,9 @@ version = "0.5.13"
 
 [[deps.MakieCore]]
 deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
-git-tree-sha1 = "c1c950560397ee68ad7302ee0e3efa1b07466a2f"
+git-tree-sha1 = "1753d72dcf82beb1c582826d0a51a8253a719613"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.8.4"
+version = "0.8.5"
 
 [[deps.MappedArrays]]
 git-tree-sha1 = "2dab0221fe2b0f2cb6754eaa743cc266339f527e"
@@ -2163,9 +2151,9 @@ weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
 [[deps.StatsModels]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Printf", "REPL", "ShiftedArrays", "SparseArrays", "StatsAPI", "StatsBase", "StatsFuns", "Tables"]
-git-tree-sha1 = "5cf6c4583533ee38639f73b880f35fc85f2941e0"
+git-tree-sha1 = "9022bcaa2fc1d484f1326eaa4db8db543ca8c66d"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.7.3"
+version = "0.7.4"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
@@ -2335,9 +2323,9 @@ version = "1.6.1"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "d9717ce3518dc68a99e6b96300813760d887a01d"
+git-tree-sha1 = "1165b0443d0eca63ac1e32b8c0eb69ed2f4f8127"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.1+0"
+version = "2.13.3+0"
 
 [[deps.XMLDict]]
 deps = ["EzXML", "IterTools", "OrderedCollections"]
@@ -2419,9 +2407,9 @@ version = "0.9.4"
 
 [[deps.ZipArchives]]
 deps = ["ArgCheck", "CodecZlib", "InputBuffers", "PrecompileTools", "TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "446f46947c32494e5d4904bb1f028ce63e0164f1"
+git-tree-sha1 = "8612bfcf4c0a5a2863bf4c9a92a1917a4bd4e691"
 uuid = "49080126-0e18-4c2a-b176-c102e4b3760c"
-version = "2.1.6"
+version = "2.1.7"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/docs/src/architecture/domain_and_resultsets.md
+++ b/docs/src/architecture/domain_and_resultsets.md
@@ -8,7 +8,7 @@ Data specifications are outlined/stored in this repository: https://github.com/o
 
 The overall structure and data formats of the data packages are illustrated in the diagram below.
 
-![Domain-Results Diagram](../assets/imgs/domain_and_resultsets/ADRIA_Input_Output_diagram.png?raw=true "Domain-Results Diagram")
+![Domain-Results Diagram](../assets/imgs/domain_and_resultsets/ADRIA_Input_Output_diagram.png)
 
 ## Domain data package
 
@@ -63,10 +63,10 @@ ReefModDomain
 │       CONNECT_ACRO_2016_17.bin
 │
 ├───id # location ids
-│       id_list_2023_03_30.csv 
+│       id_list_2023_03_30.csv
 │
 └───region # geospatial data
-        reefmod_gbr.gpkg 
+        reefmod_gbr.gpkg
 ```
 
 ### ReefMod Engine datasets
@@ -153,7 +153,7 @@ Example_domain
 
 The directory holding results is also treated as a data package referred to as a `ResultSet`.
 Scenario outcomes are written out to disk as they complete to a directory located in the
-user-defined `Output` directory (see [Getting started](@ref)).
+user-defined `Output` directory (see [Getting Started](@ref)).
 
 The directory name follows the convention of `[Domain Name]__[IDs of RCPs]__[date/time of run]`.
 For example: `Moore_2022-11-17__RCPs45_60__2023-01-01_19_00_00_000`

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -128,7 +128,7 @@ fig_s_tac = ADRIA.viz.scenarios(
 save("scenarios_tac.png", fig_s_tac)
 ```
 
-![Quick scenario plots](/ADRIA.jl/dev/assets/imgs/analysis/scenarios_tac.png?raw=true "Quick scenario plot")
+![Quick scenario plots](../assets/imgs/analysis/scenarios_tac.png)
 
 And compose a figure with subplots. In the example below we also use the parameter `opts`
 that accepts the keys `by_RCP` to group scenarios by RCP (default is `false`), `legend`
@@ -158,7 +158,7 @@ tf  # display the figure
 save("aviz_scenario.png", tf)  # save the figure to a file
 ```
 
-![Scenarios with subplots](/ADRIA.jl/dev/assets/imgs/analysis/aviz_scenario.png?raw=true "Scenarios with subplots")
+![Scenarios with subplots](../assets/imgs/analysis/aviz_scenario.png)
 
 ### Intervention location selection - visualisation
 
@@ -177,7 +177,7 @@ rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, 1; fig_opts=Dict(:size=
 save("single_rank_plot.png", rank_fig)
 ```
 
-![Rank frequency plots for single rank](/ADRIA.jl/dev/assets/imgs/analysis/single_rank_plot.png?raw=true "Rank frequency plot 1 rank")
+![Rank frequency plots for single rank](../assets/imgs/analysis/single_rank_plot.png)
 
 ```julia
 # Plot 1st, 2nd and 3rd rank frequencies as an overlayed colormap
@@ -186,7 +186,7 @@ rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, [1, 2, 3]; fig_opts=Dic
 save("ranks_plot.png", rank_fig)
 ```
 
-![Rank frequency plots for multiple ranks](/ADRIA.jl/dev/assets/imgs/analysis/ranks_plot.png?raw=true "Rank frequency plot 3 ranks")
+![Rank frequency plots for multiple ranks](../assets/imgs/analysis/ranks_plot.png)
 
 ### PAWN sensitivity (heatmap overview)
 
@@ -207,7 +207,7 @@ pawn_fig = ADRIA.viz.pawn(
 save("pawn_si.png", pawn_fig)
 ```
 
-![PAWN sensitivity plots](/ADRIA.jl/dev/assets/imgs/analysis/pawn_si.png?raw=true "PAWN sensitivity plots")
+![PAWN sensitivity plots](../assets/imgs/analysis/pawn_si.png)
 
 ### Temporal Sensitivity Analysis
 
@@ -226,7 +226,7 @@ tsa_fig = ADRIA.viz.tsa(
 save("tsa.png", tsa_fig)
 ```
 
-![Plots of Temporal Sensitivities](/ADRIA.jl/dev/assets/imgs/analysis/tsa.png?raw=true "Temporal Sensitivity Analysis")
+![Plots of Temporal Sensitivities](../assets/imgs/analysis/tsa.png)
 
 
 ### Convergence Analysis
@@ -263,8 +263,8 @@ conv_hm_fig = ADRIA.viz.convergence(Si_conv, components; opts=Dict(:viz_type=>:h
 save("convergence_components_heatmap.png", conv_hm_fig)
 ```
 
-![Convergence analysis of factors overlayed](/ADRIA.jl/dev/assets/imgs/analysis/convergence_factors_series.png?raw=true "Convergence Analysis - factors")
-![Grouped convergence analysis](/ADRIA.jl/dev/assets/imgs/analysis/convergence_components_heatmap.png?raw=true "Convergence Analysis - model components as a heatmap")
+![Convergence analysis of factors overlayed](../assets/imgs/analysis/convergence_factors_series.png)
+![Grouped convergence analysis](../assets/imgs/analysis/convergence_components_heatmap.png)
 
 ### Time Series Clustering
 
@@ -297,7 +297,7 @@ tsc_fig = ADRIA.viz.clustered_scenarios(
 save("tsc.png", tsc_fig)
 ```
 
-![Plots of Time Series Cluster](/ADRIA.jl/dev/assets/imgs/analysis/tsc.png?raw=true "Time Series Cluster")
+![Plots of Time Series Cluster](../assets/imgs/analysis/tsc.png)
 
 ### Target clusters
 
@@ -330,7 +330,7 @@ tsc_asc_fig = ADRIA.viz.clustered_scenarios(
 save("tsc_asv.png", tsc_asc_fig)
 ```
 
-![Plots of targeted lowest clusters](/ADRIA.jl/dev/assets/imgs/analysis/tsc_asv.png?raw=true "Targeted lowest clusters")
+![Plots of targeted lowest clusters](../assets/imgs/analysis/tsc_asv.png)
 
 ### Multiple Time Series Clustering
 
@@ -384,7 +384,7 @@ tsc_map_fig = ADRIA.viz.map(rs, tac_sites, clusters)
 save("tsc_map.png", tsc_map_fig)
 ```
 
-![Plots of Spatial Time Series Clusters](/ADRIA.jl/dev/assets/imgs/analysis/tsc_map.png?raw=true "Spatial Time Series Cluster")
+![Plots of Spatial Time Series Clusters](../assets/imgs/analysis/tsc_map.png)
 
 ### Rule Induction (using Series Clusters)
 
@@ -428,7 +428,7 @@ rules_scatter_fig = ADRIA.viz.rules_scatter(
 save("rules_scatter.png", rules_scatter_fig)
 ```
 
-![Plots of Rule Induction](/ADRIA.jl/dev/assets/imgs/analysis/rules_scatter.png?raw=true "Rule Induction")
+![Plots of Rule Induction](../assets/imgs/analysis/rules_scatter.png)
 
 ### Regional Sensitivity Analysis
 
@@ -448,7 +448,7 @@ rsa_fig = ADRIA.viz.rsa(
 save("rsa.png", rsa_fig)
 ```
 
-![Plots of Regional Sensitivities](/ADRIA.jl/dev/assets/imgs/analysis/rsa.png?raw=true "Regional Sensitivity Analysis")
+![Plots of Regional Sensitivities](../assets/imgs/analysis/rsa.png)
 
 ### Outcome mapping
 
@@ -482,7 +482,7 @@ ADRIA.viz.outcome_map!(
 save("outcome_map.png", tf)
 ```
 
-![Outcome mapping](/ADRIA.jl/dev/assets/imgs/analysis/outcome_map.png?raw=true "Outcome mapping")
+![Outcome mapping](../assets/imgs/analysis/outcome_map.png)
 
 ### GUI for high-level exploration (prototype only!)
 
@@ -494,4 +494,4 @@ ADRIA.viz.explore("path to Result Set")
 # ADRIA.viz.explore(rs)
 ```
 
-![Standalone app for data exploration](/ADRIA.jl/dev/assets/imgs/analysis/aviz_app.png?raw=true "Data Exploration App")
+![Standalone app for data exploration](../assets/imgs/analysis/aviz_app.png)


### PR DESCRIPTION
This fixes the errors that appeared after upgrading `Documenter` from `0.27.25` to `1.5.0`

Example Error:
```
┌ Error: invalid local link/image: file does not exist in src\usage\analysis.md
│   link =
│    @ast MarkdownAST.Image("../assets/imgs/analysis/single_rank_plot.png \"title text breaks\"", "") do
│      MarkdownAST.Text("Rank frequency plots for single rank")
│    end
```

Also, ran Pkg `update`, so now we're on `1.6.0`

# Summary

title text doesn't work in current docs, and `raw=true` seems to have no effect for our largest png on GitHub. So I don't think we're losing anything with the changes in this PR.

# Notes

These errors appeared because Documenter 1.0 switched to strict mode.
https://github.com/JuliaDocs/Documenter.jl/blob/v1.6.0/CHANGELOG.md#version-v100---2023-09-15

Also, Documenter does not support image titles. 
`![alt text](url "text for title attribute")`

If we really want to use title (hover tooltip), we could ask Documenter to implement it or submit the feature. But maybe better to have this text as a caption to the image.

Documenter documentation states that `./assets` should work, but it doesn't seem to.

Also, needed to remove `?raw=true`. This makes GitHub serve the full raw image instead of a possibly downscaled one.
However, looking at one of our images deployed now, with and without raw has the same size.
https://open-aims.github.io/ADRIA.jl/dev/assets/imgs/analysis/rules_scatter.png?raw=true  
_(this is our largest image)_

## Alternative

If we want title and/or `raw=true`, Documenter lets us change this error to a warning as mentioned in 1.0 release notes.
`warnonly = :cross_references`


