### PR TITLE
Viz metadata

### DIFF
--- a/ext/AvizExt/outcome_metadata.jl
+++ b/ext/AvizExt/outcome_metadata.jl
@@ -2,11 +2,27 @@ function outcome_title(outcomes::YAXArray)::String
     return get(outcomes.properties, :metric_name, "")
 end
 
-function outcome_label(outcomes::YAXArray; label_case=titlecase)::String
+function set_plot_opts!(
+    outcomes::AbstractArray,
+    opts::OPT_TYPE,
+    opts_key::Symbol;
+    metadata_key::Symbol=:metric_feature,
+    label_case=titlecase
+)
+    if !haskey(opts, opts_key) && (outcomes isa YAXArray)
+        opts[opts_key] = outcome_label(
+            outcomes; metadata_key=metadata_key, label_case=label_case
+        )
+    end
+end
+
+function outcome_label(
+    outcomes::YAXArray; metadata_key::Symbol=:metric_feature, label_case=titlecase
+)::String
     outcome_metadata = outcomes.properties
 
-    return if all(haskey.([outcome_metadata], [:metric_feature, :metric_unit]))
-        _metric_feature = label_case(outcome_metadata[:metric_feature])
+    return if all(haskey.([outcome_metadata], [metadata_key, :metric_unit]))
+        _metric_feature = label_case(outcome_metadata[metadata_key])
         _metric_label = if !isempty(outcome_metadata[:metric_unit])
             "[$(outcome_metadata[:metric_unit])]"
         else

--- a/ext/AvizExt/outcome_metadata.jl
+++ b/ext/AvizExt/outcome_metadata.jl
@@ -21,15 +21,14 @@ function outcome_label(
 )::String
     outcome_metadata = outcomes.properties
 
-    return if all(haskey.([outcome_metadata], [metadata_key, :metric_unit]))
+    _outcome_label = if all(haskey.([outcome_metadata], [metadata_key, :metric_unit]))
         _metric_feature = label_case(outcome_metadata[metadata_key])
-        _metric_label = if !isempty(outcome_metadata[:metric_unit])
-            "[$(outcome_metadata[:metric_unit])]"
-        else
-            ""
-        end
+        _metric_unit = outcome_metadata[:metric_unit]
+        _metric_label = !isempty(_metric_unit) ? "[$(_metric_unit)]" : ""
         "$(_metric_feature) $(_metric_label)"
     else
         ""
     end
+
+    return _outcome_label
 end

--- a/ext/AvizExt/outcome_metadata.jl
+++ b/ext/AvizExt/outcome_metadata.jl
@@ -1,0 +1,14 @@
+function outcome_title(outcomes::YAXArray)::String
+    return get(outcomes.properties, :metric_name, "")
+end
+
+function outcome_label(outcomes::YAXArray)::String
+    outcome_metadata = outcomes.properties
+
+    return if haskey(outcome_metadata, :metric_feature) &&
+        haskey(outcome_metadata, :metric_unit)
+        "$(outcome_metadata[:metric_feature]) [$(outcome_metadata[:metric_unit])]"
+    else
+        ""
+    end
+end

--- a/ext/AvizExt/outcome_metadata.jl
+++ b/ext/AvizExt/outcome_metadata.jl
@@ -7,7 +7,12 @@ function outcome_label(outcomes::YAXArray; label_case=titlecase)::String
 
     return if all(haskey.([outcome_metadata], [:metric_feature, :metric_unit]))
         _metric_feature = label_case(outcome_metadata[:metric_feature])
-        "$(_metric_feature) [$(outcome_metadata[:metric_unit])]"
+        _metric_label = if !isempty(outcome_metadata[:metric_unit])
+            "[$(outcome_metadata[:metric_unit])]"
+        else
+            ""
+        end
+        "$(_metric_feature) $(_metric_label)"
     else
         ""
     end

--- a/ext/AvizExt/outcome_metadata.jl
+++ b/ext/AvizExt/outcome_metadata.jl
@@ -2,12 +2,12 @@ function outcome_title(outcomes::YAXArray)::String
     return get(outcomes.properties, :metric_name, "")
 end
 
-function outcome_label(outcomes::YAXArray)::String
+function outcome_label(outcomes::YAXArray; label_case=titlecase)::String
     outcome_metadata = outcomes.properties
 
-    return if haskey(outcome_metadata, :metric_feature) &&
-        haskey(outcome_metadata, :metric_unit)
-        "$(outcome_metadata[:metric_feature]) [$(outcome_metadata[:metric_unit])]"
+    return if all(haskey.([outcome_metadata], [:metric_feature, :metric_unit]))
+        _metric_feature = label_case(outcome_metadata[:metric_feature])
+        "$(_metric_feature) [$(outcome_metadata[:metric_unit])]"
     else
         ""
     end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -105,7 +105,7 @@ Visualize clustered time series for each location and map.
 
 # Arguments
 - `rs` : ResultSet
-- `data` : Vector of summary statistics data for each location
+- `loc_outcomes` : Vector of summary statistics data for each location
 - `clusters` : Vector of numbers corresponding to clusters
 - `opts` : Options specific to this plotting method
     - `highlight` : Vector of colors indicating cluster membership for each location.
@@ -117,7 +117,7 @@ Figure
 """
 function ADRIA.viz.map(
     rs::Union{Domain,ResultSet},
-    data::AbstractArray{<:Real},
+    loc_outcomes::AbstractVector{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
@@ -125,14 +125,21 @@ function ADRIA.viz.map(
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
-    ADRIA.viz.map!(g, rs, data, clusters; opts=opts, axis_opts=axis_opts)
+
+    if !haskey(axis_opts, :title)
+        axis_opts[:title] = "$(outcome_title(loc_outcomes)) Clusters"
+    end
+
+    opts[:colorbar_label] = get(opts, :colorbar_label, outcome_label(loc_outcomes))
+
+    ADRIA.viz.map!(g, rs, loc_outcomes, clusters; opts=opts, axis_opts=axis_opts)
 
     return f
 end
 function ADRIA.viz.map!(
     g::Union{GridLayout,GridPosition},
     rs::Union{Domain,ResultSet},
-    data::AbstractVector{<:Real},
+    loc_outcomes::AbstractVector{<:Real},
     clusters::Union{BitVector,Vector{Int64}};
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
@@ -141,7 +148,7 @@ function ADRIA.viz.map!(
     loc_groups::Dict{Symbol,BitVector} = ADRIA.analysis.scenario_clusters(clusters)
     group_colors::Dict{Symbol,Union{Symbol,RGBA{Float32}}} = colors(loc_groups)
 
-    legend_params::Tuple = _cluster_legend_params(data, loc_groups, group_colors)
+    legend_params::Tuple = _cluster_legend_params(loc_outcomes, loc_groups, group_colors)
 
     _colors::Vector{Union{Symbol,RGBA{Float32}}} = Vector{Union{Symbol,RGBA{Float32}}}(
         undef, length(clusters)
@@ -154,7 +161,7 @@ function ADRIA.viz.map!(
     opts[:highlight] = get(opts, :highlight, _colors)
     opts[:legend_params] = get(opts, :legend_params, legend_params)
 
-    ADRIA.viz.map!(g, rs, data; opts=opts, axis_opts=axis_opts)
+    ADRIA.viz.map!(g, rs, loc_outcomes; opts=opts, axis_opts=axis_opts)
 
     return g
 end
@@ -191,7 +198,7 @@ function _cluster_legend_params(
 
     legend_labels =
         labels(group_keys) .* ": " .* ADRIA.to_scientific.(label_means, digits=2)
-    legend_title = "Cluster mean"
+    legend_title = "Cluster mean $(outcome_label(data; label_case=lowercase))"
 
     return (legend_entries, legend_labels, legend_title)
 end

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -79,6 +79,10 @@ function ADRIA.viz.clustered_scenarios(
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
+    if !haskey(axis_opts, :title)
+        axis_opts[:title] = "$(outcome_title(outcomes)) Clusters"
+    end
+
     return ADRIA.viz.scenarios(
         outcomes, clusters; opts=opts, fig_opts=fig_opts, axis_opts=axis_opts
     )

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -120,17 +120,13 @@ function ADRIA.viz.map(
     loc_outcomes::AbstractVector{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
-    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
-    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )::Figure
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 
-    if !haskey(axis_opts, :title)
-        axis_opts[:title] = "$(outcome_title(loc_outcomes)) Clusters"
-    end
-
-    opts[:colorbar_label] = get(opts, :colorbar_label, outcome_label(loc_outcomes))
+    set_plot_opts!(loc_outcomes, opts, :colorbar_label)
 
     ADRIA.viz.map!(g, rs, loc_outcomes, clusters; opts=opts, axis_opts=axis_opts)
 

--- a/ext/AvizExt/viz/clustering.jl
+++ b/ext/AvizExt/viz/clustering.jl
@@ -120,9 +120,13 @@ function ADRIA.viz.map(
     loc_outcomes::AbstractVector{<:Real},
     clusters::Union{BitVector,AbstractVector{Int64}};
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
-    fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )::Figure
+    # Setup fig_opts size before the other default fig_opts
+    fig_opts[:size] = get(fig_opts, :size, (800, 700))
+    set_figure_defaults(fig_opts)
+
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 

--- a/ext/AvizExt/viz/rule_extraction.jl
+++ b/ext/AvizExt/viz/rule_extraction.jl
@@ -34,11 +34,17 @@ function ADRIA.viz.rules_scatter(
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
-    f = Figure(; fig_opts...)
-    g = f[1, 1] = GridLayout()
-
     # For now we only plot conditions with two clauses
     rules = filter(r -> length(r.condition) == 2, rules)
+
+    # Setup figure size
+    n_rows = ceil(10 / 4)
+    base_width = 1200
+    base_height = n_rows * base_width / 5
+    fig_opts[:size] = get(fig_opts, :size, (base_width, base_height))
+
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
 
     ADRIA.viz.rules_scatter!(
         g, rs, scenarios, clusters, rules; opts=opts, axis_opts=axis_opts

--- a/ext/AvizExt/viz/rule_extraction.jl
+++ b/ext/AvizExt/viz/rule_extraction.jl
@@ -141,6 +141,11 @@ function ADRIA.viz.rules_scatter!(
         margin=(5, 5, 5, 5)
     )
 
+    Label(
+        g[1, :, Top()], "SIRUS extracted rules"; padding=(0, 0, 50, 0), font=:bold,
+        valign=:bottom
+    )
+
     return g
 end
 

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -184,7 +184,7 @@ function ADRIA.viz.scenarios!(
         _render_legend(g, scen_groups, legend_position, legend_labels)
     end
 
-    ax.xlabel = "Time [years]"
+    ax.xlabel = "Year"
     ax.ylabel = outcome_label(outcomes)
     return g
 end

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -129,6 +129,11 @@ function ADRIA.viz.scenarios!(
     # Ensure last year is always shown in x-axis
     xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
     xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
+
+    if !haskey(axis_opts, :title)
+        axis_opts[:title] = outcome_title(outcomes)
+    end
+
     ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
 
     _scenarios = copy(scenarios[1:end .∈ [outcomes.scenarios], :])
@@ -179,9 +184,8 @@ function ADRIA.viz.scenarios!(
         _render_legend(g, scen_groups, legend_position, legend_labels)
     end
 
-    ax.xlabel = "Year"
-    # ax.ylabel = metric_label(metric)
-
+    ax.xlabel = "Time [years]"
+    ax.ylabel = outcome_label(outcomes)
     return g
 end
 
@@ -198,7 +202,7 @@ function _confints(
     agg_dim = symdiff(axes_names(outcomes), [:timesteps])[1]
     for (idx, group) in enumerate(group_names)
         confints[:, idx, :] = series_confint(
-            outcomes[:, scen_groups[group]]; agg_dim=agg_dim
+            outcomes.data[:, scen_groups[group]]; agg_dim=agg_dim
         )
     end
 

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -182,6 +182,8 @@ function ADRIA.viz.map(
     fig_opts::OPT_TYPE=set_figure_defaults(DEFAULT_OPT_TYPE()),
     axis_opts::OPT_TYPE=set_axis_defaults(DEFAULT_OPT_TYPE())
 )
+    set_plot_opts!(y, opts, :colorbar_label; metadata_key=:metric_name)
+
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
 

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -139,6 +139,10 @@ function ADRIA.viz.taxonomy!(
         )
     end
 
+    Label(
+        g[1, :, Top()], "Taxa dynamics"; padding=(0, 0, 30, 0), font=:bold, valign=:bottom
+    )
+
     return g
 end
 

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -20,12 +20,12 @@ ADRIA.viz.taxonomy(scenarios, relative_taxa_cover)
 # Arguments
 - `rs` : ADRIA result set
 - `scenarios` : Scenario specification
-- `relative_taxa_cover` : YAXArray of dimensions [timesteps ⋅ taxa ⋅ scenarios]
+- `relative_taxa_cover` : YAXArray of dimensions [timesteps ⋅ species ⋅ scenarios]
 - `opts` : Aviz options
     - `by_RCP` : Split plots by RCP otherwise split by scenario type. Defaults to false.
     - `by_functional_groups` : If true, split plots by scenario types, otherwise split by taxonomy. Defaults to true.
     - `show_confints` : Show confidence intervals around series. Defaults to true.
-    - `colors` : Colormap for each taxonomy or scenario type. Defaults to Set1_5 for taxa and ADRIA defaults for scenario type.
+    - `colors` : Colormap for each taxonomy or scenario type. Defaults to Set1_5 for species and ADRIA defaults for scenario type.
 - `axis_opts` : Additional options to pass to adjust Axis attributes.
   See: https://docs.makie.org/v0.19/api/index.html#Axis
 - `series_opts` : Additional options to pass to adjust Series attributes
@@ -103,7 +103,7 @@ function ADRIA.viz.taxonomy!(
     by_functional_groups::Bool = get(opts, :by_functional_groups, true)
     if by_functional_groups
         # Create colors
-        n_functional_groups::Int64 = length(relative_taxa_cover.taxa)
+        n_functional_groups::Int64 = length(relative_taxa_cover.species)
         default_color = Symbol("Set1_" * string(n_functional_groups))
         color = get(opts, :colors, default_color)
         _colors = categorical_colors(color, n_functional_groups)
@@ -193,12 +193,13 @@ function taxonomy_by_intervention!(
     series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Nothing where {T<:Float32}
     n_timesteps::Int64 = length(relative_taxa_cover.timesteps)
-    n_functional_groups::Int64 = length(relative_taxa_cover.taxa)
+    functional_groups::Vector{Int64} = ADRIA.axis_labels(relative_taxa_cover, :species)
+    n_functional_groups::Int64 = length(functional_groups)
 
     # Plot and calculate confidence intervals
     confints = zeros(n_timesteps, n_functional_groups, 3)
-    for (idx, taxa) in enumerate(relative_taxa_cover.taxa)
-        confints[:, idx, :] = series_confint(relative_taxa_cover[taxa=At(taxa)])
+    for (idx, group) in enumerate(functional_groups)
+        confints[:, idx, :] = series_confint(relative_taxa_cover[species=At(group)])
         show_confints ?
         band!(
             ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
@@ -247,7 +248,7 @@ function intervention_by_taxonomy!(
 
         intervention_by_taxonomy!(
             ax,
-            relative_taxa_cover[taxa=idx],
+            relative_taxa_cover[species=idx],
             colors,
             scen_groups;
             show_confints=show_confints,

--- a/ext/AvizExt/viz/viz.jl
+++ b/ext/AvizExt/viz/viz.jl
@@ -85,6 +85,7 @@ function _calc_gridsize(n_factors::Int64; max_cols::Int64=4)::Tuple{Int64,Int64}
     return n_rows, n_cols
 end
 
+include("../outcome_metadata.jl")
 include("scenarios.jl")
 include("sensitivity.jl")
 include("clustering.jl")

--- a/src/metrics/metadata.jl
+++ b/src/metrics/metadata.jl
@@ -1,0 +1,72 @@
+const METRIC_METADATA = (:metric_name, :metric_feature, :is_relative, :metric_unit)
+const AXIS_METADATA = (:axes_names, :axes_units)
+
+function metadata(outcomes::YAXArray)::Dict{Symbol,Any}
+    return outcomes.properties
+end
+
+"""
+    fill_metadata!(outcomes::YAXArray, metric::Metric)::Nothing
+    fill_metadata!(outcomes::YAXArray; kwargs...)::Nothing
+
+Fill `:axes_names` and `:axes_units` properties of the datacube.
+
+# Arguments
+- `outcomes` : YAXArray datacube of metric outcomes
+- `metric` : ADRIA.metrics.Metric object
+"""
+function fill_metadata!(
+    outcomes::YAXArray{T,N,A}, metric::Metric
+)::YAXArray{T,N,A} where {T,N,A}
+    fill_axes_metadata!(@views(outcomes))
+
+    outcomes.properties[:metric_name] = to_string(metric; is_titlecase=true)
+    outcomes.properties[:metric_feature] = metric.feature
+    outcomes.properties[:is_relative] = metric.is_relative
+    outcomes.properties[:metric_unit] = metric.unit
+
+    return outcomes
+end
+function fill_metadata!(
+    outcomes::YAXArray{T,N,A}, metadata::Dict{Symbol,Any}
+)::YAXArray{T,N,A} where {T,N,A}
+    # If `outcomes.properties`` is not a Dict{Symbol,Any} we need to build a new cube
+    # because `properties`` type can't be updated
+    if !(typeof(outcomes.properties) == Dict{Symbol,Any})
+        _axis_names = axes_names(outcomes)
+        _axis_labels = axis_labels.([outcomes], _axis_names)
+        outcomes = DataCube(outcomes.data; NamedTuple{_axis_names}(_axis_labels)...)
+    end
+
+    fill_axes_metadata!(@views(outcomes))
+
+    for metric_metadata in METRIC_METADATA
+        if haskey(metadata, metric_metadata)
+            outcomes.properties[metric_metadata] = metadata[metric_metadata]
+        else
+            @warn "Metric metadata \"$metric_metadata\" not found and won't be filled."
+        end
+    end
+
+    return outcomes
+end
+
+function fill_axes_metadata!(outcomes::YAXArray)::Nothing
+    _axes_names::Tuple = axes_names(outcomes)
+    outcomes.properties[:axes_names] = collect(
+        parentmodule(metrics).human_readable_name.(
+            _axes_names
+        )
+    )
+    outcomes.properties[:axes_units] = collect(axes_units(_axes_names))
+    return nothing
+end
+
+"""
+    axes_units(axes_names::Tuple)::Tuple
+
+Units for each metric axis.
+"""
+function axes_units(axes_names::Union{Vector{Symbol},Tuple})::Tuple
+    return values((timesteps="years", species="", locations="", scenarios="")[axes_names])
+end

--- a/src/metrics/metadata.jl
+++ b/src/metrics/metadata.jl
@@ -1,19 +1,25 @@
 const METRIC_METADATA = (:metric_name, :metric_feature, :is_relative, :metric_unit)
 const AXIS_METADATA = (:axes_names, :axes_units)
 
+"""
+    metadata(outcomes::YAXArray)::Dict{Symbol,Any}
+
+Helper function to extract metadata from YAXArrays.
+"""
 function metadata(outcomes::YAXArray)::Dict{Symbol,Any}
     return outcomes.properties
 end
 
 """
-    fill_metadata!(outcomes::YAXArray, metric::Metric)::Nothing
-    fill_metadata!(outcomes::YAXArray; kwargs...)::Nothing
+    fill_metadata!(outcomes::YAXArray{T,N,A}, metric::Metric)::YAXArray{T,N,A} where {T,N,A}
+    fill_metadata!(outcomes::YAXArray{T,N,A}, metadata::Dict{Symbol,Any})::YAXArray{T,N,A} where {T,N,A}
 
-Fill `:axes_names` and `:axes_units` properties of the datacube.
+Fill outcomes YAXArray metadata (`properties` attribute).
 
 # Arguments
-- `outcomes` : YAXArray datacube of metric outcomes
-- `metric` : ADRIA.metrics.Metric object
+- `outcomes` : YAXArray datacube of metric outcomes.
+- `metric` : ADRIA.metrics.Metric object.
+- `metadata` : Dict to be used to fill outcomes metrics metadata.
 """
 function fill_metadata!(
     outcomes::YAXArray{T,N,A}, metric::Metric
@@ -51,6 +57,11 @@ function fill_metadata!(
     return outcomes
 end
 
+"""
+    fill_axes_metadata!(outcomes::YAXArray)::Nothing
+
+Fill outcomes axes metadata.
+"""
 function fill_axes_metadata!(outcomes::YAXArray)::Nothing
     _axes_names::Tuple = axes_names(outcomes)
     outcomes.properties[:axes_names] = collect(
@@ -63,9 +74,9 @@ function fill_axes_metadata!(outcomes::YAXArray)::Nothing
 end
 
 """
-    axes_units(axes_names::Tuple)::Tuple
+    axes_units(axes_names::Union{Vector{Symbol},Tuple})::Tuple
 
-Units for each metric axis.
+Get units for each metric axis.
 """
 function axes_units(axes_names::Union{Vector{Symbol},Tuple})::Tuple
     return values((timesteps="years", species="", locations="", scenarios="")[axes_names])

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -29,10 +29,12 @@ const IS_NOT_RELATIVE = false
 struct Metric{F<:Function,T<:Tuple,S<:String,B<:Bool} <: Outcome
     func::F
     dims::T     # output dimension axes ?
+    feature::S
     is_relative::B
     unit::S
 end
-Metric(f, d, r) = Metric(f, d, r, "")
+
+Metric(func, dims, feature, is_relative) = Metric(func, dims, feature, is_relative, "")
 
 """
     (f::Metric)(raw, args...; kwargs...)
@@ -70,7 +72,9 @@ end
 function _relative_cover(rs::ResultSet)::YAXArray{<:Real}
     return rs.outcomes[:relative_cover]
 end
-relative_cover = Metric(_relative_cover, (:timesteps, :locations, :scenarios), IS_RELATIVE)
+relative_cover = Metric(
+    _relative_cover, (:timesteps, :locations, :scenarios), "Relative Cover", IS_RELATIVE
+)
 
 """
     total_absolute_cover(X::AbstractArray{<:Real}, k_area::Vector{<:Real})::AbstractArray{<:Real}
@@ -96,7 +100,11 @@ function _total_absolute_cover(rs::ResultSet)::AbstractArray{<:Real}
     return _total_absolute_cover(rs.outcomes[:relative_cover], site_k_area(rs))
 end
 total_absolute_cover = Metric(
-    _total_absolute_cover, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE, UNIT_AREA
+    _total_absolute_cover,
+    (:timesteps, :locations, :scenarios),
+    "Cover",
+    IS_NOT_RELATIVE,
+    UNIT_AREA
 )
 
 """
@@ -144,7 +152,7 @@ function _relative_taxa_cover(rs::ResultSet)::AbstractArray{<:Real,3}
     return rs.outcomes[:relative_taxa_cover]
 end
 relative_taxa_cover = Metric(
-    _relative_taxa_cover, (:timesteps, :species, :scenarios), IS_RELATIVE
+    _relative_taxa_cover, (:timesteps, :species, :scenarios), "Cover", IS_RELATIVE
 )
 
 """
@@ -183,7 +191,10 @@ function _relative_loc_taxa_cover(
     return replace!(taxa_cover, NaN => 0.0)
 end
 relative_loc_taxa_cover = Metric(
-    _relative_loc_taxa_cover, (:timesteps, :species, :locations, :scenarios), IS_RELATIVE
+    _relative_loc_taxa_cover,
+    (:timesteps, :species, :locations, :scenarios),
+    "Relative Cover",
+    IS_RELATIVE
 )
 
 """
@@ -210,7 +221,7 @@ function _relative_juveniles(rs::ResultSet)::AbstractArray{<:Real,3}
     return rs.outcomes[:relative_juveniles]
 end
 relative_juveniles = Metric(
-    _relative_juveniles, (:timesteps, :locations, :scenarios), IS_RELATIVE
+    _relative_juveniles, (:timesteps, :locations, :scenarios), "Relative Cover", IS_RELATIVE
 )
 
 """
@@ -234,7 +245,11 @@ function _absolute_juveniles(rs::ResultSet)::AbstractArray{<:Real,3}
     return rs.outcomes[:relative_juveniles] .* site_k_area(rs)'
 end
 absolute_juveniles = Metric(
-    _absolute_juveniles, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE, UNIT_AREA
+    _absolute_juveniles,
+    (:timesteps, :locations, :scenarios),
+    "Cover",
+    IS_NOT_RELATIVE,
+    UNIT_AREA
 )
 
 """
@@ -282,7 +297,10 @@ function _juvenile_indicator(rs::ResultSet)::AbstractArray{<:Real,3}
     return rs.outcomes[:juvenile_indicator]
 end
 juvenile_indicator = Metric(
-    _juvenile_indicator, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE,
+    _juvenile_indicator,
+    (:timesteps, :locations, :scenarios),
+    "Density Indicator",
+    IS_NOT_RELATIVE,
     UNIT_AREA_INVERSE)
 
 """
@@ -323,7 +341,10 @@ function _coral_evenness(rs::ResultSet)::AbstractArray{<:Real,3}
     return rs.outcomes[:coral_evenness]
 end
 coral_evenness = Metric(
-    _coral_evenness, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE
+    _coral_evenness,
+    (:timesteps, :locations, :scenarios),
+    "Evenness Indicator",
+    IS_NOT_RELATIVE
 )
 
 """
@@ -567,7 +588,10 @@ function _absolute_shelter_volume(rs::ResultSet)::AbstractArray
     return rs.outcomes[:absolute_shelter_volume]
 end
 absolute_shelter_volume = Metric(
-    _absolute_shelter_volume, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE,
+    _absolute_shelter_volume,
+    (:timesteps, :locations, :scenarios),
+    "Volume",
+    IS_NOT_RELATIVE,
     UNIT_VOLUME
 )
 
@@ -702,7 +726,10 @@ function _relative_shelter_volume(rs::ResultSet)::YAXArray
     return rs.outcomes[:relative_shelter_volume]
 end
 relative_shelter_volume = Metric(
-    _relative_shelter_volume, (:timesteps, :locations, :scenarios), IS_RELATIVE
+    _relative_shelter_volume,
+    (:timesteps, :locations, :scenarios),
+    "Relative Volume",
+    IS_RELATIVE
 )
 
 include("pareto.jl")

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -44,10 +44,10 @@ Makes Metric types callable with arbitary arguments that are passed to associate
 """
 function (f::Metric)(raw, args...; kwargs...)::YAXArray
     axes::Tuple = (:timesteps, :species, :locations, :scenarios)[1:ndims(raw)]
-    return fill_metadata!(@views(f.func(DataCube(raw, axes), args...; kwargs...)), f)
+    return fill_metadata!(f.func(DataCube(raw, axes), args...; kwargs...), f)
 end
 function (f::Metric)(rs::ResultSet, args...; kwargs...)::YAXArray
-    return fill_metadata!(@views(f.func(rs, args...; kwargs...)), f)
+    return fill_metadata!(f.func(rs, args...; kwargs...), f)
 end
 
 """

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -44,11 +44,10 @@ Makes Metric types callable with arbitary arguments that are passed to associate
 """
 function (f::Metric)(raw, args...; kwargs...)::YAXArray
     axes::Tuple = (:timesteps, :species, :locations, :scenarios)[1:ndims(raw)]
-
-    return fill_axes_properties(f, f.func(DataCube(raw, axes), args...; kwargs...))
+    return fill_metadata!(@views(f.func(DataCube(raw, axes), args...; kwargs...)), f)
 end
 function (f::Metric)(rs::ResultSet, args...; kwargs...)::YAXArray
-    return fill_axes_properties(f, (f.func(rs, args...; kwargs...)))
+    return fill_metadata!(@views(f.func(rs, args...; kwargs...)), f)
 end
 
 """
@@ -732,11 +731,12 @@ relative_shelter_volume = Metric(
     IS_RELATIVE
 )
 
+include("metadata.jl")
 include("pareto.jl")
 include("ranks.jl")
 include("reef_indices.jl")
 include("scenario.jl")
-include("site_level.jl")
+include("spatial.jl")
 include("temporal.jl")
 include("utils.jl")
 

--- a/src/metrics/reef_indices.jl
+++ b/src/metrics/reef_indices.jl
@@ -104,7 +104,10 @@ function _reef_condition_index(rs::ResultSet)::AbstractArray{<:Real}
     return _reef_condition_index(rc, evenness, sv, juves)
 end
 reef_condition_index = Metric(
-    _reef_condition_index, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE
+    _reef_condition_index,
+    (:timesteps, :locations, :scenarios),
+    "RCI",
+    IS_NOT_RELATIVE
 )
 
 """
@@ -127,7 +130,7 @@ function _scenario_rci(rs::ResultSet; kwargs...)
 
     return _scenario_rci(rci, tac; kwargs...)
 end
-scenario_rci = Metric(_scenario_rci, (:timesteps, :scenarios), IS_NOT_RELATIVE)
+scenario_rci = Metric(_scenario_rci, (:timesteps, :scenarios), "RCI", IS_NOT_RELATIVE)
 
 """
     reef_tourism_index(rc::AbstractArray, evenness::AbstractArray, sv::AbstractArray, juves::AbstractArray, intcp_u::Vector)::AbstractArray
@@ -192,7 +195,7 @@ function _reef_tourism_index(rs::ResultSet; intcp_u::Bool=false)::AbstractArray
     return _reef_tourism_index(rc, evenness, sv, juves, intcp)
 end
 reef_tourism_index = Metric(
-    _reef_tourism_index, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE
+    _reef_tourism_index, (:timesteps, :locations, :scenarios), "RTI", IS_NOT_RELATIVE
 )
 
 """
@@ -208,7 +211,7 @@ end
 function _scenario_rti(rs::ResultSet; kwargs...)
     return _scenario_rti(reef_tourism_index(rs); kwargs...)
 end
-scenario_rti = Metric(_scenario_rti, (:timesteps, :scenarios), IS_NOT_RELATIVE)
+scenario_rti = Metric(_scenario_rti, (:timesteps, :scenarios), "RTI", IS_NOT_RELATIVE)
 
 """
     reef_fish_index(rc::AbstractArray)
@@ -276,7 +279,7 @@ function _reef_fish_index(rs::ResultSet; intcp_u1::Bool=false, intcp_u2::Bool=fa
     return _reef_fish_index(rc, icp1, icp2)
 end
 reef_fish_index = Metric(
-    _reef_fish_index, (:timesteps, :locations, :scenarios), IS_NOT_RELATIVE
+    _reef_fish_index, (:timesteps, :locations, :scenarios), "RFI", IS_NOT_RELATIVE
 )
 
 """
@@ -292,4 +295,4 @@ end
 function _scenario_rfi(rs::ResultSet; kwargs...)
     return _scenario_rfi(reef_fish_index(rs); kwargs...)
 end
-scenario_rfi = Metric(_scenario_rfi, (:timesteps, :scenarios), IS_NOT_RELATIVE)
+scenario_rfi = Metric(_scenario_rfi, (:timesteps, :scenarios), "RFI", IS_NOT_RELATIVE)

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -49,7 +49,7 @@ function _scenario_total_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_total_cover(tac::AbstractArray; kwargs...)
 end
 scenario_total_cover = Metric(
-    _scenario_total_cover, (:timesteps, :scenarios), IS_NOT_RELATIVE, UNIT_AREA
+    _scenario_total_cover, (:timesteps, :scenarios), "Cover", IS_NOT_RELATIVE, UNIT_AREA
 )
 
 """
@@ -64,7 +64,7 @@ function _scenario_relative_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Rea
     return _scenario_total_cover(rs; kwargs...) ./ target_area
 end
 scenario_relative_cover = Metric(
-    _scenario_relative_cover, (:timesteps, :scenarios), IS_RELATIVE
+    _scenario_relative_cover, (:timesteps, :scenarios), "Relative Cover", IS_RELATIVE
 )
 
 """
@@ -107,7 +107,10 @@ function _scenario_relative_juveniles(rs::ResultSet; kwargs...)::YAXArray
     return dropdims(sum(aj; dims=:locations); dims=:locations) ./ sum(site_k_area(rs))
 end
 scenario_relative_juveniles = Metric(
-    _scenario_relative_juveniles, (:timesteps, :scenarios), IS_RELATIVE
+    _scenario_relative_juveniles,
+    (:timesteps, :scenarios),
+    "Relative Juveniles",
+    IS_RELATIVE
 )
 
 """
@@ -136,7 +139,11 @@ function _scenario_absolute_juveniles(rs::ResultSet; kwargs...)::AbstractArray{<
     return dropdims(sum(absolute_juveniles(rs); dims=:locations); dims=:locations)
 end
 scenario_absolute_juveniles = Metric(
-    _scenario_absolute_juveniles, (:timesteps, :scenarios), IS_NOT_RELATIVE, UNIT_AREA
+    _scenario_absolute_juveniles,
+    (:timesteps, :scenarios),
+    "Number of Juveniles",
+    IS_NOT_RELATIVE,
+    UNIT_AREA
 )
 
 """
@@ -164,7 +171,10 @@ function _scenario_juvenile_indicator(rs::ResultSet; kwargs...)::AbstractArray{<
     return dropdims(mean(juvenile_indicator(rs); dims=:locations); dims=:locations)
 end
 scenario_juvenile_indicator = Metric(
-    _scenario_juvenile_indicator, (:timesteps, :scenarios), IS_RELATIVE
+    _scenario_juvenile_indicator,
+    (:timesteps, :scenarios),
+    "Juvenile Indicator",
+    IS_RELATIVE
 )
 
 """
@@ -185,7 +195,11 @@ function _scenario_asv(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_asv(rs.outcomes[:absolute_shelter_volume]; kwargs...)
 end
 scenario_asv = Metric(
-    _scenario_asv, (:timesteps, :scenarios), IS_NOT_RELATIVE, "$UNIT_VOLUME/$UNIT_AREA"
+    _scenario_asv,
+    (:timesteps, :scenarios),
+    "Volume",
+    IS_NOT_RELATIVE,
+    "$UNIT_VOLUME/$UNIT_AREA"
 )
 
 """
@@ -201,7 +215,9 @@ end
 function _scenario_rsv(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_rsv(rs.outcomes[:relative_shelter_volume]; kwargs...)
 end
-scenario_rsv = Metric(_scenario_rsv, (:timesteps, :scenarios), IS_RELATIVE)
+scenario_rsv = Metric(
+    _scenario_rsv, (:timesteps, :scenarios), "Relative Volume", IS_RELATIVE
+)
 
 """
     scenario_evenness(ev::YAXArray; kwargs...)::AbstractArray{<:Real}
@@ -217,7 +233,12 @@ end
 function _scenario_evenness(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     return _scenario_evenness(rs.outcomes[:coral_evenness]; kwargs...)
 end
-scenario_evenness = Metric(_scenario_evenness, (:timesteps, :scenarios), IS_NOT_RELATIVE)
+scenario_evenness = Metric(
+    _scenario_evenness,
+    (:timesteps, :scenarios),
+    "Evenness Indicator",
+    IS_NOT_RELATIVE
+)
 
 """
     scenario_outcomes(rs::ResultSet, metrics::Vector{Metric})::YAXArray

--- a/src/metrics/spatial.jl
+++ b/src/metrics/spatial.jl
@@ -96,7 +96,7 @@ function summarize(
     # Only use this approach when data occupies more than 70% of available RAM
     if data_size > available_ram
         # `D.` is ensuring the returned YAXArray has the same type as the input `data`
-        return D.(mapslices(metric, data; dims=alongs_axis))
+        return fill_metadata!(D.(mapslices(metric, data; dims=alongs_axis)), metadata(data))
     end
 
     alongs = sort([axis_index(data, axis) for axis in alongs_axis])
@@ -110,7 +110,9 @@ function summarize(
     new_dims = setdiff(axes_names(data), alongs_axis)
     new_axis = [axis_labels(data, ax) for ax in new_dims]
 
-    return DataCube(summarized_data; NamedTuple{Tuple(new_dims)}(new_axis)...)
+    return fill_metadata!(
+        DataCube(summarized_data; NamedTuple{Tuple(new_dims)}(new_axis)...), metadata(data)
+    )
 end
 function summarize(
     data::YAXArray{D,T,N,A},

--- a/src/metrics/utils.jl
+++ b/src/metrics/utils.jl
@@ -45,15 +45,6 @@ function metric_label(f::Function, unit::String)::String
 end
 
 """
-    axes_units(axes_names::Tuple)::Tuple
-
-Units for each metric axis.
-"""
-function axes_units(axes_names::Union{Vector{Symbol},Tuple})::Tuple
-    return values((timesteps="years", species="", locations="", scenarios="")[axes_names])
-end
-
-"""
     dims(m::Metric)::Tuple
 
 Get dimension names for a given outcome/metric.
@@ -90,30 +81,6 @@ function call_metric(metric::Union{Function,Metric}, data::YAXArray, args...; kw
     else
         return metric(slice_results(data; kwargs...), args...; dims=dims)
     end
-end
-
-"""
-    fill_axes_properties(metric::Metric, metric_result::YAXArray)::YAXArray
-
-Fill `:axes_names` and `:axes_units` properties of the datacube.
-
-# Arguments
-- `datacube` : YAXArray datacube
-"""
-function fill_axes_properties(metric::Metric, metric_result::YAXArray)::YAXArray
-    metric_result.properties[:metric_name] = to_string(metric; is_titlecase=true)
-    metric_result.properties[:metric_feature] = metric.feature
-    metric_result.properties[:is_relative] = metric.is_relative
-    metric_result.properties[:metric_unit] = metric.unit
-
-    _axes_names::Tuple = axes_names(metric_result)
-    metric_result.properties[:axes_names] = collect(
-        parentmodule(metrics).human_readable_name.(
-            _axes_names
-        )
-    )
-    metric_result.properties[:axes_units] = collect(axes_units(_axes_names))
-    return metric_result
 end
 
 """

--- a/src/metrics/utils.jl
+++ b/src/metrics/utils.jl
@@ -50,7 +50,7 @@ end
 Units for each metric axis.
 """
 function axes_units(axes_names::Union{Vector{Symbol},Tuple})::Tuple
-    return values((timesteps="year", species="", locations="", scenarios="")[axes_names])
+    return values((timesteps="years", species="", locations="", scenarios="")[axes_names])
 end
 
 """
@@ -101,9 +101,10 @@ Fill `:axes_names` and `:axes_units` properties of the datacube.
 - `datacube` : YAXArray datacube
 """
 function fill_axes_properties(metric::Metric, metric_result::YAXArray)::YAXArray
-    metric_result.properties[:metric_name] = metric_label(metric)
-    metric_result.properties[:metric_unit] = metric.unit
+    metric_result.properties[:metric_name] = to_string(metric; is_titlecase=true)
+    metric_result.properties[:metric_feature] = metric.feature
     metric_result.properties[:is_relative] = metric.is_relative
+    metric_result.properties[:metric_unit] = metric.unit
 
     _axes_names::Tuple = axes_names(metric_result)
     metric_result.properties[:axes_names] = collect(

--- a/test/metrics/test_metrics_helper.jl
+++ b/test/metrics/test_metrics_helper.jl
@@ -42,16 +42,15 @@ function test_metric(metric::metrics.Metric, params::Tuple)::Nothing
     return nothing
 end
 
-function _test_properties(metric::metrics.Metric, metric_result::YAXArray)
+function _test_properties(metric::metrics.Metric, outcomes::YAXArray)
     prop_labels::NTuple{4,Symbol} = (:metric_name, :metric_unit, :axes_names, :axes_units)
-    all_properties_present = all(haskey.([metric_result.properties], prop_labels))
+    outcome_metadata = outcomes.properties
+    all_properties_present = all(haskey.([outcome_metadata], prop_labels))
     @test all_properties_present
     if all_properties_present
-        result_prop_axes_names::Vector{String} = metric_result.properties[:axes_names]
-        result_prop_axes_units::Vector{String} = metric_result.properties[:axes_units]
-        result_axes_names = string.(axes_names(metric_result))
-
-        @test metric_result.properties[:metric_name] == metrics.metric_label(metric)
+        result_prop_axes_names::Vector{String} = outcome_metadata[:axes_names]
+        result_prop_axes_units::Vector{String} = outcome_metadata[:axes_units]
+        result_axes_names = string.(axes_names(outcomes))
 
         # All keys in result properties match YAXArray
         @test all(result_prop_axes_names .∈ [result_axes_names]) ||

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ include("metrics/scenario.jl")
 include("metrics/metrics.jl")
 include("utils/scale.jl")
 include("utils/text_display.jl")
+include("viz/taxa_dynamics.jl")
 
 # TODO Fix spatial_clustering and site_selection tests
 # include("site_selection.jl")

--- a/test/viz/taxa_dynamics.jl
+++ b/test/viz/taxa_dynamics.jl
@@ -1,0 +1,36 @@
+using WGLMakie, GeoMakie, GraphMakie
+
+using ADRIA
+
+if !@isdefined(TEST_RS)
+    const TEST_DOM, TEST_N_SAMPLES, TEST_SCENS, TEST_RS = test_rs()
+end
+
+@testset "taxonomy" begin
+    @testset "Default opts" begin
+        @test ADRIA.viz.taxonomy(TEST_RS) isa Figure
+    end
+
+    # Default opts values
+    opts::Dict{Symbol,Any} = Dict(
+        :by_functional_groups => true, :by_RCP => false, :show_confints => true
+    )
+
+    @testset "Split by taxonomy" begin
+        opts[:by_functional_groups] = false
+        @test ADRIA.viz.taxonomy(TEST_RS; opts=opts) isa Figure
+    end
+
+    @testset "Split by RCP" begin
+        opts[:by_functional_groups] = true
+        opts[:by_RCP] = true
+        @test ADRIA.viz.taxonomy(TEST_RS; opts=opts) isa Figure
+    end
+
+    @testset "Don't show confidence intervals" begin
+        opts[:by_functional_groups] = true
+        opts[:by_RCP] = true
+        opts[:show_confints] = false
+        @test ADRIA.viz.taxonomy(TEST_RS; opts=opts) isa Figure
+    end
+end


### PR DESCRIPTION
Closes #453 

Use metrics metadata to automatically generate title and labels for viz functions.

1. Not all viz functions were updated yet.
2. Maybe not in this PR, I need to display relative metrics as percentage. The reason why I don't want to do that in this PR is because is not only a label change. 
3. In order to update sensitivity analysis related viz functions, I'll need to update some sensitivity analysis functions too because they return an array without metadata. 

## Same examples:
### viz/scenarios
```
# Absolute metric
s_tac = ADRIA.metrics.scenario_total_cover(rs)
fig_s_tac = ADRIA.viz.scenarios(rs, s_tac)
```
![s_tac](https://github.com/user-attachments/assets/ad809b87-f416-49a8-9f7b-d49509870785)

```
# Relative metric
s_rc = ADRIA.metrics.scenario_relative_cover(rs)
fig_s_rc = ADRIA.viz.scenarios(rs, s_rc)
```

![s_rc](https://github.com/user-attachments/assets/ccb185cf-0400-490a-9b6c-003113b847dc)

### spatial
```
tac = ADRIA.metrics.total_absolute_cover(rs)
loc_tac = ADRIA.metrics.per_loc(median, tac)

tsc_map_fig = ADRIA.viz.map(rs, loc_tac)
fig_spatial_tac = ADRIA.viz.map(rs)
```

![map_spatial_tac](https://github.com/user-attachments/assets/d700136d-7102-483c-8591-28f90da9d0ef)


### viz/clustering
```
# Extract metric from scenarios
s_tac = ADRIA.metrics.scenario_total_cover(rs)

# Cluster scenarios
n_clusters = 4
clusters = ADRIA.analysis.cluster_scenarios(s_tac, n_clusters)

tsc_fig = ADRIA.viz.clustered_scenarios(s_tac, clusters)
```

![stac_clusters](https://github.com/user-attachments/assets/36d40ae0-9ed1-48c4-bcb8-c2bd847e7794)

```
# Extract metric from scenarios
tac = ADRIA.metrics.total_absolute_cover(rs)

# Get a timeseries summarizing the scenarios for each location
tac_site_series = ADRIA.metrics.loc_trajectory(median, tac)

# Cluster scenarios
n_clusters = 6
clusters = ADRIA.analysis.cluster_scenarios(tac_site_series, n_clusters)

# Get a vector summarizing the scenarios and timesteps for each site
loc_tac = ADRIA.metrics.per_loc(median, tac)

# Plot figure
tsc_map_fig = ADRIA.viz.map(rs, loc_tac, clusters)
```

![stac_clusters_map](https://github.com/user-attachments/assets/cd7f3273-eb8c-4b64-9aff-02a1fea91dcd)

### Rule Extraction
```
# Find Time Series Clusters
s_tac = ADRIA.metrics.scenario_total_cover(rs)
num_clusters = 6
clusters = ADRIA.analysis.cluster_scenarios(s_tac, num_clusters)

# Target scenarios
target_clusters = ADRIA.analysis.target_clusters(clusters, s_tac)

# Select only desired features
fields_iv =
    ADRIA.component_params(
        rs, [Intervention, SeedCriteriaWeights, FogCriteriaWeights]
    ).fieldname
scenarios_iv = scens[:, fields_iv]

# Use SIRUS algorithm to extract rules
max_rules = 10
rules_iv = ADRIA.analysis.cluster_rules(target_clusters, scenarios_iv, max_rules)

# Plot scatters for each rule highlighting the area selected them
rules_scatter_fig = ADRIA.viz.rules_scatter(
    rs,
    scenarios_iv,
    target_clusters,
    rules_iv
)
```

![rules_scatter](https://github.com/user-attachments/assets/8100fb2f-27ad-48db-81ec-75a5adbc1821)