### PR TITLE
Remove duplicate rules

### DIFF
--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -110,8 +110,8 @@ function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothi
 end
 
 """
-    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T; seed::Int64=123, kwargs...) where {T<:Integer,F<:Real}
-    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T; kwargs...) where {T<:Int64}
+    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric
 (default is median). More information about the keyword arguments accepeted can be found in
@@ -136,8 +136,10 @@ A StableRules object (implemented by SIRUS).
    Electron. J. Statist. 15 (1) 427 - 505.
    https://doi.org//10.1214/20-EJS1792
 """
-function cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;
-    seed::Int64=123, kwargs...) where {T<:Int64}
+function cluster_rules(
+    clusters::Vector{T}, X::DataFrame, max_rules::T;
+    seed::Int64=123, remove_duplicates=true, kwargs...
+)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     # Set seed and Random Number Generator
     rng = StableRNG(seed)
 
@@ -155,11 +157,61 @@ function cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;
         error("Failed fitting SIRUS. Try increasing the number of scenarios/samples.")
     end
 
-    return rules(mach.fitresult)
+    if remove_duplicates
+        return _remove_duplicates(rules(mach.fitresult))
+    else
+        return rules(mach.fitresult)
+    end
 end
-function cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;
-    kwargs...) where {T<:Int64}
+function cluster_rules(
+    clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;
+    kwargs...
+)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     return cluster_rules(convert.(Int64, clusters), X, max_rules; kwargs...)
+end
+
+"""
+    _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}
+
+Returns `Vector{Rule}` without duplicate rules (if there's any). The criteria to choose
+which rule to keep is based on the rule consequence probability (the one with the highest
+probability one is kept). If more than one rule has the same highest probability, the first
+one is chosen.
+"""
+function _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}
+    # Extract subclauses from each rule without value
+    subclauses = join.([_strip_value.(r.condition) for r in rules], "_&_")
+    unique_subclauses = unique(subclauses)
+
+    # Return rules if there are no duplicate rules
+    n_unique_rules = length(unique_subclauses)
+    n_unique_rules == length(rules) && return rules
+
+    unique_rules::Vector{Rule} = Vector{Rule}(undef, n_unique_rules)
+    for (unique_idx, unique_subclause) in enumerate(unique_subclauses)
+        duplicate_rules_filter = unique_subclause .== subclauses
+
+        # If current rule has no duplicates go to next iteration
+        if sum(duplicate_rules_filter) == 1
+            unique_rules[unique_idx] = rules[duplicate_rules_filter][1]
+            continue
+        end
+
+        duplicate_rules = rules[duplicate_rules_filter]
+        max_probability_idx = findmax([r.consequent[1] for r in duplicate_rules])[2]
+        unique_rules[unique_idx] = duplicate_rules[max_probability_idx]
+    end
+
+    return unique_rules
+end
+
+"""
+    _strip_value(condition_subclause::Vector)
+
+Helper function that extracts factor name and direction from a rule condition subclause
+"""
+function _strip_value(condition_subclause::Vector)
+    return join(condition_subclause[1:2], "__")
 end
 
 """

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -183,14 +183,20 @@ which rule to keep is based on the rule consequence probability (the one with th
 probability is kept). If there are more than one rule with the same highest probability,
 then the first one is chosen.
 """
-function _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}
+function _remove_duplicates(
+    rules::T
+)::T where {T<:Vector{Rule{Vector{Vector},Vector{Float64}}}}
     # Extract subclauses from each rule without value
     subclauses = join.([_strip_value.(r.condition) for r in rules], "_&_")
     unique_subclauses = unique(subclauses)
 
     # Return rules if there are no duplicate rules
     n_unique_rules = length(unique_subclauses)
-    n_unique_rules == length(rules) && return rules
+    (n_unique_rules == length(rules)) && return rules
+
+    n_rules = length(rules)
+    n_duplicates = n_rules - n_unique_rules
+    @warn "$n_duplicates of $n_rules duplicated rules were found and are going to be removed."
 
     unique_rules::Vector{Rule} = Vector{Rule}(undef, n_unique_rules)
     for (unique_idx, unique_subclause) in enumerate(unique_subclauses)

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -194,9 +194,11 @@ function _remove_duplicates(
     subclauses = join.([_strip_value.(r.condition) for r in rules], "_&_")
     unique_subclauses = unique(subclauses)
 
-    # Return rules if there are no duplicate rules
+    # Check if there are duplicate rules before moving on
     n_unique_rules = length(unique_subclauses)
-    (n_unique_rules == length(rules)) && return rules
+    if n_unique_rules == length(rules)
+        return rules
+    end
 
     n_rules = length(rules)
     n_duplicates = n_rules - n_unique_rules

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -13,6 +13,13 @@ past of the 'positive class' given that the condition is true or false.
 struct Rule{V<:Vector{Vector},W<:Vector{Float64}}
     condition::V
     consequent::W
+
+    function Rule(condition, consequent)
+        condition_order = sortperm(condition; by=x -> x[1])
+        return new{typeof(condition),typeof(consequent)}(
+            condition[condition_order], consequent[condition_order]
+        )
+    end
 end
 
 """

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -110,7 +110,7 @@ end
 
 """
     cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric
 (default is median). More information about the keyword arguments accepeted can be found in

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -178,10 +178,14 @@ end
 """
     _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}
 
-Returns `Vector{Rule}` without duplicate rules (if there's any). The criteria to choose
-which rule to keep is based on the rule consequence probability (the one with the highest
+Identifies and removes duplicate rulesets (if any are found).
+
+The criteria to choose which rule to keep is based on the rule consequence probability (the one with the highest
 probability is kept). If there are more than one rule with the same highest probability,
 then the first one is chosen.
+
+# Returns
+A ruleset with duplicate rules removed
 """
 function _remove_duplicates(
     rules::T

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -15,9 +15,8 @@ struct Rule{V<:Vector{Vector},W<:Vector{Float64}}
     consequent::W
 
     function Rule(condition, consequent)
-        condition_order = sortperm(condition; by=x -> x[1])
         return new{typeof(condition),typeof(consequent)}(
-            condition[condition_order], consequent[condition_order]
+            sort(condition; by=x -> x[1]), consequent
         )
     end
 end

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -180,8 +180,8 @@ end
 
 Returns `Vector{Rule}` without duplicate rules (if there's any). The criteria to choose
 which rule to keep is based on the rule consequence probability (the one with the highest
-probability one is kept). If more than one rule has the same highest probability, the first
-one is chosen.
+probability is kept). If there are more than one rule with the same highest probability,
+then the first one is chosen.
 """
 function _remove_duplicates(rules)::Vector{Rule{Vector{Vector},Vector{Float64}}}
     # Extract subclauses from each rule without value
@@ -213,7 +213,9 @@ end
 """
     _strip_value(condition_subclause::Vector)
 
-Helper function that extracts factor name and direction from a rule condition subclause
+Helper function that extracts factor name and direction from a rule condition subclause.
+Besides having just one line, this was extracted to a separate function to allow/facilitate
+broadcasting this operation.
 """
 function _strip_value(condition_subclause::Vector)
     return join(condition_subclause[1:2], "__")

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -110,18 +110,21 @@ function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothi
 end
 
 """
-    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric
 (default is median). More information about the keyword arguments accepeted can be found in
 MLJ's doc (https://juliaai.github.io/MLJ.jl/dev/models/StableRulesClassifier_SIRUS/).
 
 # Arguments
-- `clusters` : Vector of cluster indexes for each scenario outcome
-- `X` : Features to be used as input by SIRUS
-- `max_rules` : Maximum number of rules, to be used as input by SIRUS
-- `seed` : Seed to be used by RGN
+- `clusters` : Vector of cluster indexes for each scenario outcome.
+- `X` : Features to be used as input by SIRUS.
+- `max_rules` : Maximum number of rules, to be used as input by SIRUS.
+- `seed` : Seed to be used by RGN. Defaults to 123.
+- `remove_duplicates` : If true, duplicate rules will be removed from resulting ruleset. In
+that case, the rule with the highest probability score is kept. Defaults to true.
+- `kwargs` : Keyword arguments to be passed to `StableRulesClassifier`.
 
 # Returns
 A StableRules object (implemented by SIRUS).
@@ -138,7 +141,7 @@ A StableRules object (implemented by SIRUS).
 """
 function cluster_rules(
     clusters::Vector{T}, X::DataFrame, max_rules::T;
-    seed::Int64=123, remove_duplicates=true, kwargs...
+    seed::Int64=123, remove_duplicates::Bool=true, kwargs...
 )::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     # Set seed and Random Number Generator
     rng = StableRNG(seed)
@@ -165,9 +168,12 @@ function cluster_rules(
 end
 function cluster_rules(
     clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T;
-    kwargs...
+    seed::Int64=123, remove_duplicates::Bool=true, kwargs...
 )::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
-    return cluster_rules(convert.(Int64, clusters), X, max_rules; kwargs...)
+    return cluster_rules(
+        convert.(Int64, clusters), X, max_rules;
+        seed=seed, remove_duplicates=remove_duplicates, kwargs...
+    )
 end
 
 """

--- a/src/analysis/rule_extraction.jl
+++ b/src/analysis/rule_extraction.jl
@@ -109,7 +109,7 @@ function print_rules(rules::Vector{Rule{Vector{Vector},Vector{Float64}}})::Nothi
 end
 
 """
-    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T;seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
+    cluster_rules(clusters::Vector{T}, X::DataFrame, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     cluster_rules(clusters::Union{BitVector,Vector{Bool}}, X::DataFrame, max_rules::T; seed::Int64=123, remove_duplicates::Bool=true, kwargs...)::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
 
 Use SIRUS package to extract rules from time series clusters based on some summary metric

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -245,8 +245,13 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
     scenarios_iv = scens[:, fields_iv]
 
     # Use SIRUS algorithm to extract rules
-    max_rules = 4
-    rules_iv = ADRIA.analysis.cluster_rules(target_clusters, scenarios_iv, max_rules)
+    max_rules = 10
+    rules_iv = ADRIA.analysis.cluster_rules(
+        target_clusters, scenarios_iv, max_rules; remove_duplicates=true
+    )
+    rules_iv_duplicates = ADRIA.analysis.cluster_rules(
+        target_clusters, scenarios_iv, max_rules; remove_duplicates=false
+    )
 
     # Plot scatters for each rule highlighting the area selected them
     rules_scatter_fig = ADRIA.viz.rules_scatter(
@@ -254,6 +259,15 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
         scenarios_iv,
         target_clusters,
         rules_iv;
+        fig_opts=fig_opts,
+        opts=opts
+    )
+
+    ADRIA.viz.rules_scatter(
+        rs,
+        scenarios_iv,
+        target_clusters,
+        rules_iv_duplicates;
         fig_opts=fig_opts,
         opts=opts
     )

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -252,6 +252,8 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame)
     rules_iv_duplicates = ADRIA.analysis.cluster_rules(
         target_clusters, scenarios_iv, max_rules; remove_duplicates=false
     )
+    ADRIA.analysis.print_rules(rules_iv)
+    ADRIA.analysis.print_rules(rules_iv_duplicates)
 
     # Plot scatters for each rule highlighting the area selected them
     rules_scatter_fig = ADRIA.viz.rules_scatter(


### PR DESCRIPTION
Add optional kwarg to `cluster_rules` to allow for removing duplicate rules. The criteria to choose
which rule to keep is based on the rule consequence probability: the one with the highest probability is kept. If more than one rule has the same highest probability, the first one is chosen.


Example of two plots one with and one without duplicated rules (the duplicated rule is `Assisted Adaptation & Selection Frequency (Seed)` (3rd row, 2nd and 3rd cols on the second figure):

![tmp_rules](https://github.com/user-attachments/assets/53c1d80c-5a67-4d86-b937-0dd5002397a3)
![tmp_duplicated_rules](https://github.com/user-attachments/assets/9259f8db-a4f1-4b3a-9607-fed981ad7d51)
