### PR TITLE
Speed up CScape Result Interface

### DIFF
--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -280,7 +280,8 @@ function _create_inputs_dataframe(
     input_index::Int
 )::DataFrame
     functional_types::Vector{String} = _get_functional_types(nc_handle)
-    n_draws::Int = "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
+    n_draws::Int =
+        "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
 
     dhws::Vector{Float64} = Float64.(repeat([input_index], n_draws))
     cyclones::Vector{Float64} = Float64.(repeat([input_index], n_draws))
@@ -686,7 +687,7 @@ function _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
     return dropdims(sum(cube; dims=red_dims); dims=red_dims)
 end
 function _drop_sum(cube::AbstractArray, red_dims::Tuple)::AbstractArray
-    return dropdims(sum(cube; dims=red_dims), dims=red_dims)
+    return dropdims(sum(cube; dims=red_dims); dims=red_dims)
 end
 
 """
@@ -755,9 +756,10 @@ function _cscape_relative_cover(nc_handle::NcFile)::Array
             )
     end
 
-    relative_cover ./= reshape(
-        sum(area; dims=1) .* habitable_area' ./ 100, reshape_tuple
-    ) .* 100
+    relative_cover ./=
+        reshape(
+            sum(area; dims=1) .* habitable_area' ./ 100, reshape_tuple
+        ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario
@@ -885,11 +887,12 @@ function load_variable!(
     agg_func = x -> NetCDF.readvar(x[var_name])
     if :thermal_tolerance in _ncvar_dim_names(rs.raw_data[1].vars[var_name])
         thermal_tol_dim_idx::Int64 = findfirst(
-            x->x==:thermal_tolerance,
+            x -> x == :thermal_tolerance,
             _ncvar_dim_names(rs.raw_data[1].vars[var_name])
         )
         agg_func =
-            x -> dropdims(aggregate_ttol(
+            x -> dropdims(
+                aggregate_ttol(
                     NetCDF.readvar(x[var_name]); dims=thermal_tol_dim_idx
                 ); dims=thermal_tol_dim_idx)
     end


### PR DESCRIPTION
Use the [NetCDF.jl](https://github.com/JuliaGeo/NetCDF.jl) api instead of [YAXArrays](https://github.com/JuliaDataCubes/YAXArrays.jl) to load netcdf data.

Loading 22 files now takes around 1 second.

![image](https://github.com/user-attachments/assets/56b4f218-20e4-4cac-9719-a530f0e96e08)


Loading a variable from 22 files takes around 1 second as well.

![image](https://github.com/user-attachments/assets/be6b6bfd-8631-4ea8-a081-4ecb79e8c6bf)


It would be good to see if this scales well to 2000 files.

## Relative cover of random files downloaded

![image](https://github.com/user-attachments/assets/8a5a9c55-e960-4847-8c7a-4594d3f25a1c)
