### PR TITLE
Add additional convenience functions and update docstrings

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -122,13 +122,17 @@ function update_params!(d::Domain, params::Union{AbstractVector,DataFrameRow})::
 end
 
 """
+    component_params(dom::Domain, component)::DataFrame
     component_params(m::Model, component)::DataFrame
     component_params(spec::DataFrame, component)::DataFrame
-    component_params(m::Model, components::Vector)::DataFrame
-    component_params(spec::DataFrame, components::Vector)::DataFrame
+    component_params(m::Model, components::Vector{T})::DataFrame
+    component_params(spec::DataFrame, components::Vector{T})::DataFrame
 
 Extract parameters for a specific model component.
 """
+function component_params(dom::Domain, component)::DataFrame
+    return component_params(model_spec(dom), component)
+end
 function component_params(m::Model, component)::DataFrame
     return component_params(model_spec(m), component)
 end

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -346,9 +346,10 @@ function _deactivate_interventions(to_update::DataFrame)::Nothing
 end
 
 """
-    fix_factor!(d::Domain, factor::Symbol)
-    fix_factor!(d::Domain, factor::Symbol, val::Real)
-    fix_factor!(d::Domain, factors...)
+    fix_factor!(d::Domain, factor::Symbol)::Nothing
+    fix_factor!(d::Domain, factor::Symbol, val::Real)::Nothing
+    fix_factor!(d::Domain, factors::Vector{Symbol})::Nothing
+    fix_factor!(d::Domain; factors...)::Nothing
 
 Fix a factor so it gets ignored for the purpose of constructing samples.
 If no value is provided, the default is used.
@@ -363,6 +364,9 @@ fix_factor!(dom, :guided)
 
 # Fix `guided` to specified value
 fix_factor!(dom, :guided, 3)
+
+# Fix a set of factors to their default values
+fix_factor!(dom, [:guided, :N_seed_TA])
 
 # Fix specified factors to provided values
 fix_factor!(dom; guided=3, N_seed_TA=1e6)
@@ -388,6 +392,13 @@ function fix_factor!(d::Domain, factor::Symbol, val::Real)::Nothing
     params[params.fieldname .== factor, :dist_params] .= [new_dist_params]
 
     update!(d, params)
+    return nothing
+end
+function fix_factor!(d::Domain, factors::Vector{Symbol})::Nothing
+    for f in factors
+        fix_factor!(d, f)
+    end
+
     return nothing
 end
 function fix_factor!(d::Domain; factors...)::Nothing


### PR DESCRIPTION
Adding the following:

```julia
# Get model component parameters directly from a domain
coral_params = ADRIA.component_params(dom, ADRIA.Coral)

# Set a list of factors to default values by name
ADRIA.fix_factor!(dom, [:N_seed_TA, :N_seed_CA])
```

The addition extends already existing method names and simplifies their use.

pinging @Zapiano  @DanTanAtAims for awareness.
Skipping the usual review process in the interest of time given the low risk.



