### PR TITLE
Cscape interface improvements

### DIFF
--- a/docs/src/usage/results.md
+++ b/docs/src/usage/results.md
@@ -31,6 +31,7 @@ data_dir
         results.nc
         scenarios.csv
 ```
+
 In order to reduce the duplication of geospatial and connectivity data, the data directory
 and results directory can be supplied separately to avoid having copies for each result set
 analysed.
@@ -39,22 +40,23 @@ analysed.
 rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>", "<path to results dir>")
 ```
 
-## Loading CScape Results
+## Loading C~scape Results
 
-Results from CScape can be loaded with the `load_results` function.
+Results from C~scape can be loaded with the `load_results` function.
 
 ```julia
-# Assumes NetCDFs are contained in result subdirectory
+# Assumes NetCDFs are contained in result subdirectory (see example directory tree below)
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>")
 
 # Retrieves NetCDFs from separate directory
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", "<path to result directory>")
 
-# Manually passes a list of files to load as results
+# Manually pass in a list of files to load as results
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
 ```
 
-The expected directory structure is
+The expected directory structure is:
+
 ```bash
 data_dir
 │   ScenarioID.csv

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -76,7 +76,7 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
-    rs::Union{RMEResultSet, CScapeResultSet},
+    rs::Union{RMEResultSet,CScapeResultSet},
     outcomes::YAXArray;
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -220,7 +220,7 @@ function coral_spec()::NamedTuple
     params.coral_id = String[join(x, "_") for x in zip(tn, params.taxa_id, params.class_id)]
 
     # Ecological parameters
-    # To be more consistent with parameters in ReefMod, C~Scape and RRAP
+    # To be more consistent with parameters in ReefMod, C~scape and RRAP
     # interventions, we express coral abundance as colony numbers in different
     # size classes and growth rates as linear extension (in cm per year).
     colony_area_mean_cm², mean_colony_diameter_m = colony_areas()

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -704,14 +704,14 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     ) .* reshape(
         area[1, :] .* dataset.k[:],
         reshape_tuple
-    ) ./ 100
+    ) ./ 100.0
 
     relative_cover .+= _drop_sum(
         dataset.cover[intervened=2], dim_sum
     ) .* reshape(
         area[2, :] .* dataset.k[:],
         reshape_tuple
-    ) ./ 100
+    ) ./ 100.0
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -708,7 +708,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
 
     area = dataset.area.data[:, :]
     relative_cover .= _drop_sum(
-        dataset.cover[intervened=1], dim_sum
+        dataset.cover[intervened=1][dummy_selector...], dim_sum
     ) .* reshape(
         area[1, :] .* dataset.k[:],
         reshape_tuple

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -558,8 +558,9 @@ Get the name of the data set from the properties of the dataset.
 function _get_result_name(ds::Dataset)::String
     name = "CScape Results"
     if !haskey(ds.properties, "title")
-        @warn "Unable to find key `title` in dataset properties, \
-               defaulting to `CScape Results`"
+        msg = "Unable to find key `title` in dataset properties, "
+        msg *= "defaulting to `CScape Results`"
+        @warn msg
     else
         name = ds.properties["title"]
     end
@@ -645,8 +646,10 @@ function reformat_cube(cscape_cube::YAXArray)::YAXArray
 end
 
 function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
-    throw(ArgumentError("NetCDF $(dataset.properties["scenario_ID"]) does not \
-                         contain $(String.(var_name)) variable"))
+    msg = "NetCDF $(dataset.properties["scenario_ID"]) does not "
+    msg *= "contain $(String.(var_name)) variable"
+    throw(ArgumentError(msg))
+
     return nothing
 end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -654,7 +654,7 @@ function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
 end
 
 """
-    drop_sum(cube::YAXArray, dims)::YAXArray
+    _drop_sum(cube::YAXArray, red_dims)::YAXArray
 
 Sum over given dimensions and drop the same given dimensions.
 """
@@ -663,9 +663,10 @@ function _drop_sum(cube::YAXArray, red_dims)::YAXArray
 end
 
 """
-    _cscape_relative_cover(dataset::Dataset; loc_mask::BitVector=[])::YAXArray
+    _cscape_relative_cover(dataset::Dataset)::YAXArray
+    _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
 
-Calculate relative cover metric for cscape data.
+Calculate relative cover metric for C~scape data.
 """
 function _cscape_relative_cover(dataset::Dataset)::Array
     # Throw error and identify specific misformatted file.
@@ -678,6 +679,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     if !haskey(dataset.cubes, :k)
         _throw_missing_variable(dataset, :k)
     end
+
     dim_sum = (:ft, :thermal_tolerance)
 
     multi_scenario::Bool = :draws in keys(dataset.axes)

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -34,7 +34,14 @@ end
     load_results(::Type{CscapeResultSet}, data_dir::String, result_dir::String)::CScapeResultSet
     load_results(::Type{CScapeResultSet}, data_dir::String, result_files::Vector{String})::CScapeResultSet
 
-Interface for loading CScape model outputs.
+Interface for loading C~scape model outputs.
+
+See the [Loading C~scape Results](@ref) section for details on expected directory structure.
+
+# Examples
+```julia
+rs = ADRIA.load_results(CScapeResultSet, "a C~scape dataset of interest")
+```
 """
 function load_results(::Type{CScapeResultSet}, data_dir::String)::CScapeResultSet
     return load_results(CScapeResultSet, data_dir, joinpath(data_dir, "results"))

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -654,11 +654,11 @@ function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
 end
 
 """
-    _drop_sum(cube::YAXArray, red_dims)::YAXArray
+    _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
 
 Sum over given dimensions and drop the same given dimensions.
 """
-function _drop_sum(cube::YAXArray, red_dims)::YAXArray
+function _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
     return dropdims(sum(cube, dims=red_dims), dims=red_dims)
 end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -759,7 +759,7 @@ function _n_scenarios(dataset::Dataset)::Int64
 end
 
 """
-    _data_position(n_per_dataset::Vector{Int})
+    _data_position(n_per_dataset::Vector{Int64})
 
 Determine the index positions of a set of data if they were collated into a single dataset.
 
@@ -783,10 +783,10 @@ start_pos, end_pos = _data_position(n_scens)
 # Returns
 The start and end position of each entry
 """
-function _data_position(n_per_dataset::Vector{Int})::Vector{Tuple{Int64, Int64}}
+function _data_position(n_per_dataset::Vector{Int64})::Vector{Tuple{Int64, Int64}}
     n = length(n_per_dataset)
-    starts = Vector{Int}(undef, n)
-    ends = Vector{Int}(undef, n)
+    starts = Vector{Int64}(undef, n)
+    ends = Vector{Int64}(undef, n)
 
     starts[1] = 1
     ends[1] = n_per_dataset[1]

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -721,9 +721,10 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     return relative_cover
 end
 function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
+    # Assume same number of locations and timesteps for every dataset
     n_locs::Int64 = length(datasets[1].reef_sites)
 
-    # Assume same number of locations and timesteps for every dataset
+    # Determine the number of entries for each file
     n_scens::Vector{Int64} = _n_scenarios.(datasets)
 
     relative_cover = ZeroDataCube(

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -698,6 +698,14 @@ function _cscape_relative_cover(dataset::Dataset)::Array
 
     # Calculate relative cover from non-intervened areas
     # Force load with dimensions [intervened ⋅ reef_sites]
+
+    # We want to read in data before any calculations are conducted to maintain
+    # speed/performance. Using `read()` converts data into a base Matrix, so we
+    # use a dummy selector to retain the nice YAXArray data type while also reading
+    # the data into memory.
+    n_dims = length(dims(dataset.cover))
+    dummy_selector = fill((:), n_dims-1)
+
     area = dataset.area.data[:, :]
     relative_cover .= _drop_sum(
         dataset.cover[intervened=1], dim_sum

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -714,12 +714,15 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         reshape_tuple
     ) ./ 100.0
 
-    relative_cover .+= _drop_sum(
-        dataset.cover[intervened=2], dim_sum
-    ) .* reshape(
-        area[2, :] .* dataset.k[:],
-        reshape_tuple
-    ) ./ 100.0
+    # Only calculate if there are area values > 0
+    if !any(area[2, :] .> 0.0)
+        relative_cover .+= _drop_sum(
+            dataset.cover[intervened=2][dummy_selector...], dim_sum
+        ) .* reshape(
+            area[2, :] .* dataset.k[:],
+            reshape_tuple
+        ) ./ 100.0
+    end
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario


### PR DESCRIPTION
Reduced ResultSet load times from \~2:10 mins to \~27 seconds for a 20 scenario dataset.
Note, improvements will be more noticeable if more each C~Scape dataset holds more than a single scenario.

Achieved by:
1. A "smarter" indexing strategy used to read C~Scape results into a common data structure
    Precalculates the indices for the scenarios in each dataset to avoid `if` branching in the loop
2. avoiding loading/calculating data where results are all zeros, 
3. reading in data into memory prior to any calculations

I've also organized the function definitions so that methods with the same names are together in the file, as per style guide.

I also applied the formatter so it passes the format check we now have in place.