### PR TITLE
correct calculation of relative cover

### DIFF
--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -691,9 +691,9 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         _drop_sum(
             dataset.cover[intervened=1][dummy_selector...], dim_sum
         ) .* reshape(
-            area[1, :] .* dataset.k[:],
+            area[1, :],
             reshape_tuple
-        ) ./ 100.0 # k area in %
+        )
 
     # Only calculate if there are area values > 0
     if !any(area[2, :] .> 0.0)
@@ -701,13 +701,13 @@ function _cscape_relative_cover(dataset::Dataset)::Array
             _drop_sum(
                 dataset.cover[intervened=2][dummy_selector...], dim_sum
             ) .* reshape(
-                area[2, :] .* dataset.k[:],
+                area[2, :],
                 reshape_tuple
-            ) ./ 100.0 # k area in %
+            )
     end
 
     relative_cover ./= reshape(
-        sum(area; dims=1), reshape_tuple
+        sum(area; dims=1) .* dataset.k' ./ 100, reshape_tuple
     ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -693,7 +693,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         ) .* reshape(
             area[1, :] .* dataset.k[:],
             reshape_tuple
-        ) ./ 100.0
+        ) ./ 100.0 # k area in %
 
     # Only calculate if there are area values > 0
     if !any(area[2, :] .> 0.0)
@@ -703,8 +703,12 @@ function _cscape_relative_cover(dataset::Dataset)::Array
             ) .* reshape(
                 area[2, :] .* dataset.k[:],
                 reshape_tuple
-            ) ./ 100.0
+            ) ./ 100.0 # k area in %
     end
+
+    relative_cover ./= reshape(
+        sum(area, dims=1), reshape_tuple
+    ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -707,7 +707,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     end
 
     relative_cover ./= reshape(
-        sum(area, dims=1), reshape_tuple
+        sum(area; dims=1), reshape_tuple
     ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]


### PR DESCRIPTION
Corrections to relative cover calculations.

1. Divide by area of each location (summing intervened and non-intervened area)
2. Divide by 100 to convert percentage to proportion.