### PR TITLE
Fix StackOverflow error when plotting maps

### DIFF
--- a/ext/AvizExt/viz/location_selection.jl
+++ b/ext/AvizExt/viz/location_selection.jl
@@ -49,7 +49,7 @@ function ADRIA.viz.ranks_to_frequencies!(
 
     opts[:color_map] = all_colormaps[sym_rank_ids[1]]
     geodata = _get_geoms(rs)
-    legend_els = Vector{Any}(undef, length(rank_ids))
+    legend_els = Vector{PolyElement}(undef, length(rank_ids))
     legend_labels = Vector{String}(undef, length(rank_ids))
     opts[:show_colorbar] = get(opts, :show_colorbar, false)
 

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -149,9 +149,8 @@ function create_map!(
         end
     end
 
-    reset_limits!(current_axis())
+    # Remove any empty subplots
     trim!(f)
-    resize_to_layout!(current_figure())
 
     return f
 end

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -36,6 +36,8 @@ function set_axis_defaults(axis_opts::OPT_TYPE)::OPT_TYPE
     axis_opts[:xgridwidth] = get(axis_opts, :xgridwidth, 0.5)
     axis_opts[:ygridwidth] = get(axis_opts, :ygridwidth, 0.5)
     axis_opts[:dest] = get(axis_opts, :dest, "+proj=latlong +datum=WGS84")
+    axis_opts[:xgridvisible] = get(axis_opts, :xgridvisible, false)
+    axis_opts[:ygridvisible] = get(axis_opts, :ygridvisible, false)
 
     return axis_opts
 end


### PR DESCRIPTION
See initial investigative notes here: https://github.com/open-AIMS/ADRIA.jl/issues/890#issuecomment-2434642334

I'm still unsure of the exact cause as I can get tests to pass when `infiltrate`d by first calling `reset_limits!(current_axis())` to invoke the error, and then `@continue`ing on.

My first suspicion was on the custom [legend parameter creation](https://github.com/open-AIMS/ADRIA.jl/blob/578999fe836d759ac5c1aac1098cbf5d1c4425a9/ext/AvizExt/viz/clustering.jl#L185-L205), but it seems to be fine outside the test context.
Removing the two offending lines of code allows tests to pass.

The resulting figure seemed as expected with the exception of gridlines being out of alignment.
So I have set gridlines to false by default for maps for now.

Tests pass locally for me.

Closes #890 