### PR TITLE
Remove defunct method `seed_corals!`

### DIFF
--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -44,113 +44,37 @@ function distribute_seeded_corals(
 end
 
 """
-    seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space_m²::V, seed_locs::Vector{Int64}, seeded_area::YAXArray, seed_sc::BitVector, a_adapt::V, Yseed::SubArray, stdev::V, c_dist_t::Matrix{Float64})::Nothing where {V<:Vector{Float64}}
-    seed_corals!(cover::AbstractArray{Float64,3}, loc_k_area::Vector{T}, leftover_space_m²::Vector{T}, seed_locs::Vector{Int64}, seeded_area::YAXArray, seed_sc::Matrix{Bool}, a_adapt::Matrix{T}, Yseed::SubArray, stdev::Matrix{T}, c_dist_t::Array{Float64,3})::Nothing where {T<:Float64}
+    update_tolerance_distribution!(
+        scaled_seed::YAXArray,
+        cover::Matrix{T},
+        c_dist_t::Matrix{T},
+        stdev::Vector{T},
+        seed_locs::Vector{Int64},
+        seed_sc::BitVector,
+        a_adapt::Vector{T}
+    )::Nothing where {T<:Float64}
 
-Deploy corals to indicated locations ("seeding" or "outplanting").
-Increases indicated area covered by the given coral taxa and determines the modified
-distribution of critical DHW thresholds.
-
-Note: Units for all areas are expected to be identical, and are assumed to be in m².
+Update the thermal tolerance distribution of a population due to seeding.
+Updates the store `c_dist_t` in place.
 
 # Arguments
-- `cover` : Area currently covered by coral
-- `loc_k_area` : Carrying capacity of location (in m²)
-- `leftover_space_m²` : Currently available area at each location
-- `seed_locs` : Selected locations to seed
-- `seeded_area` : Area to seed
-- `seed_sc` : Indicates in-matrix locations of the coral size classes to seed
-- `a_adapt` : Mean of thermal enhancement in terms of DHW
-- `Yseed` : Log of seeded locations to update
-- `c_dist_t` : Critical DHW distributions of corals to update (i.e., for time \$t\$)
+- `scaled_seed` : Seeding values transformed to proportion cover increase relative to k area.
+- `cover` : Current coral cover state.
+- `c_dist_t` : Critical DHW distributions of corals to update (i.e., for time \$t\$).
+- `stdev` : Standard deviation of DHW tolerance distributions for each functional type.
+- `seed_locs` : Seeding locations
+- `seed_sc` : Size classes to seed
+- `a_adapt` : Level of assisted adaptation (as DHW tolerance increase)
 """
-function seed_corals!(
-    cover::Matrix{Float64},
-    loc_k_area::V,
-    leftover_space_m²::V,
+function update_tolerance_distribution!(
+    scaled_seed::YAXArray,
+    cover::AbstractArray{T},
+    c_dist_t::AbstractArray{T},
+    stdev::AbstractArray{T},
     seed_locs::Vector{Int64},
-    seeded_area::YAXArray,
-    seed_sc::BitVector,
-    a_adapt::V,
-    Yseed::SubArray,
-    stdev::V,
-    c_dist_t::Matrix{Float64}
-)::Nothing where {V<:Vector{Float64}}
-    # Selected locations can fill up over time so avoid locations with no space
-    seed_locs = seed_locs[findall(leftover_space_m²[seed_locs] .> 0.0)]
-
-    # Calculate proportion to seed based on current available space
-    scaled_seed = distribute_seeded_corals(
-        loc_k_area[seed_locs],
-        leftover_space_m²[seed_locs],
-        seeded_area
-    )
-
-    # Log seeded corals
-    Yseed[:, seed_locs] .= scaled_seed
-
-    # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
-    # Note: It is entirely possible for a location to be ranked in the top N, but
-    #       with no deployments (for a given species). A location with 0 cover
-    #       and no deployments will therefore be NaN due to zero division.
-    #       These are replaced with 1.0 so that the distribution for unseeded
-    #       corals are used.
-    w_taxa::Matrix{Float64} = scaled_seed ./ (cover[seed_sc, seed_locs] .+ scaled_seed)
-    replace!(w_taxa, NaN => 1.0)
-
-    # Update critical DHW distribution for deployed size classes
-    for (i, loc) in enumerate(seed_locs)
-        # Previous distributions
-        c_dist_ti = @view(c_dist_t[seed_sc, loc])
-
-        # Truncated normal distributions for deployed corals
-        # Assume same stdev and bounds as original
-        tn::Vector{Float64} =
-            truncated_normal_mean.(
-                a_adapt[seed_sc], stdev[seed_sc], 0.0, a_adapt[seed_sc] .+ HEAT_UB
-            )
-
-        # If seeding an empty location, no need to do any further calculations
-        if all(isapprox.(w_taxa[:, i], 1.0))
-            c_dist_t[seed_sc, loc] .= tn
-            continue
-        end
-
-        # Create new distributions by mixing previous and current distributions using
-        # proportional cover as the priors/weights
-        # Priors (weights based on cover for each species)
-        tx::Vector{Weights} = Weights.(eachcol(vcat(w_taxa[:, i]', 1.0 .- w_taxa[:, i]')))
-        c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
-    end
-
-    return nothing
-end
-function seed_corals!(
-    cover::AbstractArray{Float64,3},
-    loc_k_area::Vector{T},
-    leftover_space_m²::Vector{T},
-    seed_locs::Vector{Int64},
-    seeded_area::YAXArray,
-    seed_sc::Matrix{Bool},
-    a_adapt::Matrix{T},
-    Yseed::SubArray,
-    stdev::Matrix{T},
-    c_dist_t::Array{Float64,3}
+    seed_sc::AbstractMatrix{Bool},
+    a_adapt::AbstractMatrix{T}
 )::Nothing where {T<:Float64}
-    # Selected locations can fill up over time so avoid locations with no space
-    seed_locs = seed_locs[findall(leftover_space_m²[seed_locs] .> 0.0)]
-    loc_mask::BitVector = [loc in seed_locs for loc in 1:length(loc_k_area)]
-
-    # Calculate proportion to seed based on current available space
-    scaled_seed = distribute_seeded_corals(
-        loc_k_area[seed_locs],
-        leftover_space_m²[seed_locs],
-        seeded_area
-    )
-
-    # Seed each location and log
-    Yseed[:, seed_locs] .= scaled_seed
-
     # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
     # Note: It is entirely possible for a location to be ranked in the top N, but
     #       with no deployments (for a given species). A location with 0 cover

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -44,9 +44,10 @@ function distribute_seeded_corals(
 end
 
 """
-    seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space_m²::V, seed_locs::Vector{Int64}, seeded_area::YAXArray, seed_sc::BitVector, a_adapt::V, Yseed::SubArray, stdev::V, c_dist_t::Matrix)::Nothing where {V<:Vector{Float64}}
+    seed_corals!(cover::Matrix{Float64}, loc_k_area::V, leftover_space_m²::V, seed_locs::Vector{Int64}, seeded_area::YAXArray, seed_sc::BitVector, a_adapt::V, Yseed::SubArray, stdev::V, c_dist_t::Matrix{Float64})::Nothing where {V<:Vector{Float64}}
+    seed_corals!(cover::AbstractArray{Float64,3}, loc_k_area::Vector{T}, leftover_space_m²::Vector{T}, seed_locs::Vector{Int64}, seeded_area::YAXArray, seed_sc::Matrix{Bool}, a_adapt::Matrix{T}, Yseed::SubArray, stdev::Matrix{T}, c_dist_t::Array{Float64,3})::Nothing where {T<:Float64}
 
-Deploy thermally enhanced corals to indicated locations ("seeding" or "outplanting").
+Deploy corals to indicated locations ("seeding" or "outplanting").
 Increases indicated area covered by the given coral taxa and determines the modified
 distribution of critical DHW thresholds.
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -720,6 +720,7 @@ function run_model(
         C_cover_t[:, :, habitable_locs] .=
             C_cover[tstep - 1, :, :, habitable_locs] .* habitable_loc_areas′
 
+        # Settlers from t-1 grow into observable sizes.
         C_cover_t[:, 1, habitable_locs] .+= recruitment
 
         lin_ext_scale_factors::Vector{Float64} = linear_extension_scale_factors(

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -529,7 +529,6 @@ function run_model(
     C_cover[1, :, :, :] .= _reshape_init_cover(
         domain.init_coral_cover, (n_sizes, n_groups, n_locs)
     )
-    loc_cover_cache = zeros(n_locs)
 
     # Locations that can support corals
     vec_abs_k = site_k_area(domain)


### PR DESCRIPTION
Code flow in `run_model()` is very convoluted so I extracted and refactored the key process for coral deployments so what is happening in the main loop is more obvious.

`seed_corals!()` is now consolidated into the `run_model()` method, allowing some defunct code to be cleaned up.