### PR TITLE
Minor tweaks to taxa visualization

### DIFF
--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -123,9 +123,13 @@ function ADRIA.viz.taxonomy!(
         n_scenario_groups::Int64 = length(keys(scen_groups))
         color = get(opts, :colors, nothing)
         _colors =
-            isnothing(color) ? [
+            if isnothing(color)
+                [
                 COLORS[scen_name] for scen_name in keys(scen_groups)
-            ] : categorical_colors(color, n_scenario_groups)
+            ]
+            else
+                categorical_colors(color, n_scenario_groups)
+            end
 
         # Plot results
         intervention_by_taxonomy!(
@@ -204,11 +208,14 @@ function taxonomy_by_intervention!(
     confints = zeros(n_timesteps, n_functional_groups, 3)
     for (idx, group) in enumerate(functional_groups)
         confints[:, idx, :] = series_confint(relative_taxa_cover[species=At(group)])
-        show_confints ?
-        band!(
+        if show_confints
+            band!(
             ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
             color=(colors[idx], 0.4)
-        ) : nothing
+        )
+        else
+            nothing
+        end
     end
 
     # Plot series
@@ -237,7 +244,9 @@ function intervention_by_taxonomy!(
     taxa_names = human_readable_name(functional_group_names(); title_case=true)
 
     scenario_group_names::Vector{Symbol} = collect(keys(scen_groups))
-    series_opts[:labels] = get(series_opts, :labels, titlecase.(String.(scenario_group_names)))
+    series_opts[:labels] = get(
+        series_opts, :labels, titlecase.(String.(scenario_group_names))
+    )
 
     for (idx, taxa_name) in enumerate(taxa_names)
         xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(relative_taxa_cover)))
@@ -280,11 +289,14 @@ function intervention_by_taxonomy!(
         confints[:, idx, :] = series_confint(
             relative_taxa_cover[scenarios=scen_groups[scen]]
         )
-        show_confints ?
-        band!(
+        if show_confints
+            band!(
             ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
             color=(colors[idx], 0.4)
-        ) : nothing
+        )
+        else
+            nothing
+        end
     end
 
     # Plot series

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -65,7 +65,7 @@ function ADRIA.viz.taxonomy(
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )::Figure
-    fig_opts[:size] = get(fig_opts, :size, (1200, 1200))
+    fig_opts[:size] = get(fig_opts, :size, (1200, 600))
     f = Figure(; fig_opts...)
 
     g = f[1, 1] = GridLayout()
@@ -140,7 +140,7 @@ function ADRIA.viz.taxonomy!(
     end
 
     Label(
-        g[1, :, Top()], "Taxa dynamics"; padding=(0, 0, 30, 0), font=:bold, valign=:bottom
+        g[1, :, Top()], "Taxa Dynamics"; padding=(0, 0, 30, 0), font=:bold, valign=:bottom
     )
 
     return g
@@ -213,7 +213,7 @@ function taxonomy_by_intervention!(
 
     # Plot series
     series!(ax, 1:n_timesteps, confints[:, :, 2]'; solid_color=colors, series_opts...)
-    show_legend ? axislegend(ax) : nothing
+    show_legend ? axislegend(ax; position=:lt) : nothing
 
     return nothing
 end
@@ -237,7 +237,7 @@ function intervention_by_taxonomy!(
     taxa_names = human_readable_name(functional_group_names(); title_case=true)
 
     scenario_group_names::Vector{Symbol} = collect(keys(scen_groups))
-    series_opts[:labels] = get(series_opts, :labels, String.(scenario_group_names))
+    series_opts[:labels] = get(series_opts, :labels, titlecase.(String.(scenario_group_names)))
 
     for (idx, taxa_name) in enumerate(taxa_names)
         xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(relative_taxa_cover)))
@@ -289,7 +289,7 @@ function intervention_by_taxonomy!(
 
     # Plot series
     series!(ax, 1:n_timesteps, confints[:, :, 2]'; solid_color=colors, series_opts...)
-    show_legend ? axislegend(ax) : nothing
+    show_legend ? axislegend(ax; position=:lt) : nothing
 
     return nothing
 end

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -125,8 +125,8 @@ function ADRIA.viz.taxonomy!(
         _colors =
             if isnothing(color)
                 [
-                COLORS[scen_name] for scen_name in keys(scen_groups)
-            ]
+                    COLORS[scen_name] for scen_name in keys(scen_groups)
+                ]
             else
                 categorical_colors(color, n_scenario_groups)
             end
@@ -210,9 +210,9 @@ function taxonomy_by_intervention!(
         confints[:, idx, :] = series_confint(relative_taxa_cover[species=At(group)])
         if show_confints
             band!(
-            ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
-            color=(colors[idx], 0.4)
-        )
+                ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
+                color=(colors[idx], 0.4)
+            )
         else
             nothing
         end
@@ -291,9 +291,9 @@ function intervention_by_taxonomy!(
         )
         if show_confints
             band!(
-            ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
-            color=(colors[idx], 0.4)
-        )
+                ax, 1:n_timesteps, confints[:, idx, 1], confints[:, idx, 3];
+                color=(colors[idx], 0.4)
+            )
         else
             nothing
         end

--- a/ext/AvizExt/viz/taxa_dynamics.jl
+++ b/ext/AvizExt/viz/taxa_dynamics.jl
@@ -176,7 +176,7 @@ function taxonomy_by_intervention!(
     for (idx, scen_name) in enumerate(keys(scen_groups))
         ax = Axis(
             g[idx, 1];
-            title=String(scen_name),
+            title=titlecase(String(scen_name)),
             xticks=xtick_vals,
             xticklabelrotation=xtick_rot,
             axis_opts...


### PR DESCRIPTION
The following tweaks were applied:

- Reduced large display of plot (1200x1200 to 1200x600)
- Adjust title text to be in title case
- Change position of legend to left hand side to avoid hiding other plot elements. This should be moved outside the plot but I don't have time to make the necessary adjustments.

![image](https://github.com/user-attachments/assets/6d8ad40a-3fd9-437d-917a-aba2e63696c7)

One change I needed but couldn't work out was changing the scenario type name to title case ("counterfactual" -> "Counterfactual").

Please note there was some chatter about `viz.taxonomy` in another issue, I'm not sure if the changes there will impact this PR.
https://github.com/open-AIMS/ADRIA.jl/pull/896#issuecomment-2597022820