### PR TITLE
Add option to input functional groups and size classes parameters

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -18,16 +18,17 @@ mutable struct EnvLayer{S<:AbstractString,TF}
 end
 
 """
-    load_domain(path::String)
+    load_domain(path::String; coral_spec_path::String="")
 
 Load ADRIA domain specification from data package.
 No SSP/RCP data is preset.
 
 # Arguments
 - `path` : location of data package.
+- `coral_spec_path` : location of JSON with coral ecological parameters if not using default functional groups and size classes.
 """
-function load_domain(path::String)::Domain
-    return load_domain(path, "")
+function load_domain(path::String; coral_spec_path::String="")::Domain
+    return load_domain(path, ""; coral_spec_path=coral_spec_path)
 end
 
 function unique_loc_ids(d::Domain)::Vector{String}

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -124,6 +124,8 @@ function rank_locations(
 
     loc_data = dom.loc_data
     coral_habitable_locs = loc_data.k .> 0.0
+
+    coral_params = dom.coral_params
     for (scen_idx, scen) in enumerate(eachrow(scens))
         # Decisions should place more weight on environmental conditions
         # closer to the decision point
@@ -154,7 +156,7 @@ function rank_locations(
         MCDA_approach = mcda_methods()[Int64(scen[factors=At("guided")][1])]
         leftover_space_m² = vec(leftover_space_scens[scen_idx, :])
 
-        corals = to_coral_spec(scenarios[scen_idx, :])
+        corals = to_coral_spec(coral_params, scenarios[scen_idx, :])
         area_to_seed = mean(
             n_corals *
             colony_mean_area(corals.mean_colony_diameter_m[corals.class_id .== 2])

--- a/src/ecosystem/corals/CoralGrowth.jl
+++ b/src/ecosystem/corals/CoralGrowth.jl
@@ -25,33 +25,37 @@ function CoralGrowth(n_locs::Int64, n_groups::Int64, n_sizes::Int64)::CoralGrowt
     n_group_and_size::Int64 = n_groups * n_sizes
 
     # Store specific indices for use in growth ODE function
-    # These are specific to the 35 "species"/ 5 group formulation
-    small::SVector = @SVector [1, 8, 15, 22, 29]
-    mid::SVector = SVector{25}(collect([2:6; 9:13; 16:20; 23:27; 30:34]))
-    large::SVector = @SVector [7, 14, 21, 28, 35]
+    # The following splits into "small, mid and large" indices based on number of size classes and functional groups
+    indices_array = zeros(Int64, (n_groups, n_sizes))
+    for n_g in 0:(n_groups - 1)
+        indices_array[n_g + 1, :] .= collect((n_g * n_sizes + 1):(n_g * n_sizes + n_sizes))
+    end
 
-    # Values for ode_p
-    # TODO: The named tuple was for use with ODE solvers, which is no unneeded.
-    # These caches should all be moved into the `CoralGrowth` struct.
+    mid_ind = collect(indices_array[:, 2:(end - 1)])[:]
+    size_mid = prod(size(indices_array[:, 2:(end - 1)]))
+
+    small::SVector{n_groups} = indices_array[:, 1]
+    mid::SVector{size_mid} = mid_ind
+    large::SVector{n_groups} = indices_array[:, end]
     p = @NamedTuple{
-        small::StaticArrays.SVector{5,Int64},  # indices for small size classes
-        mid::StaticArrays.SVector{25,Int64},   # indices for mid-size corals
-        large::StaticArrays.SVector{5,Int64},  # indices for large corals
-        rec::Matrix{Float64},                  # recruitment values, where `s` relates to available space (not max carrying capacity)
-        sXr::Array{Float64,3},                  # s * X * r
-        X_mb::Array{Float64,3},                 # X * mb
-        r::Matrix{Float64},                    # growth rate
-        mb::Matrix{Float64}                    # background mortality
+        small::StaticArrays.SVector{n_groups,Int64},           # indices for small size classes
+        mid::StaticArrays.SVector{size_mid,Int64},            # indices for mid-size corals
+        large::StaticArrays.SVector{n_groups,Int64},           # indices for large corals
+        rec::Matrix{Float64},                           # recruitment values, where `s` relates to available space (not max carrying capacity)
+        sXr::Array{Float64},                           # s * X * r
+        X_mb::Array{Float64},                          # X * mb
+        r::Matrix{Float64},                             # growth rate
+        mb::Matrix{Float64}                             # background mortality
     }((                        # cache matrix to hold X (current coral cover)
-        # Cached indices
+        # cached indices
         small, mid, large,
 
-        # Cache matrices
-        zeros(n_groups, n_locs),           # rec
-        zeros(n_groups, n_sizes, n_locs),  # sXr
+        # cache matrices
+        zeros(n_groups, n_locs),  # rec
+        zeros(n_groups, n_sizes, n_locs), # sXr
         zeros(n_groups, n_sizes, n_locs),  # X_mb
-        zeros(n_groups, n_sizes),          # r
-        zeros(n_groups, n_sizes)           # mb
+        zeros(n_groups, n_sizes),  # r
+        zeros(n_groups, n_sizes)   # mb
     ))
 
     return CoralGrowth(n_locs, n_groups, n_sizes, n_group_and_size, p)

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -80,8 +80,8 @@ end
 
 Helper function defining coral colony diameter bin widths.
 """
-function bin_widths()
-    return bin_edges()[:, 2:end] .- bin_edges()[:, 1:(end - 1)]
+function bin_widths(bin_edges)
+    return bin_edges[:, 2:end] .- bin_edges[:, 1:(end - 1)]
 end
 
 """
@@ -119,9 +119,7 @@ Generate colony area data based on Bozec et al., [1].
        management in the Whitsundays.
      https://doi.org/10.13140/RG.2.2.26976.20482
 """
-function colony_areas()
-    # The coral colony diameter bin edges (cm) are: 0, 2, 5, 10, 20, 40, 80
-    edges = bin_edges(; unit=:cm)
+function colony_areas(edges)
 
     # Diameters in cm
     mean_cm_diameters =
@@ -143,7 +141,7 @@ function bins_bounds(mean_diam::Matrix{Float64})::Matrix{Float64}
 end
 
 """
-    coral_spec()
+    coral_spec(coral_params::Dict{Symbol,Any})
 
 Template for coral parameter values for ADRIA.
 Includes "vital" bio/ecological parameters, to be filled with
@@ -191,7 +189,7 @@ between bleaching years come from [1].
    Global Change Biology 27, 5694-5710.
    https://doi.org/10.1111/gcb.15829
 """
-function coral_spec()::NamedTuple
+function coral_spec(coral_params::Dict{Symbol,Any})::NamedTuple
     # Below parameters pertaining to species are new. We now add size classes
     # to each coral species, but treat each coral size class as a 'species'.
     # Need a better word than 'species' to signal that we are using different
@@ -200,11 +198,11 @@ function coral_spec()::NamedTuple
     params = DataFrame()
 
     # Coral species are divided into taxa and size classes
-    group_names = string.(functional_group_names())
+    group_names::Vector{String} = coral_params[:group_names]
 
     # Coral growth rates as linear extensions.
     # All values in cm/year and are from (unpublished) ecoRRAP data.
-    _linear_extensions::Matrix{Float64} = linear_extensions()
+    _linear_extensions::Matrix{Float64} = coral_params[:linear_extension]
 
     # number of functional groups and size classes modelled in the current version.
     n_groups::Int64, n_sizes::Int64 = size(_linear_extensions)
@@ -223,7 +221,7 @@ function coral_spec()::NamedTuple
     # To be more consistent with parameters in ReefMod, C~Scape and RRAP
     # interventions, we express coral abundance as colony numbers in different
     # size classes and growth rates as linear extension (in cm per year).
-    colony_area_mean_cm², mean_colony_diameter_m = colony_areas()
+    colony_area_mean_cm², mean_colony_diameter_m = colony_areas(coral_params[:bin_edges])
     params.mean_colony_diameter_m = reshape(mean_colony_diameter_m', n_groups_and_sizes)[:]
     params.linear_extension = reshape(_linear_extensions', n_groups_and_sizes)[:]
 
@@ -234,26 +232,61 @@ function coral_spec()::NamedTuple
     # Second, growth as transitions of cover to higher bins is estimated as
     #     rate of growth per year.
     params.growth_rate .= reshape(
-        growth_rate(_linear_extensions, bin_widths()), n_groups_and_sizes
+        growth_rate(_linear_extensions, bin_widths(coral_params[:bin_edges])),
+        n_groups_and_sizes
     )[:]
-
-    # Scope for fecundity as a function of colony area (Hall and Hughes 1996)
-    # Corymbose non-acropora uses the Stylophora data from Hall and Hughes with interpolation
-    fec_par_a = Float64[1.03; 1.69; 0.02; 0.86; 0.86]  # fecundity parameter a
-    fec_par_b = Float64[1.28; 1.05; 2.27; 1.21; 1.21]  # fecundity parameter b
-    min_colony_area_full_fec = Float64[123.0; 134.0; 134.0; 38.0; 38.0]
 
     # fecundity as a function of colony basal area (cm2) from Hall and Hughes 1996
     # unit is number of larvae per colony
     colony_area_cm2 = colony_mean_area(mean_colony_diameter_m .* 100.0)
-    fec = exp.(log.(fec_par_a) .+ fec_par_b .* log.(colony_area_cm2)) ./ 0.1
+    fec =
+        exp.(
+            log.(coral_params[:fec_par_a]) .+
+            coral_params[:fec_par_b] .* log.(colony_area_cm2)
+        ) ./ 0.1
 
     # Colonies with area (in cm2) below indicated size are not fecund (reproductive)
-    fec[colony_area_cm2 .< min_colony_area_full_fec] .= 0.0
+    fec[colony_area_cm2 .< coral_params[:min_colony_area_full_fec]] .= 0.0
 
     # then convert to number of larvae produced per m2
     fec_m² = fec ./ (colony_mean_area(mean_colony_diameter_m)) # convert from per colony area to per m2
     params.fecundity = fec_m²'[:]
+
+    mb = 1.0 .- coral_params[:survival_rate]
+    params.mb_rate = mb'[:]
+
+    upper_bound::Matrix{Float64} = coral_params[:bin_edges][:, 2:end]
+    params.bin_ub = reshape(upper_bound', n_groups_and_sizes)[:]
+
+    # Natural adaptation / heritability
+    # Values here informed by Bairos-Novak et al., (2022) and (unpublished) data from
+    # Hughes et al., (2018)
+    # Mean and std for each species (row) and size class (cols)
+    params.dist_mean = repeat(coral_params[:dist_mean]; inner=n_sizes)
+    params.dist_std = repeat(coral_params[:dist_std]; inner=n_sizes)
+
+    # Get perturbable coral parameters
+    # i.e., the parameter names not defined in the second list
+    param_names = setdiff(names(params), ["name", "taxa_id", "class_id", "coral_id"])
+
+    return (taxa_names=group_names, param_names=param_names, params=params)
+end
+
+function default_coral_params()::Dict{Symbol,Any}
+    coral_params::Dict{Symbol,Any} = Dict(:group_names => string.(functional_group_names()))
+
+    # Coral growth rates as linear extensions.
+    # All values in cm/year and are from (unpublished) ecoRRAP data.
+    coral_params[:linear_extension] = linear_extensions()
+
+    # Edges of size class bins
+    coral_params[:bin_edges] = bin_edges()
+
+    # Scope for fecundity as a function of colony area (Hall and Hughes 1996)
+    # Corymbose non-acropora uses the Stylophora data from Hall and Hughes with interpolation
+    coral_params[:fec_par_a] = Float64[1.03; 1.69; 0.02; 0.86; 0.86]  # fecundity parameter a
+    coral_params[:fec_par_b] = Float64[1.28; 1.05; 2.27; 1.21; 1.21]  # fecundity parameter b
+    coral_params[:min_colony_area_full_fec] = Float64[123.0; 134.0; 134.0; 38.0; 38.0]
 
     # Mortality
     # Survival rates taken from (unpublished) ecoRRAP data.
@@ -265,48 +298,35 @@ function coral_spec()::NamedTuple
     #     0.869976692 0.938029324 0.977889252 0.987199004 0.99207702 0.996931548 0.996931548;     # Small massives and encrusting
     #     0.9782479 0.979496637 0.980850254 0.982178103 0.983568572 0.984667677 0.984667677       # Large massives
     # ]
-    survival_rate::Matrix{Float64} = [
+    coral_params[:survival_rate] = [
         0.6 0.76 0.805 0.76 0.85 0.86 0.86;    # Tabular Acropora
         0.6 0.76 0.77 0.875 0.83 0.90 0.90;    # Corymbose Acropora
         0.52 0.77 0.77 0.875 0.89 0.97621179 0.97621179;                # Corymbose non-Acropora
         0.72 0.87 0.77 0.98 0.996931548 0.996931548 0.996931548;        # Small massives and encrusting
         0.58 0.87 0.78 0.983568572 0.984667677 0.984667677 0.984667677  # Large massives
     ]
-    mb = 1.0 .- survival_rate
-    params.mb_rate = mb'[:]
-
-    upper_bound::Matrix{Float64} = bin_edges()[:, 2:end]
-    params.bin_ub = reshape(upper_bound', n_groups_and_sizes)[:]
 
     # Natural adaptation / heritability
     # Values here informed by Bairos-Novak et al., (2022) and (unpublished) data from
     # Hughes et al., (2018)
     # Mean and std for each species (row) and size class (cols)
-    params.dist_mean = repeat(
-        Float64[
-            # 3.345484656,  # arborescent Acropora
-            3.751612251,  # tabular Acropora
-            4.081622683,  # corymbose Acropora
-            4.487465256,  # Pocillopora + non-Acropora corymbose
-            6.165751937,  # Small massives and encrusting
-            7.153507902   # Large massives
-        ]; inner=n_sizes)
-
-    params.dist_std = repeat(
-        Float64[
-            # 2.590016677,  # arborescent Acropora
-            2.904433676,  # tabular Acropora
-            3.159922076,  # corymbose Acropora
-            3.474118416,  # Pocillopora + non-Acropora corymbose
-            4.773419097,  # Small massives and encrusting
-            5.538122776   # Large massives
-        ]; inner=n_sizes)
-
-    # Get perturbable coral parameters
-    # i.e., the parameter names not defined in the second list
-    param_names = setdiff(names(params), ["name", "taxa_id", "class_id", "coral_id"])
-
-    return (taxa_names=group_names, param_names=param_names, params=params)
+    coral_params[:dist_mean] = Float64[
+        # 3.345484656,  # arborescent Acropora
+        3.751612251,  # tabular Acropora
+        4.081622683,  # corymbose Acropora
+        4.487465256,  # Pocillopora + non-Acropora corymbose
+        6.165751937,  # Small massives and encrusting
+        7.153507902   # Large massives
+    ]
+    coral_params[:dist_std] = Float64[
+        # 2.590016677,  # arborescent Acropora
+        2.904433676,  # tabular Acropora
+        3.159922076,  # corymbose Acropora
+        3.474118416,  # Pocillopora + non-Acropora corymbose
+        4.773419097,  # Small massives and encrusting
+        5.538122776   # Large massives
+    ]
+    return coral_params
 end
 
 """
@@ -351,7 +371,7 @@ function _coral_struct(field_defs::OrderedDict)::Nothing
 end
 
 """
-    create_coral_struct(bounds=(0.9, 1.1))
+    create_coral_struct(coral_params::Dict, bounds=(0.9, 1.1))
 
 Generates Coral struct using the default parameter spec.
 
@@ -368,7 +388,13 @@ coral = Coral()
 ```
 """
 function create_coral_struct(bounds::Tuple{Float64,Float64}=(0.9, 1.1))::Nothing
-    _, base_coral_params, p_vals = coral_spec()
+    coral_params = default_coral_params()
+    return create_coral_struct(coral_params, bounds)
+end
+function create_coral_struct(
+    coral_params::Dict, bounds::Tuple{Float64,Float64}=(0.9, 1.1)
+)::Nothing
+    _, base_coral_params, p_vals = coral_spec(coral_params)
 
     struct_fields = OrderedDict{String,Param}()
     struct_fields["heritability"] = Factor(
@@ -405,24 +431,24 @@ end
 create_coral_struct()
 
 """
-    to_coral_spec(m::Model)::DataFrame
+    to_coral_spec(coral_params::Dict, m::Model)::DataFrame
 
 Convert Coral Model specification to a coral spec DataFrame
 """
-function to_coral_spec(m::Coral)::DataFrame
-    _, pnames, spec = coral_spec()
+function to_coral_spec(coral_params::Dict, m::Coral)::DataFrame
+    _, pnames, spec = coral_spec(coral_params)
     val_df = DataFrame(Model(m))
 
     return _update_coral_spec(spec, pnames, val_df)
 end
 
 """
-    to_coral_spec(coral_df::DataFrame)::DataFrame
+    to_coral_spec(coral_params::Dict, coral_df::DataFrame)::DataFrame
 
 Convert dataframe of model parameters to a coral spec.
 """
-function to_coral_spec(coral_df::DataFrame)::DataFrame
-    _, pnames, spec = coral_spec()
+function to_coral_spec(coral_params::Dict, coral_df::DataFrame)::DataFrame
+    _, pnames, spec = coral_spec(coral_params)
 
     return _update_coral_spec(spec, pnames, coral_df)
 end
@@ -480,8 +506,8 @@ function _update_coral_factors(spec::DataFrame, coral_params::DataFrame)::DataFr
     return spec
 end
 
-function to_coral_spec(inputs::YAXArray)::DataFrame
-    _, pnames, spec = coral_spec()
+function to_coral_spec(coral_params::Dict, inputs::YAXArray)::DataFrame
+    _, pnames, spec = coral_spec(coral_params)
 
     coral_ids::Vector{String} = spec[:, :coral_id]
     for p in pnames
@@ -491,9 +517,9 @@ function to_coral_spec(inputs::YAXArray)::DataFrame
 
     return spec
 end
-function to_coral_spec(inputs::DataFrameRow)::DataFrame
+function to_coral_spec(coral_params::Dict, inputs::DataFrameRow)::DataFrame
     ins = DataCube(Vector(inputs); factors=names(inputs))
-    return to_coral_spec(ins)
+    return to_coral_spec(coral_params, ins)
 end
 
 """

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -141,7 +141,7 @@ function bins_bounds(mean_diam::Matrix{Float64})::Matrix{Float64}
 end
 
 """
-    coral_spec(coral_params::Dict{Symbol,Any})
+    coral_spec(coral_params::Dict{Symbol,Any})::NamedTuple
 
 Template for coral parameter values for ADRIA.
 Includes "vital" bio/ecological parameters, to be filled with
@@ -153,6 +153,16 @@ made available to the ADRIA model.
 Notes:
 Values for the historical, temporal patterns of degree heating weeks
 between bleaching years come from [1].
+
+# Returns
+- `coral_params` A dictionary containing key coral parameters, can be loaded from file or using `default_coral_params()`.
+    Must include the keys
+    - `linear_extension` : Radial extensions per year for each functional group and size class
+    - `bin_edges` : The edges for the size class bins for each functional group
+    - `survival_rate` : The survival proportion for each functional group and size class per year due to background mortality
+    - `dist_mean`, `dist_std` : Mean and standard deviation in heat stress survival curve for each functional group (in DHW)
+    - `min_colony_area_full_fec`, `fec_par_a` and `fec_par_b` : See Hall and Hughes 1996
+    - `group_names` : Name of each functional group as strings
 
 # Returns
 - `params` : NamedTuple[taxa_names, param_names, params], taxa names, parameter
@@ -272,6 +282,14 @@ function coral_spec(coral_params::Dict{Symbol,Any})::NamedTuple
     return (taxa_names=group_names, param_names=param_names, params=params)
 end
 
+"""
+    default_coral_params()::Dict{Symbol,Any}
+
+Returns the default coral parameters for 5 functional groups and 7 size classes.
+
+# Returns
+- `coral_params` : A dictionary of key coral parameters and their default values
+"""
 function default_coral_params()::Dict{Symbol,Any}
     coral_params::Dict{Symbol,Any} = Dict(:group_names => string.(functional_group_names()))
 
@@ -327,6 +345,16 @@ function default_coral_params()::Dict{Symbol,Any}
         5.538122776   # Large massives
     ]
     return coral_params
+end
+
+"""
+    default_coral_spec()::NamedTuple
+
+Returns the default coral specification for 5 functional groups and 7 size classes.
+
+"""
+function default_coral_spec()::NamedTuple
+    return coral_spec(default_coral_params())
 end
 
 """
@@ -485,7 +513,7 @@ default_scen = ADRIA.param_table(dom)
 # ... modify the coral specification at some point
 # this would normally require restarting the Julia session for changes to take effect.
 # Instead, we update the specification with the updated values instead.
-default_scen = ADRIA._update_coral_factors(default_scen, ADRIA.coral_spec().params)
+default_scen = ADRIA._update_coral_factors(default_scen, ADRIA.default_coral_spec().params)
 ```
 """
 function _update_coral_factors(spec::DataFrame, coral_params::DataFrame)::DataFrame

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -231,7 +231,9 @@ function coral_spec(coral_params::Dict{Symbol,Any})::NamedTuple
     # To be more consistent with parameters in ReefMod, C~Scape and RRAP
     # interventions, we express coral abundance as colony numbers in different
     # size classes and growth rates as linear extension (in cm per year).
-    colony_area_mean_cm², mean_colony_diameter_m = colony_areas(coral_params[:bin_edges])
+    colony_area_mean_cm², mean_colony_diameter_m = colony_areas(
+        coral_params[:bin_edges] .* 100
+    )
     params.mean_colony_diameter_m = reshape(mean_colony_diameter_m', n_groups_and_sizes)[:]
     params.linear_extension = reshape(_linear_extensions', n_groups_and_sizes)[:]
 
@@ -299,6 +301,9 @@ function default_coral_params()::Dict{Symbol,Any}
 
     # Edges of size class bins
     coral_params[:bin_edges] = bin_edges()
+
+    # Planar area for each functional group
+    coral_params[:planar_area_params] = planar_area_params()
 
     # Scope for fecundity as a function of colony area (Hall and Hughes 1996)
     # Corymbose non-acropora uses the Stylophora data from Hall and Hughes with interpolation

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -170,7 +170,7 @@ function load_cyclone_mortality(timeframe::Vector{Int64}, loc_data::DataFrame)::
     return ZeroDataCube(;
         timesteps=1:length(timeframe),
         locations=sort(loc_data.reef_siteid),
-        species=ADRIA.coral_spec().taxa_names,
+        species=ADRIA.default_coral_spec().taxa_names,
         scenarios=[1]
     )
 end

--- a/src/io/inputs.jl
+++ b/src/io/inputs.jl
@@ -174,3 +174,26 @@ function load_cyclone_mortality(timeframe::Vector{Int64}, loc_data::DataFrame)::
         scenarios=[1]
     )
 end
+
+"""
+    load_coral_params(coral_path::String)::Dict{Symbol,Any}
+
+Load coral ecological parameters from JSON, or use default parameters if no file provided.
+"""
+function load_coral_params(coral_path::String)::Dict{Symbol,Any}
+    if coral_path == ""
+        coral_params = default_coral_params()
+    else
+        try
+            coral_params = JSON.parsefile(coral_path; dicttype=Dict{Symbol,Any})
+        catch err
+            if err isa (SystemError)
+                println("Specified path for coral parameters not found.\n")
+            end
+        end
+        coral_params[:survival_rate] = vcat(coral_params[:survival_rate]'...)
+        coral_params[:linear_extension] = vcat(coral_params[:linear_extension]'...)
+        coral_params[:bin_edges] = vcat(coral_params[:bin_edges]'...)
+    end
+    return coral_params
+end

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -369,7 +369,9 @@ function _colony_Lcm2_to_m3m2(inputs::DataFrame, coral_params::Dict)::Tuple
     _inputs = DataCube(Matrix(inputs); scenarios=1:nrow(inputs), factors=names(inputs))
     return _colony_Lcm2_to_m3m2(_inputs, coral_params)
 end
-function _colony_Lcm2_to_m3m2(inputs::YAXArray, coral_params::Dict)::Tuple{Vector{Float64},Vector{Float64}}
+function _colony_Lcm2_to_m3m2(
+    inputs::YAXArray, coral_params::Dict
+)::Tuple{Vector{Float64},Vector{Float64}}
     _, _, cs_p::DataFrame = coral_spec(coral_params)
     n_sizes::Int64 = length(unique(cs_p.class_id))
 
@@ -529,7 +531,7 @@ function _absolute_shelter_volume(
         Matrix(Vector(inputs)'); scenarios=1:1, factors=names(inputs)
     )
 
-    return _absolute_shelter_volume(X, k_area, _inputs, coral_params=coral_params)
+    return _absolute_shelter_volume(X, k_area, _inputs; coral_params=coral_params)
 end
 function _absolute_shelter_volume(
     X::YAXArray{T,4},
@@ -541,7 +543,7 @@ function _absolute_shelter_volume(
         Matrix(inputs); scenarios=1:size(inputs, 1), factors=names(inputs)
     )
 
-    return _absolute_shelter_volume(X, k_area, _inputs, coral_params=coral_params)
+    return _absolute_shelter_volume(X, k_area, _inputs; coral_params=coral_params)
 end
 function _absolute_shelter_volume(
     X::YAXArray{T,3},
@@ -720,7 +722,7 @@ function _relative_shelter_volume(
     for scen::Int64 in 1:nscens
         colony_vol, max_colony_vol = _colony_Lcm2_to_m3m2(scens[scen, :], coral_params)
         RSV[scenarios=scen] .= _shelter_species_loop(
-            X[scenarios=scen], nspecies, colony_vol, max_colony_vol, k_area,
+            X[scenarios=scen], nspecies, colony_vol, max_colony_vol, k_area
         )
     end
 

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -9,7 +9,7 @@ using
 
 using YAXArrays
 using ADRIA:
-    DataCube, ZeroDataCube, axes_names, axis_labels, axis_index
+    DataCube, ZeroDataCube, axes_names, axis_labels, axis_index, default_coral_params, default_coral_spec
 using ADRIA: n_sizes, group_indices
 
 using FLoops
@@ -378,6 +378,7 @@ function _colony_Lcm2_to_m3m2(
     # Extract colony diameter (in cm) for each taxa/size class from scenario inputs
     # Have to be careful to extract data in the correct order, matching coral id
     n_groups_sizes::Int64 = size(cs_p, 1)
+    #Main.@infiltrate
     colony_mean_diams_cm::Vector{Float64} = reshape(
         (inputs[factors=At(cs_p.coral_id .* "_mean_colony_diameter_m")] .* 100.0).data,
         n_groups_sizes
@@ -386,7 +387,7 @@ function _colony_Lcm2_to_m3m2(
     # Colony planar area parameters (see Fig 2B in Aston et al., [1])
     # First column is `b`, second column is `a`
     # log(S) = b + a * log(x)
-    pa_params::Array{Float64,2} = planar_area_params()
+    pa_params::Array{Float64,2} = coral_params[:planar_area_params]
 
     # Repeat each entry `n_sizes` times to cover the number size classes represented
     pa_params = repeat(pa_params; inner=(n_sizes, 1))
@@ -431,6 +432,7 @@ function _shelter_species_loop(
 )::YAXArray where {T1<:Real,F<:Float64}
     # Calculate absolute shelter volumes first
     ASV::YAXArray = ZeroDataCube((:timesteps, :species, :locations), size(X))
+
     _shelter_species_loop!(X, ASV, n_group_and_size, colony_vol_m3_per_m2, k_area)
 
     # Maximum shelter volume

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -9,7 +9,8 @@ using
 
 using YAXArrays
 using ADRIA:
-    DataCube, ZeroDataCube, axes_names, axis_labels, axis_index, default_coral_params, default_coral_spec
+    DataCube, ZeroDataCube, axes_names, axis_labels, axis_index, default_coral_params,
+    default_coral_spec
 using ADRIA: n_sizes, group_indices
 
 using FLoops
@@ -378,7 +379,7 @@ function _colony_Lcm2_to_m3m2(
     # Extract colony diameter (in cm) for each taxa/size class from scenario inputs
     # Have to be careful to extract data in the correct order, matching coral id
     n_groups_sizes::Int64 = size(cs_p, 1)
-    #Main.@infiltrate
+
     colony_mean_diams_cm::Vector{Float64} = reshape(
         (inputs[factors=At(cs_p.coral_id .* "_mean_colony_diameter_m")] .* 100.0).data,
         n_groups_sizes

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -711,7 +711,7 @@ function _relative_shelter_volume(
     nscens::Int64 = size(X, :scenarios)
 
     # Result template - six entries, one for each taxa
-    n_groups::Int64 = length(coral_spec().taxa_names)
+    n_groups::Int64 = length(default_coral_spec().taxa_names)
     RSV::YAXArray = ZeroDataCube(
         (:timesteps, :species, :locations, :scenarios),
         size(X[:, 1:n_groups, :, :]),

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -84,7 +84,7 @@ Calculate the mean relative juvenile population for each scenario for the entire
 num_scens = 2^5
 scens = ADRIA.sample(dom, num_scens)
 
-_coral_spec = ADRIA.to_coral_spec(scens[1,:])
+_coral_spec = ADRIA.to_coral_spec(dom.coral_params, scens[1,:])
 _k_area = site_k_area(dom)
 
 # X contains raw coral cover results for a single scenario

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -691,7 +691,9 @@ function run_model(
 
     # Cache matrix to store potential settlers
     potential_settlers = zeros(size(fec_scope)...)
-    _linear_extensions::Matrix{Float64} = _to_group_size(domain.coral_growth, corals.linear_extension)
+    _linear_extensions::Matrix{Float64} = _to_group_size(
+        domain.coral_growth, corals.linear_extension
+    )
     _bin_edges::Matrix{Float64} = domain.coral_params[:bin_edges]
     survival_rate = 1.0 .- _to_group_size(domain.coral_growth, corals.mb_rate)
 

--- a/test/growth.jl
+++ b/test/growth.jl
@@ -18,7 +18,7 @@ using ADRIA.Distributions
 end
 
 @testset "Coral Spec" begin
-    coral_params = ADRIA.coral_spec().params
+    coral_params = ADRIA.default_coral_spec().params
 
     bin_edge_diameters_cm2 = ADRIA.colony_mean_area(ADRIA.bin_edges())
     stored_colony_mean_areas = ADRIA.colony_mean_area(

--- a/test/metrics/metrics.jl
+++ b/test/metrics/metrics.jl
@@ -52,7 +52,7 @@ end
 
     @testset "relative_juveniles" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
         test_metric(metrics.relative_juveniles, (TEST_RS,))
         for cover in _test_covers
             test_metric(
@@ -63,7 +63,7 @@ end
 
     @testset "absolute_juveniles" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
         test_metric(metrics.absolute_juveniles, (TEST_RS,))
         for cover in _test_covers
             test_metric(
@@ -74,7 +74,7 @@ end
 
     @testset "juvenile_indicator" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
         test_metric(metrics.juvenile_indicator, (TEST_RS,))
         for cover in _test_covers
             test_metric(

--- a/test/metrics/metrics.jl
+++ b/test/metrics/metrics.jl
@@ -52,7 +52,9 @@ end
 
     @testset "relative_juveniles" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(
+            ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :]
+        )
         test_metric(metrics.relative_juveniles, (TEST_RS,))
         for cover in _test_covers
             test_metric(
@@ -63,7 +65,9 @@ end
 
     @testset "absolute_juveniles" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(
+            ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :]
+        )
         test_metric(metrics.absolute_juveniles, (TEST_RS,))
         for cover in _test_covers
             test_metric(
@@ -74,7 +78,9 @@ end
 
     @testset "juvenile_indicator" begin
         scen_idx = 1
-        coral_spec::DataFrame = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :])
+        coral_spec::DataFrame = ADRIA.to_coral_spec(
+            ADRIA.default_coral_params(), TEST_SCENS[scen_idx, :]
+        )
         test_metric(metrics.juvenile_indicator, (TEST_RS,))
         for cover in _test_covers
             test_metric(

--- a/test/metrics/metrics.jl
+++ b/test/metrics/metrics.jl
@@ -8,7 +8,7 @@ end
 
 @testset "metrics.jl" begin
     n_scenarios::Int64 = size(TEST_SCENS, 1)
-    n_groups::Int64 = length(ADRIA.coral_spec().taxa_names)
+    n_groups::Int64 = length(ADRIA.default_coral_spec().taxa_names)
     test_scens_datacube::YAXArray{Float64,2} = DataCube(
         Matrix(TEST_SCENS); scenarios=1:n_scenarios, factors=names(TEST_SCENS)
     )

--- a/test/metrics/scenario.jl
+++ b/test/metrics/scenario.jl
@@ -28,7 +28,7 @@ end
 
     @testset "scenario_relative_juveniles" begin
         test_metric(metrics.scenario_relative_juveniles, (TEST_RS,))
-        _coral_spec = ADRIA.to_coral_spec(ADRA.default_coral_params(), TEST_SCENS[1, :])
+        _coral_spec = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[1, :])
 
         for cover in _test_covers
             test_metric(
@@ -40,7 +40,7 @@ end
 
     @testset "scenario_absolute_juveniles" begin
         test_metric(metrics.scenario_absolute_juveniles, (TEST_RS,))
-        _coral_spec = ADRIA.to_coral_spec(TEST_SCENS[1, :])
+        _coral_spec = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[1, :])
 
         for cover in _test_covers
             test_metric(
@@ -52,7 +52,7 @@ end
 
     @testset "scenario_juvenile_indicator" begin
         test_metric(metrics.scenario_juvenile_indicator, (TEST_RS,))
-        _coral_spec = ADRIA.to_coral_spec(TEST_SCENS[1, :])
+        _coral_spec = ADRIA.to_coral_spec(ADRIA.default_coral_params(), TEST_SCENS[1, :])
 
         for cover in _test_covers
             test_metric(

--- a/test/metrics/scenario.jl
+++ b/test/metrics/scenario.jl
@@ -28,7 +28,7 @@ end
 
     @testset "scenario_relative_juveniles" begin
         test_metric(metrics.scenario_relative_juveniles, (TEST_RS,))
-        _coral_spec = ADRIA.to_coral_spec(TEST_SCENS[1, :])
+        _coral_spec = ADRIA.to_coral_spec(ADRA.default_coral_params(), TEST_SCENS[1, :])
 
         for cover in _test_covers
             test_metric(
@@ -88,7 +88,7 @@ end
 
     @testset "scenario_evenness" begin
         test_metric(metrics.scenario_evenness, (TEST_RS,))
-        n_groups::Int64 = length(ADRIA.coral_spec().taxa_names)
+        n_groups::Int64 = length(ADRIA.default_coral_spec().taxa_names)
 
         # TODO
         # for cover in _test_covers

--- a/test/metrics/test_metrics_helper.jl
+++ b/test/metrics/test_metrics_helper.jl
@@ -7,9 +7,10 @@ if !@isdefined(TEST_RS)
 end
 
 function mock_covers()::Vector{YAXArray{Float64,4}}
+    coral_spec = ADRIA.default_coral_spec()
     n_timesteps::Int64 = length(TEST_RS.env_layer_md.timeframe)
-    n_groups::Int64 = length(ADRIA.coral_spec().taxa_names)
-    n_sizes::Int64 = length(ADRIA.coral_spec().params.name) / n_groups
+    n_groups::Int64 = length(coral_spec.taxa_names)
+    n_sizes::Int64 = length(coral_spec.params.name) / n_groups
     n_group_sizes::Int64 = n_groups * n_sizes
     n_locations::Int64 = length(TEST_RS.coral_dhw_tol_log.locations)
     n_scenarios::Int64 = size(TEST_SCENS, 1)

--- a/test/metrics/test_metrics_helper.jl
+++ b/test/metrics/test_metrics_helper.jl
@@ -36,7 +36,6 @@ end
 function test_metric(metric::metrics.Metric, params::Tuple)::Nothing
     metric_result = metric(params...)
     @test all(0.0 .<= metric_result.data)
-
     metric.is_relative && @test all(metric_result.data .<= 1.0)
 
     _test_properties(metric, metric_result)


### PR DESCRIPTION
Adds the option to input the number of functional groups and size classes and associated parameters as an input file when loading the domain. If no file is input, the domain loads the default parameters as normal.

- Changes to `CoralGrowth` so number of functional groups and size classes is not hard coded
- If no file is provided, default parameters and number of functional groups and size classes are loaded as normal
- `coral_spec()` requires an input dictionary with the base parameters required to build the spec, but the default can be loaded without inputs using `ADRIA.load_default_coral_spec()`

@ConnectedSystems, I'm not sure what you think of storing alternative coral parameters in a json. This was used due to being able to load directly into a dict, but open to other formats.