### PR TITLE
Update interface to use correct gpkg

### DIFF
--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -125,7 +125,7 @@ function load_results(
         timeframe
     )
 
-    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_max_coral_cover = geodata.k ./ 100
     location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
 
     outcomes = Dict{Symbol,YAXArray}()

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -78,8 +78,6 @@ function load_results(
     gpkg_path = _get_gpkg_path(data_dir)
     geodata = GDF.read(gpkg_path)
 
-    geodata = _manual_site_additions(geodata, location_ids, raw_set)
-
     connectivity_path = joinpath(data_dir, "connectivity/connectivity.csv")
     connectivity = CSV.read(connectivity_path, DataFrame; comment="#", header=true)
 
@@ -155,50 +153,6 @@ function load_results(
         outcomes,
         reformat_cube(raw_set.coral_size_diameter)
     )
-end
-
-"""
-    _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
-
-Add missing sites to geopackage
-"""
-function _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
-    row_indx::Int64 = findfirst(x -> x == "Moore_MR_S_39", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Moore_MR_S_40", loc_ids)
-    geodata[end, :site_id] = "MR_S_40"
-    geodata[end, :reef_siteid] = "Moore_MR_S_40"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Milln_MR_OF_3", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Milln_MR_OF_4", loc_ids)
-    geodata[end, :site_id] = "MR_OF_4"
-    geodata[end, :reef_siteid] = "Milln_MR_OF_4"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Elford_ER_S_50", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Elford_ER_S_51", loc_ids)
-    geodata[end, :site_id] = "ER_S_51"
-    geodata[end, :reef_siteid] = "Elford_ER_S_51"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Elford_ER_S_50", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Elford_ER_S_52", loc_ids)
-    geodata[end, :site_id] = "ER_S_52"
-    geodata[end, :reef_siteid] = "Elford_ER_S_52"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-    return geodata
 end
 
 """

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -9,13 +9,13 @@ struct CScapeResultSet <: ResultSet
     name::String
     RCP::String
 
-    site_ids
-    site_area::Vector{Float64}
-    site_max_coral_cover::Vector{Float64}
-    site_centroids
+    loc_ids
+    loc_area::Vector{Float64}
+    loc_max_coral_cover::Vector{Float64}
+    loc_centroids
     env_layer_md::EnvLayer
     connectivity_data
-    site_data
+    loc_data
     scenario_groups
     raw_data::Vector{Dataset}
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -732,7 +732,8 @@ function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
     # all(diff(cumsum(n_scens)) .== 1)
 
     start_end_pos = _data_position(n_scens)
-    @showprogress desc="Loading datasets" for (ds_idx, dataset) in zip(start_end_pos, datasets)
+    @showprogress desc = "Loading datasets" for (ds_idx, dataset) in
+                                                zip(start_end_pos, datasets)
         relative_cover[scenarios=ds_idx[1]:ds_idx[2]] = _cscape_relative_cover(dataset)
     end
 


### PR DESCRIPTION
1. Correct the calculation of maximum available coral cover in result loading
2. Remove the manual site data correction (new dpkg available on teams in ADRIA result sets, `cscape_dpkg_2024_09_16.zip`)
3. Use `loc` instead of `site` to maintain compatability with existing `ResultSet`

closes #849 