### PR TITLE
convert recruitment from relative area to area before use

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -981,7 +981,7 @@ function run_model(
         survival_rate_slices = [@view survival_rate_cache[:, :, loc] for loc in 1:n_locs]
         apply_mortality!.(functional_groups, survival_rate_slices)
         recruitment .*= reshape(survival_rate_cache[:, 1, :], (n_groups, n_locs))
-        recruitment .*= habitable_loc_areas'
+        recruitment .*= loc_k_area
 
         C_cover[tstep, :, :, :] .= C_cover_t
     end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -981,6 +981,7 @@ function run_model(
         survival_rate_slices = [@view survival_rate_cache[:, :, loc] for loc in 1:n_locs]
         apply_mortality!.(functional_groups, survival_rate_slices)
         recruitment .*= reshape(survival_rate_cache[:, 1, :], (n_groups, n_locs))
+        recruitment .*= habitable_loc_areas'
 
         C_cover[tstep, :, :, :] .= C_cover_t
     end


### PR DESCRIPTION
Marking this as draft because changes would need to be made to growth constraints to consider recruits.

`CoralBlox` accepts recruitment as `area` not `relative area`. 

16 `RMEDomain` countfactuals

### Before change

<img width="485" alt="unchanged_recruitment" src="https://github.com/user-attachments/assets/06107543-9f47-46ee-a43c-b28e750fa3a0">

### After Change

<img width="496" alt="changed_recruitment" src="https://github.com/user-attachments/assets/5201bbc8-a130-4ca2-833d-92c0212e17ef">
