### PR TITLE
Switch to logging number of coral deployed

### DIFF
--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -13,8 +13,6 @@ Distributes seeded corals according to current available space at each selected 
 - seed_volume : Absolute number of coral to deploy.
 
 # Returns
-YAXArray[taxa to seed ⋅ number of seed locations], area increased relative to k area.
-
 - YAXArray[taxa to seed ⋅ number of seed locations], Proportional increase in cover relative to locations' `k` area
 - Matrix[seed locations ⋅ taxa to seed], Number of coral deployed
 """

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -23,7 +23,7 @@ function distribute_seeded_corals(
     available_space::Vector{Float64},
     seeded_area::YAXArray,
     seed_volume::Vector{Float64}
-)::Tuple{YAXArray, Matrix{Float64}}
+)::Tuple{YAXArray,Matrix{Float64}}
     total_seeded_area::Float64 = sum(seeded_area)
     total_available_space::Float64 = sum(available_space)
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -45,7 +45,10 @@ function distribute_seeded_corals(
         locations=1:length(available_space)
     )
 
-    n_deployed_coral = prop_area_avail .* seed_volume'
+    n_deployed_coral =
+        prop_area_avail .* seed_volume' .* max(
+            total_available_space / total_seeded_area, 1.0
+        )
 
     return proportional_increase, n_deployed_coral
 end

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -7,18 +7,23 @@ Calculate proportion of deployed corals to be seeded at each of the selected loc
 Distributes seeded corals according to current available space at each selected site.
 
 # Arguments
-- seed_loc_k_m² : carrying capacity area of locations to seed in m².
-- available_space : currently available space at each seed location in m².
-- seeded_area : area (in m²) of each coral type to be seeded with dim taxa.
+- seed_loc_k_m² : Carrying capacity area of locations to seed in m².
+- available_space : Currently available space at each seed location in m².
+- seeded_area : Area (in m²) of each coral type to be seeded with dim taxa.
+- seed_volume : Absolute number of coral to deploy.
 
 # Returns
 YAXArray[taxa to seed ⋅ number of seed locations], area increased relative to k area.
+
+- YAXArray[taxa to seed ⋅ number of seed locations], Proportional increase in cover relative to locations' `k` area
+- Matrix[seed locations ⋅ taxa to seed], Number of coral deployed
 """
 function distribute_seeded_corals(
     seed_loc_k_m²::Vector{Float64},
     available_space::Vector{Float64},
-    seeded_area::YAXArray
-)::YAXArray
+    seeded_area::YAXArray,
+    seed_volume::Vector{Float64}
+)::Tuple{YAXArray, Matrix{Float64}}
     total_seeded_area::Float64 = sum(seeded_area)
     total_available_space::Float64 = sum(available_space)
 
@@ -27,6 +32,7 @@ function distribute_seeded_corals(
     prop_area_avail = available_space ./ total_available_space
     if total_seeded_area > total_available_space
         @warn "Seeded area exceeds available space. Restricting to available space."
+        seeded_area = copy(seeded_area)
         seeded_area .*= total_available_space / total_seeded_area
     end
 
@@ -35,12 +41,15 @@ function distribute_seeded_corals(
     #     proportion * (area of 1 coral * num seeded corals)
     # Convert to relative cover proportion by dividing by location area
     scaled_seed = ((prop_area_avail .* seeded_area.data') ./ seed_loc_k_m²)'
-
-    return DataCube(
+    proportional_increase = DataCube(
         scaled_seed;
         taxa=caxes(seeded_area)[1].val.data,
         locations=1:length(available_space)
     )
+
+    n_deployed_coral = prop_area_avail .* seed_volume'
+
+    return proportional_increase, n_deployed_coral
 end
 
 """

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -953,7 +953,7 @@ function run_model(
             seed_locs = seed_locs[findall(available_space .> 0.0)]
 
             # Calculate proportion to seed based on current available space
-            proportional_increase, abs_seeded_area = distribute_seeded_corals(
+            proportional_increase, n_corals_seeded = distribute_seeded_corals(
                 vec_abs_k[seed_locs],
                 available_space,
                 max_seeded_area,
@@ -961,7 +961,7 @@ function run_model(
             )
 
             # Log estimated number of corals seeded
-            Yseed[tstep, :, seed_locs] .= abs_seeded_area'
+            Yseed[tstep, :, seed_locs] .= n_corals_seeded'
 
             # Add coral seeding to recruitment
             # (1,2,4) refer to the coral functional groups being seeded

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -950,33 +950,39 @@ function run_model(
             seed_locs = findall(log_location_ranks.locations .∈ [selected_seed_ranks])
 
             available_space = leftover_space_m²[seed_locs]
-            seed_locs = seed_locs[findall(available_space .> 0.0)]
+            locs_with_space = findall(available_space .> 0.0)
 
-            # Calculate proportion to seed based on current available space
-            proportional_increase, n_corals_seeded = distribute_seeded_corals(
-                vec_abs_k[seed_locs],
-                available_space,
-                max_seeded_area,
-                seed_volume.data
-            )
+            # If there are locations with space to select from, then deploy what we can
+            # Otherwise, do nothing.
+            if length(locs_with_space) > 0
+                seed_locs = seed_locs[locs_with_space]
 
-            # Log estimated number of corals seeded
-            Yseed[tstep, :, seed_locs] .= n_corals_seeded'
+                # Calculate proportion to seed based on current available space
+                proportional_increase, n_corals_seeded = distribute_seeded_corals(
+                    vec_abs_k[seed_locs],
+                    available_space,
+                    max_seeded_area,
+                    seed_volume.data
+                )
 
-            # Add coral seeding to recruitment
-            # (1,2,4) refer to the coral functional groups being seeded
-            # These are tabular Acropora, corymbose Acropora, and small massives
-            recruitment[[1, 2, 4], seed_locs] .+= proportional_increase
+                # Log estimated number of corals seeded
+                Yseed[tstep, :, seed_locs] .= n_corals_seeded'
 
-            update_tolerance_distribution!(
-                proportional_increase,
-                C_cover_t,
-                c_mean_t,
-                c_std,
-                seed_locs,
-                seed_sc,
-                a_adapt
-            )
+                # Add coral seeding to recruitment
+                # (1,2,4) refer to the coral functional groups being seeded
+                # These are tabular Acropora, corymbose Acropora, and small massives
+                recruitment[[1, 2, 4], seed_locs] .+= proportional_increase
+
+                update_tolerance_distribution!(
+                    proportional_increase,
+                    C_cover_t,
+                    c_mean_t,
+                    c_std,
+                    seed_locs,
+                    seed_sc,
+                    a_adapt
+                )
+            end
         end
 
         # Apply disturbances

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -586,11 +586,12 @@ function run_model(
         domain.coral_growth, (corals.taxa_id .∈ [taxa_to_seed]) .& target_class_id
     )
 
-    # Extract colony areas for sites selected in m^2 and add adaptation values
+    # Extract colony areas and determine approximate seeded area in m^2
+    seed_volume = param_set[At(taxa_names)]
     colony_areas = _to_group_size(
         domain.coral_growth, colony_mean_area(corals.mean_colony_diameter_m)
     )
-    seeded_area = colony_areas[seed_sc] .* param_set[At(taxa_names)]
+    max_seeded_area = colony_areas[seed_sc] .* seed_volume
 
     # Set up assisted adaptation values
     a_adapt = zeros(n_groups, n_sizes)
@@ -608,7 +609,7 @@ function run_model(
 
     # Calculate total area to seed respecting tolerance for minimum available space to still
     # seed at a site
-    area_to_seed = sum(seeded_area)
+    max_area_to_seed = sum(max_seeded_area)
 
     depth_criteria = identify_within_depth_bounds(
         loc_data.depth_med, param_set[At("depth_min")], param_set[At("depth_offset")]
@@ -871,7 +872,7 @@ function run_model(
         has_fog_locs::Bool = !isempty(selected_fog_ranks)
 
         # Fog selected locations
-        if fog_decision_years[tstep] && has_fog_locs
+        if has_fog_locs  # fog_decision_years[tstep] &&
             fog_locs = findall(log_location_ranks.locations .∈ [selected_fog_ranks])
             fog_locations!(@view(Yfog[tstep, :]), fog_locs, dhw_t, fogging)
         end
@@ -879,7 +880,11 @@ function run_model(
         # Seeding
         # IDs of valid locations considering locations that have space for corals
         locs_with_space = vec(leftover_space_m²) .> 0.0
-        if is_guided && seed_decision_years[tstep] && (length(locs_with_space) > 0)
+        if is_guided
+            considered_locs = findall(_valid_locs .& locs_with_space)
+        end
+
+        if is_guided && seed_decision_years[tstep] && (length(considered_locs) > 0)
             considered_locs = findall(_valid_locs .& locs_with_space)
 
             # Use modified projected DHW (may have been affected by fogging or shading)
@@ -909,7 +914,7 @@ function run_model(
                 decision_mat[location=locs_with_space[_valid_locs]],
                 MCDA_approach,
                 loc_data.cluster_id,
-                area_to_seed,
+                max_area_to_seed,
                 considered_locs,
                 vec(leftover_space_m²),
                 min_iv_locs,
@@ -939,28 +944,32 @@ function run_model(
         has_seed_locs::Bool = !isempty(selected_seed_ranks)
 
         # Apply seeding (assumed to occur after spawning)
-        if seed_decision_years[tstep] && has_seed_locs
+        if has_seed_locs  # seed_decision_years[tstep] &&
             # Seed selected locations
             # Selected locations can fill up over time so avoid locations with no space
             seed_locs = findall(log_location_ranks.locations .∈ [selected_seed_ranks])
-            seed_locs = seed_locs[findall(leftover_space_m²[seed_locs] .> 0.0)]
+
+            available_space = leftover_space_m²[seed_locs]
+            seed_locs = seed_locs[findall(available_space .> 0.0)]
 
             # Calculate proportion to seed based on current available space
-            scaled_seed = distribute_seeded_corals(
+            proportional_increase, abs_seeded_area = distribute_seeded_corals(
                 vec_abs_k[seed_locs],
-                leftover_space_m²[seed_locs],
-                seeded_area
+                available_space,
+                max_seeded_area,
+                seed_volume.data
             )
 
-            # Log seeded corals
-            Yseed[tstep, :, seed_locs] .= scaled_seed
+            # Log estimated number of corals seeded
+            Yseed[tstep, :, seed_locs] .= abs_seeded_area'
 
             # Add coral seeding to recruitment
             # (1,2,4) refer to the coral functional groups being seeded
-            recruitment[[1, 2, 4], :] .+= Yseed[tstep, :, :]
+            # These are tabular Acropora, corymbose Acropora, and small massives
+            recruitment[[1, 2, 4], seed_locs] .+= proportional_increase
 
             update_tolerance_distribution!(
-                scaled_seed,
+                proportional_increase,
                 C_cover_t,
                 c_mean_t,
                 c_std,

--- a/test/seeding.jl
+++ b/test/seeding.jl
@@ -33,7 +33,8 @@ end
 
         # evaluate seeding distributions
         seed_dist, _ = distribute_seeded_corals(
-            total_loc_area[seed_locs], available_space[seed_locs], seeded_area, seeded_volume
+            total_loc_area[seed_locs], available_space[seed_locs], seeded_area,
+            seeded_volume
         )
 
         # Area to be seeded for each site
@@ -107,7 +108,6 @@ end
             seeded_area,
             seeded_volume
         )
-        Main.@infiltrate
 
         update_tolerance_distribution!(
             proportional_increase,


### PR DESCRIPTION
**Please note: This PR requires #909 to be merged in first.**

Previously we were logging the proportional area increase for each deployment location.

For analyses, I think it makes more sense to assess the number of coral deployed at each location instead, particularly for bump hunting and feature analysis.

@DanTanAtAims sorry to overload you - I requested a review from @Zapiano initially, but realised because this PR relies on #909 , whoever reviews that one would have better context on the changes here.

Please check my math used to derive deployed number of corals with a fine-tooth comb.