### PR TITLE
Improve summarize performance by using mapslices

### DIFF
--- a/src/metrics/site_level.jl
+++ b/src/metrics/site_level.jl
@@ -93,7 +93,7 @@ function summarize(
     available_ram = Sys.free_memory() * 0.7
     data_size = sizeof(eltype(data)) * length(data)
 
-    # Only use this approach when data occupies more than 70% of available space in RAM
+    # Only use this approach when data occupies more than 70% of available RAM
     if data_size > available_ram
         # `D.` is ensuring the returned YAXArray has the same type as the input `data`
         return D.(mapslices(metric, data; dims=alongs_axis))

--- a/src/metrics/site_level.jl
+++ b/src/metrics/site_level.jl
@@ -91,7 +91,7 @@ function summarize(
     # Use of JuliennedArrays is in an attempt to speed up calculation of summary statistics.
     #   We see a small but still worthwhile improvement in practice.
     #   see: https://stackoverflow.com/a/62040897
-    data_slices = JuliennedArrays.Slices(data.data, alongs...)
+    data_slices = JuliennedArrays.Slices(read(data), alongs...)
     summarized_data = map(metric, data_slices)
 
     new_dims = setdiff(axes_names(data), alongs_axis)

--- a/src/metrics/site_level.jl
+++ b/src/metrics/site_level.jl
@@ -86,6 +86,13 @@ YAXArray with summary metric for the remaining axis.
 function summarize(
     data::YAXArray{D,T,N,A}, alongs_axis::Vector{Symbol}, metric::Function
 )::YAXArray where {D,T,N,A}
+    # Check if there's enough space to read(data)
+    data_size = Base.summarysize(data)
+    free_ram = Sys.free_memory()
+    if data_size > free_ram
+        return D.(mapslices(metric, data; dims=alongs_axis))
+    end
+
     alongs = sort([axis_index(data, axis) for axis in alongs_axis])
 
     # Use of JuliennedArrays is in an attempt to speed up calculation of summary statistics.

--- a/src/metrics/site_level.jl
+++ b/src/metrics/site_level.jl
@@ -90,12 +90,11 @@ function summarize(
     # mapslices only when we `read(data)`. Since `read(data)` loads all the data from disk
     # into memory, we only want to use that approach when there is a reasonable amount of
     # available space in RAM
-    data_size = Base.summarysize(data)
-    free_ram = Sys.free_memory()
-    proportional_usage = data_size / free_ram
+    available_ram = Sys.free_memory() * 0.7
+    data_size = sizeof(eltype(data)) * length(data)
 
     # Only use this approach when data occupies more than 70% of available space in RAM
-    if proportional_usage > 0.7 * free_ram
+    if data_size > available_ram
         # `D.` is ensuring the returned YAXArray has the same type as the input `data`
         return D.(mapslices(metric, data; dims=alongs_axis))
     end


### PR DESCRIPTION
The previous approach, using JuliannedArrays.Slices, is taking too much to run for some unknown reason. Using `mapslices` seems to fix the problem.

closes #788 
