### PR TITLE
Fix rule extraction to handle constant factors

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -393,8 +393,8 @@ median outcome temporal variability:
 ```julia
 # Find Time Series Clusters
 s_tac = ADRIA.metrics.scenario_total_cover(rs)
-num_clusters = 6
-clusters = ADRIA.analysis.cluster_scenarios(s_tac, num_clusters)
+n_clusters = 6
+clusters = ADRIA.analysis.cluster_scenarios(s_tac, n_clusters)
 
 # Target scenarios
 target_clusters = ADRIA.analysis.target_clusters(clusters, s_tac)
@@ -408,9 +408,11 @@ rule as a scatter graph:
 # Select features of interest
 foi = ADRIA.component_params(rs, [Intervention, SeedCriteriaWeights]).fieldname
 
-# Use SIRUS algorithm to extract rules
+# Use SIRUS algorithm to extract rules.
 max_rules = 10
-rules_iv = ADRIA.analysis.cluster_rules(rs, target_clusters, scens, foi, max_rules)
+rules_iv = ADRIA.analysis.cluster_rules(
+    rs, target_clusters, scens, foi, max_rules; remove_duplicates=true
+)
 
 
 # Plot scatters for each rule highlighting the area selected them

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -405,18 +405,18 @@ scenario, it is possible to use a Rule Induction algorithm (SIRUS) and plot each
 rule as a scatter graph:
 
 ```julia
-# Select only desired features
-fields_iv = ADRIA.component_params(rs, [Intervention, CriteriaWeights]).fieldname
-scenarios_iv = scens[:, fields_iv]
+# Select features of interest
+foi = ADRIA.component_params(rs, [Intervention, SeedCriteriaWeights]).fieldname
 
 # Use SIRUS algorithm to extract rules
 max_rules = 10
-rules_iv = ADRIA.analysis.cluster_rules(target_clusters, scenarios_iv, max_rules)
+rules_iv = ADRIA.analysis.cluster_rules(dom, target_clusters, scens, foi, max_rules)
+
 
 # Plot scatters for each rule highlighting the area selected them
 rules_scatter_fig = ADRIA.viz.rules_scatter(
     rs,
-    scenarios_iv,
+    scens,
     target_clusters,
     rules_iv;
     fig_opts=fig_opts,

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -410,7 +410,7 @@ foi = ADRIA.component_params(rs, [Intervention, SeedCriteriaWeights]).fieldname
 
 # Use SIRUS algorithm to extract rules
 max_rules = 10
-rules_iv = ADRIA.analysis.cluster_rules(dom, target_clusters, scens, foi, max_rules)
+rules_iv = ADRIA.analysis.cluster_rules(rs, target_clusters, scens, foi, max_rules)
 
 
 # Plot scatters for each rule highlighting the area selected them

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -109,8 +109,8 @@ function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothi
 end
 
 """
-    cluster_rules(result_set::ADRIA.ResultSet, clusters::Vector{T}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    cluster_rules(result_set::ADRIA.ResultSet, clusters::Union{BitVector,Vector{Bool}}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(result_set::ResultSet, clusters::Vector{T}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(result_set::ResultSet, clusters::Union{BitVector,Vector{Bool}}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric
 (default is median). More information about the keyword arguments accepeted can be found in
@@ -141,7 +141,7 @@ A StableRules object (implemented by SIRUS).
    https://doi.org//10.1214/20-EJS1792
 """
 function cluster_rules(
-    result_set::ADRIA.ResultSet,
+    result_set::ResultSet,
     clusters::Vector{T},
     scenarios::DataFrame,
     factors::Vector{Symbol},
@@ -185,7 +185,7 @@ function cluster_rules(
     end
 end
 function cluster_rules(
-    result_set::ADRIA.ResultSet,
+    result_set::ResultSet,
     clusters::Union{BitVector,Vector{Bool}},
     scenarios::DataFrame,
     factors::Vector{Symbol},

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -155,7 +155,7 @@ function cluster_rules(
     variable_factors::Vector{Symbol} = factors[variable_factors_filter]
 
     if isempty(variable_factors)
-        throw(ArgumentError("Factors of interest have to be non constant."))
+        throw(ArgumentError("Factors of interest cannot be constant"))
     end
 
     X = scenarios[:, variable_factors]

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -109,15 +109,15 @@ function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothi
 end
 
 """
-    cluster_rules(domain::ADRIA.Domain, clusters::Vector{T}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    cluster_rules(domain::ADRIA.Domain, clusters::Union{BitVector,Vector{Bool}}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...) where {T<:Int64}
+    cluster_rules(result_set::ADRIA.ResultSet, clusters::Vector{T}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(result_set::ADRIA.ResultSet, clusters::Union{BitVector,Vector{Bool}}, scenarios::DataFrame, factors::Vector{Symbol}, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric
 (default is median). More information about the keyword arguments accepeted can be found in
 MLJ's doc (https://juliaai.github.io/MLJ.jl/dev/models/StableRulesClassifier_SIRUS/).
 
 # Arguments
-- `domain` : Domain.
+- `result_set` : ResultSet.
 - `clusters` : Vector of cluster indexes for each scenario outcome.
 - `scenarios` : Scenarios DataFrame.
 - `factors` : Vector of factors of interest.
@@ -141,7 +141,7 @@ A StableRules object (implemented by SIRUS).
    https://doi.org//10.1214/20-EJS1792
 """
 function cluster_rules(
-    domain::ADRIA.Domain,
+    result_set::ADRIA.ResultSet,
     clusters::Vector{T},
     scenarios::DataFrame,
     factors::Vector{Symbol},
@@ -150,7 +150,8 @@ function cluster_rules(
     remove_duplicates::Bool=true,
     kwargs...
 )::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    ms = ADRIA.model_spec(domain)
+    ms = ADRIA.model_spec(result_set)
+
     variable_factors_filter::BitVector = .!ms[ms.fieldname .∈ [factors], :is_constant]
     variable_factors::Vector{Symbol} = factors[variable_factors_filter]
 
@@ -184,7 +185,7 @@ function cluster_rules(
     end
 end
 function cluster_rules(
-    domain::ADRIA.Domain,
+    result_set::ADRIA.ResultSet,
     clusters::Union{BitVector,Vector{Bool}},
     scenarios::DataFrame,
     factors::Vector{Symbol},
@@ -192,11 +193,12 @@ function cluster_rules(
     seed::Int64=123,
     remove_duplicates::Bool=true,
     kwargs...
-) where {T<:Int64}
+)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     return cluster_rules(
-        domain, convert.(Int64, clusters), scenarios, factors, max_rules;
+        result_set, convert.(Int64, clusters), scenarios, factors, max_rules;
         seed=seed, remove_duplicates=remove_duplicates, kwargs...
     )
+end
 
 """
     _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -243,15 +243,15 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
         ADRIA.component_params(
             rs, [Intervention, FogCriteriaWeights, SeedCriteriaWeights]
         ).fieldname
-    scenarios_iv = scens[:, fields_iv]
 
     # Use SIRUS algorithm to extract rules
+
     max_rules = 10
     rules_iv = ADRIA.analysis.cluster_rules(
-        target_clusters, scenarios_iv, max_rules; remove_duplicates=true
+        rs, target_clusters, scens, fields_iv, max_rules; remove_duplicates=true
     )
     rules_iv_duplicates = ADRIA.analysis.cluster_rules(
-        target_clusters, scenarios_iv, max_rules; remove_duplicates=false
+        rs, target_clusters, scens, fields_iv, max_rules; remove_duplicates=false
     )
     ADRIA.analysis.print_rules(rules_iv)
     ADRIA.analysis.print_rules(rules_iv_duplicates)
@@ -259,7 +259,7 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
     # Plot scatters for each rule highlighting the area selected them
     rules_scatter_fig = ADRIA.viz.rules_scatter(
         rs,
-        scenarios_iv,
+        scens,
         target_clusters,
         rules_iv;
         fig_opts=fig_opts,

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -268,7 +268,7 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
 
     ADRIA.viz.rules_scatter(
         rs,
-        scenarios_iv,
+        scens,
         target_clusters,
         rules_iv_duplicates;
         fig_opts=fig_opts,


### PR DESCRIPTION
Note: This branch is based on #863 's branch. Closes #672 .

---

Updates `ADRIA.analysis.cluster_rules` so we can check for constant factors (and ignore them) before trying to extract rules. The parameters you need to pass to `cluster_rules` have changed - with that is one line less of code now.

The documentation still needs to be updated - once this is done, I'll mark this as ready to review.

## Example
As an example, let's fix all `SeedCriteriaWeights` and only a few of the `FogCriteriaWeights` factors, run the model, cluster and target some cluster:

```
dom = ADRIA.load_domain("...")

ADRIA.fix_factor!(
    dom;
    # Seed criteria
    seed_out_connectivity=0.9,
    seed_heat_stress=0.8,
    seed_depth=0.7,
    seed_coral_cover=0.5,
    seed_in_connectivity=0.4,
    seed_wave_stress=0.0,
    # Fog criteria
    fog_coral_cover=0.5,
    fog_depth=0.7
)

# Create scenarios
num_scens = 2^8
scens = ADRIA.sample(dom, num_scens)

# Run model / Load ResultSet
rs = ADRIA.run_scenarios(dom, scens, "45")

# Find Time Series Clusters
s_tac = ADRIA.metrics.scenario_total_cover(rs)
num_clusters = 6
clusters = ADRIA.analysis.cluster_scenarios(s_tac, num_clusters)

# Target scenarios
target_clusters = ADRIA.analysis.target_clusters(clusters, s_tac)
```

Now if we select `Intervention` factors, everything works (as it would previously, nothing's c hanged here):

```
max_rules = 10
fields_iv = ADRIA.component_params(rs, [Intervention]).fieldname
rules_iv = ADRIA.analysis.cluster_rules(dom, target_clusters, scens, fields_iv, max_rules)
```

If we select `FogCriteriaWeights`, some are constant and some are not. Previously this would lead to an error but now it just filters off all constant factors and everything works fine:

```
max_rules = 10
fields_fog = ADRIA.component_params(rs, [FogCriteriaWeights]).fieldname
rules_fog = ADRIA.analysis.cluster_rules(
    dom, target_clusters, scens, fields_seeds, max_rules
)
```

And, finally, if we select `SeedCriteriaWeights`, because all of them are constant, this will raise an error:

```
max_rules = 10
fields_seeds = ADRIA.component_params(rs, [SeedCriteriaWeights]).fieldname
rules_seeds = ADRIA.analysis.cluster_rules(
    dom, target_clusters, scens, fields_seeds, max_rules
)
```

The error:

```
ERROR: ArgumentError: Factors of interest have to be non constant.
Stacktrace:
 [1] cluster_rules(domain::ADRIADomain, clusters::Vector{…}, scenarios::DataFrames.DataFrame, factors::Vector{…}, max_rules::Int64; seed::Int64, kwargs::@Kwargs{})
   @ ADRIA.analysis c:\Users\pribeiro\AIMS\Code\ADRIA.jl\src\analysis\rule_extraction.jl:148
 [2] cluster_rules(domain::ADRIADomain, clusters::Vector{…}, scenarios::DataFrames.DataFrame, factors::Vector{…}, max_rules::Int64)
   @ ADRIA.analysis c:\Users\pribeiro\AIMS\Code\ADRIA.jl\src\analysis\rule_extraction.jl:134
 [3] top-level scope
   @ c:\Users\pribeiro\AIMS\Code\ADRIA.jl\sandbox\rule_extraction\fixed_factors.jl:77
Some type information was truncated. Use `show(err)` to see complete types.
```

Below are the scatter plots for `Interventions` and `FogCriteriaWeights` rules (the plot functions haven't changed):

| `Intervention` | `FogCriteriaWeights` |
| -- | -- |
| ![rules_iv_scatter](https://github.com/user-attachments/assets/009286ef-65d5-4966-a175-01b57ab54e83) | ![rules_fog_scatter](https://github.com/user-attachments/assets/5bb1edd1-9efe-4773-b025-d1f2e15c3379) |
