### PR TITLE
C~Scape Result Interface

### DIFF
--- a/docs/src/usage/loading_results.md
+++ b/docs/src/usage/loading_results.md
@@ -31,6 +31,7 @@ data_dir
         results.nc
         scenarios.csv
 ```
+
 In order to reduce the duplication of geospatial and connectivity data, the data directory
 and results directory can be supplied separately to avoid having copies for each result set
 analysed.
@@ -39,22 +40,23 @@ analysed.
 rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>", "<path to results dir>")
 ```
 
-## Loading CScape Results
+## Loading C~scape Results
 
-Results from CScape can be loaded with the `load_results` function.
+Results from C~scape can be loaded with the `load_results` function.
 
 ```julia
-# Assumes NetCDFs are contained in result subdirectory
+# Assumes NetCDFs are contained in result subdirectory (see example directory tree below)
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>")
 
 # Retrieves NetCDFs from separate directory
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", "<path to result directory>")
 
-# Manually passes a list of files to load as results
+# Manually pass in a list of files to load as results
 rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
 ```
 
-The expected directory structure is
+The expected directory structure is:
+
 ```bash
 data_dir
 │   ScenarioID.csv

--- a/docs/src/usage/loading_results.md
+++ b/docs/src/usage/loading_results.md
@@ -45,13 +45,13 @@ Results from CScape can be loaded with the `load_results` function.
 
 ```julia
 # Assumes NetCDFs are contained in result subdirectory
-rs = ADRIA.load_results(RMEResultSet, "<path to data dir>")
+rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>")
 
 # Retrieves NetCDFs from separate directory
-rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to result directory>")
+rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", "<path to result directory>")
 
 # Manually passes a list of files to load as results
-rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
+rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
 ```
 
 The expected directory structure is

--- a/docs/src/usage/loading_results.md
+++ b/docs/src/usage/loading_results.md
@@ -31,10 +31,46 @@ data_dir
         results.nc
         scenarios.csv
 ```
-In order to reduce the duplication of geospatial and conectivity data, the data directory
-and results directory can be supplied seperately to avoid having copies for each resuilt set
+In order to reduce the duplication of geospatial and connectivity data, the data directory
+and results directory can be supplied separately to avoid having copies for each result set
 analysed.
 
 ```julia
 rs = ADRIA.load_domain(RMEResultSet, "<path to data dir>", "<path to results dir>")
+```
+
+## Loading CScape Results
+
+Results from CScape can be loaded with the `load_results` function.
+
+```julia
+# Assumes NetCDFs are contained in result subdirectory
+rs = ADRIA.load_results(RMEResultSet, "<path to data dir>")
+
+# Retrieves NetCDFs from seperate directory
+rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to result directory>")
+
+# Manually passes a list of files to load as results
+rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
+```
+
+The expected directory structure is
+```bash
+data_dir
+│   ScenarioID.csv
+│
+├───connectivity
+│       connectivity.csv
+│
+├───site_data
+│       geospatial_data.gpkg
+│
+├───initial_cover
+│       initial_cover.csv
+│
+└───results (optional)
+        NetCDF_Scn_140001.nc
+        NetCDF_Scn_140002.nc
+        NetCDF_Scn_140003.nc
+        ...
 ```

--- a/docs/src/usage/loading_results.md
+++ b/docs/src/usage/loading_results.md
@@ -47,7 +47,7 @@ Results from CScape can be loaded with the `load_results` function.
 # Assumes NetCDFs are contained in result subdirectory
 rs = ADRIA.load_results(RMEResultSet, "<path to data dir>")
 
-# Retrieves NetCDFs from seperate directory
+# Retrieves NetCDFs from separate directory
 rs = ADRIA.load_results(RMEResultSet, "<path to data dir>", "<path to result directory>")
 
 # Manually passes a list of files to load as results
@@ -73,4 +73,22 @@ data_dir
         NetCDF_Scn_140002.nc
         NetCDF_Scn_140003.nc
         ...
+```
+
+### Loading Variables using the interface
+
+All variables except from relative cover are not loaded automatically. The outcomes
+dictionary contained in the result structure is where all outputs are stored.
+
+```julia
+julia> rs.outcomes[:relative_cover]
+```
+
+To analyse a variable contained in the NetCDFs, use the function
+
+```julia
+julia> var = ADRIA.load_variable!(rs, :var_name)
+
+# The variable will also be stored in the outcomes dictionary.
+julia> rs.outcomes[:var_name]
 ```

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -76,7 +76,7 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
-    rs::Union{RMEResultSet,CScapeResultSet},
+    rs::RMEResultSet,
     outcomes::YAXArray;
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -76,7 +76,7 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
-    rs::RMEResultSet,
+    rs::Union{RMEResultSet, CScapeResultSet},
     outcomes::YAXArray;
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -76,7 +76,7 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
-    rs::Union{RMEResultSet, CScapeResultSet},
+    rs::Union{RMEResultSet,CScapeResultSet},
     outcomes::YAXArray;
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -73,6 +73,7 @@ include("io/ResultSet.jl")
 include("spatial/spatial.jl")
 include("io/result_io.jl")
 include("io/rme_result_io.jl")
+include("io/cscape_result_io.jl")
 include("io/result_post_processing.jl")
 include("io/sampling.jl")
 include("metrics/metrics.jl")
@@ -102,6 +103,7 @@ export RMEDomain
 export ReefModDomain
 
 export RMEResultSet
+export CScapeResultSet
 # metric helper methods
 # export dims, ndims
 

--- a/src/analysis/scenario.jl
+++ b/src/analysis/scenario.jl
@@ -31,7 +31,8 @@ end
 
 function unguided(scenarios::DataFrame)::BitVector
     has_guided_col = "guided" in names(scenarios)
-    is_unguided = has_guided_col ? scenarios.guided .== 0 : fill(false, size(scenarios, 1))
+    # If the results set does not have a guided type column default to unguided
+    is_unguided = has_guided_col ? scenarios.guided .== 0 : fill(true, size(scenarios, 1))
 
     has_fog_col = "fogging" in names(scenarios)
     has_fog = has_fog_col ? scenarios.fogging .> 0 : fill(true, size(scenarios, 1))

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -153,7 +153,7 @@ function coral_spec()::NamedTuple
     params.coral_id = String[join(x, "_") for x in zip(tn, params.taxa_id, params.class_id)]
 
     # Ecological parameters
-    # To be more consistent with parameters in ReefMod, C~Scape and RRAP
+    # To be more consistent with parameters in ReefMod, C~scape and RRAP
     # interventions, we express coral abundance as colony numbers in different
     # size classes and growth rates as linear extension (in cm per year).
     colony_area_mean_cm², mean_colony_diameter_m = colony_areas()

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -15,7 +15,6 @@ struct CScapeResultSet <: ResultSet
     env_layer_md::EnvLayer
     connectivity_data
     loc_data
-    scenario_groups
     raw_data::Vector{NcFile}
 
     inputs
@@ -132,15 +131,6 @@ function load_results(
         model_spec.component .== "Intervention"
     ]
 
-    scen_groups = Dict(
-        :counterfactual => BitVector(
-            all(collect(scen_row[intervention_params]) .== 0.0) for scen_row in eachrow(inputs)
-        ),
-        :unguided => BitVector(
-            any(collect(scen_row[intervention_params]) .!= 0.0) for scen_row in eachrow(inputs)
-        )
-    )
-
     return CScapeResultSet(
         res_name,
         res_rcp,
@@ -151,7 +141,6 @@ function load_results(
         env_layer_md,
         connectivity,
         geodata,
-        scen_groups,
         datasets,
         inputs,
         SimConstants(),

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -778,7 +778,7 @@ function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
     # all(diff(cumsum(n_scens)) .== 1)
 
     start_end_pos = _data_position(n_scens)
-    for (ds_idx, dataset) in zip(start_end_pos, datasets)
+    @showprogress desc="Loading datasets" for (ds_idx, dataset) in zip(start_end_pos, datasets)
         relative_cover[scenarios=ds_idx[1]:ds_idx[2]] = _cscape_relative_cover(dataset)
     end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -691,9 +691,9 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         _drop_sum(
             dataset.cover[intervened=1][dummy_selector...], dim_sum
         ) .* reshape(
-            area[1, :] .* dataset.k[:],
+            area[1, :],
             reshape_tuple
-        ) ./ 100.0 # k area in %
+        )
 
     # Only calculate if there are area values > 0
     if !any(area[2, :] .> 0.0)
@@ -701,13 +701,13 @@ function _cscape_relative_cover(dataset::Dataset)::Array
             _drop_sum(
                 dataset.cover[intervened=2][dummy_selector...], dim_sum
             ) .* reshape(
-                area[2, :] .* dataset.k[:],
+                area[2, :],
                 reshape_tuple
-            ) ./ 100.0 # k area in %
+            )
     end
 
     relative_cover ./= reshape(
-        sum(area; dims=1), reshape_tuple
+        sum(area; dims=1) .* dataset.k' ./ 100, reshape_tuple
     ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -704,14 +704,14 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     ) .* reshape(
         area[1, :] .* dataset.k[:],
         reshape_tuple
-    ) ./ 100
+    ) ./ 100.0
 
     relative_cover .+= _drop_sum(
         dataset.cover[intervened=2], dim_sum
     ) .* reshape(
         area[2, :] .* dataset.k[:],
         reshape_tuple
-    ) ./ 100
+    ) ./ 100.0
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -230,9 +230,10 @@ function _recreate_inputs_dataframe(
     datasets::Vector{Dataset}, scenario_spec::DataFrame
 )::DataFrame
     # Get rows from scenario spec dataframe corresponding to the scenarios
-    scenario_idxs::Vector{Int} =
-        [findfirst(x->x==idx, scenario_spec.ID) for idx in _get_scenario_id.(datasets)]
-    scenario_rows::Vector{DataFrameRow} = [scenario_spec[idx + i * 100, :] for (i, idx) in enumerate(scenario_idxs)]
+    scenario_idxs::Vector{Int} = [
+        findfirst(x->x==idx, scenario_spec.ID) for idx in _get_scenario_id.(datasets)
+    ]
+    scenario_rows::Vector{DataFrameRow} = [scenario_spec[idx, :] for idx in scenario_idxs]
 
     # Convert climate scenarios to factors
     rcps::Vector{Float64} =

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -818,14 +818,14 @@ function _load_variable!(
             output_variable[draws=cur_indx] .= scenario_func(
                 use_combined_cover ? _combine_intervention_sites(
                     nc_handle
-                ) : nc_handle[var_name_str]
+                ) : NetCDF.readvar(nc_handle[var_name_str])
             )
         else
             for j in 0:(n_sc - 1)
                 output_variable[draws=cur_indx + j] .= scenario_func(
                     use_combined_cover ? _combine_intervention_sites(
                         nc_handle, j
-                    ) : nc_handle[var_name_str][j, dim_sel...]
+                    ) : NetCDF.readvar(nc_handle[var_name_str])[j, dim_sel...]
                 )
             end
         end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -280,7 +280,8 @@ function _create_inputs_dataframe(
     input_index::Int
 )::DataFrame
     functional_types::Vector{String} = _get_functional_types(nc_handle)
-    n_draws::Int = "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
+    n_draws::Int =
+        "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
 
     dhws::Vector{Float64} = Float64.(repeat([input_index], n_draws))
     cyclones::Vector{Float64} = Float64.(repeat([input_index], n_draws))
@@ -686,7 +687,7 @@ function _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
     return dropdims(sum(cube; dims=red_dims); dims=red_dims)
 end
 function _drop_sum(cube::AbstractArray, red_dims::Tuple)::AbstractArray
-    return dropdims(sum(cube; dims=red_dims), dims=red_dims)
+    return dropdims(sum(cube; dims=red_dims); dims=red_dims)
 end
 
 """
@@ -755,9 +756,10 @@ function _cscape_relative_cover(nc_handle::NcFile)::Array
             )
     end
 
-    relative_cover ./= reshape(
-        sum(area; dims=1) .* habitable_area' ./ 100, reshape_tuple
-    ) .* 100
+    relative_cover ./=
+        reshape(
+            sum(area; dims=1) .* habitable_area' ./ 100, reshape_tuple
+        ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario
@@ -885,11 +887,12 @@ function load_variable!(
     agg_func = x -> NetCDF.readvar(x[var_name])
     if :thermal_tolerance in _ncvar_dim_names(rs.raw_data[1].vars[var_name])
         thermal_tol_dim_idx::Int64 = findfirst(
-            x->x==:thermal_tolerance,
+            x -> x == :thermal_tolerance,
             _ncvar_dim_names(rs.raw_data[1].vars[var_name])
         )
         agg_func =
-            x -> dropdims(aggregate_ttol(
+            x -> dropdims(
+                aggregate_ttol(
                     NetCDF.readvar(x[var_name]); dims=thermal_tol_dim_idx
                 ); dims=thermal_tol_dim_idx)
     end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -125,7 +125,7 @@ function load_results(
         timeframe
     )
 
-    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_max_coral_cover = geodata.k ./ 100
     location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
 
     outcomes = Dict{Symbol,YAXArray}()

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -630,17 +630,10 @@ end
 
 Rename reorder the names of the dimensions to align with ADRIA's expected dimension names.
 """
-function reformat_cube(cscape_cube::YAXArray, loc_mask::BitVector)
-    cscape_cube = reformat_cube(cscape_cube)
-    if :sites ∈ name.(cscape_cube.axes)
-        cscape_cube = cscape_cube[sites=loc_mask]
-    end
-    return cscape_cube
-end
 function reformat_cube(cscape_cube::YAXArray)::YAXArray
     dim_names = name.(cscape_cube.axes)
     cscape_names = [:year, :reef_sites, :ft, :draws]
-    adria_names = [:timesteps, :sites, :taxa, :scenarios]
+    adria_names = [:timesteps, :locations, :taxa, :scenarios]
     final_ordering::Vector{Int} = Vector{Int}(undef, length(dim_names))
     current_index = 1
     # rename expected dimensions and update the permutation vector
@@ -778,7 +771,7 @@ function _cscape_relative_cover(nc_handles::Vector{NcFile})::YAXArray
     relative_cover = ZeroDataCube(;
         T=Float64,
         timesteps=Vector(NetCDF.readvar(nc_handles[1]["year"])),
-        sites=1:n_locs,
+        locations=1:n_locs,
         scenarios=1:sum(n_scens)
     )
 
@@ -915,8 +908,8 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", rs::CScapeResultSet)
     rcps = rs.RCP
-    scens = length(rs.outcomes[:relative_cover].scenarios)
-    sites = length(rs.outcomes[:relative_cover].sites)
+    scens     = length(rs.outcomes[:relative_cover].scenarios)
+    locations = length(rs.outcomes[:relative_cover].locations)
     tf = rs.env_layer_md.timeframe
 
     return println("""
@@ -926,7 +919,7 @@ function Base.show(io::IO, mime::MIME"text/plain", rs::CScapeResultSet)
 
         RCP(s) represented: $(rcps)
         Scenarios run: $(scens)
-        Number of sites: $(sites)
+        Number of locations: $(locations)
         Timesteps: $(tf)
     """)
 end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -693,7 +693,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         ) .* reshape(
             area[1, :] .* dataset.k[:],
             reshape_tuple
-        ) ./ 100.0
+        ) ./ 100.0 # k area in %
 
     # Only calculate if there are area values > 0
     if !any(area[2, :] .> 0.0)
@@ -703,8 +703,12 @@ function _cscape_relative_cover(dataset::Dataset)::Array
             ) .* reshape(
                 area[2, :] .* dataset.k[:],
                 reshape_tuple
-            ) ./ 100.0
+            ) ./ 100.0 # k area in %
     end
+
+    relative_cover ./= reshape(
+        sum(area, dims=1), reshape_tuple
+    ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -708,7 +708,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
 
     area = dataset.area.data[:, :]
     relative_cover .= _drop_sum(
-        dataset.cover[intervened=1], dim_sum
+        dataset.cover[intervened=1][dummy_selector...], dim_sum
     ) .* reshape(
         area[1, :] .* dataset.k[:],
         reshape_tuple

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -707,7 +707,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     end
 
     relative_cover ./= reshape(
-        sum(area, dims=1), reshape_tuple
+        sum(area; dims=1), reshape_tuple
     ) .* 100
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -558,8 +558,9 @@ Get the name of the data set from the properties of the dataset.
 function _get_result_name(ds::Dataset)::String
     name = "CScape Results"
     if !haskey(ds.properties, "title")
-        @warn "Unable to find key `title` in dataset properties, \
-               defaulting to `CScape Results`"
+        msg = "Unable to find key `title` in dataset properties, "
+        msg *= "defaulting to `CScape Results`"
+        @warn msg
     else
         name = ds.properties["title"]
     end
@@ -645,8 +646,10 @@ function reformat_cube(cscape_cube::YAXArray)::YAXArray
 end
 
 function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
-    throw(ArgumentError("NetCDF $(dataset.properties["scenario_ID"]) does not \
-                         contain $(String.(var_name)) variable"))
+    msg = "NetCDF $(dataset.properties["scenario_ID"]) does not "
+    msg *= "contain $(String.(var_name)) variable"
+    throw(ArgumentError(msg))
+
     return nothing
 end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -654,7 +654,7 @@ function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
 end
 
 """
-    drop_sum(cube::YAXArray, dims)::YAXArray
+    _drop_sum(cube::YAXArray, red_dims)::YAXArray
 
 Sum over given dimensions and drop the same given dimensions.
 """
@@ -663,9 +663,10 @@ function _drop_sum(cube::YAXArray, red_dims)::YAXArray
 end
 
 """
-    _cscape_relative_cover(dataset::Dataset; loc_mask::BitVector=[])::YAXArray
+    _cscape_relative_cover(dataset::Dataset)::YAXArray
+    _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
 
-Calculate relative cover metric for cscape data.
+Calculate relative cover metric for C~scape data.
 """
 function _cscape_relative_cover(dataset::Dataset)::Array
     # Throw error and identify specific misformatted file.
@@ -678,6 +679,7 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     if !haskey(dataset.cubes, :k)
         _throw_missing_variable(dataset, :k)
     end
+
     dim_sum = (:ft, :thermal_tolerance)
 
     multi_scenario::Bool = :draws in keys(dataset.axes)

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -34,7 +34,14 @@ end
     load_results(::Type{CscapeResultSet}, data_dir::String, result_dir::String)::CScapeResultSet
     load_results(::Type{CScapeResultSet}, data_dir::String, result_files::Vector{String})::CScapeResultSet
 
-Interface for loading CScape model outputs.
+Interface for loading C~scape model outputs.
+
+See the [Loading C~scape Results](@ref) section for details on expected directory structure.
+
+# Examples
+```julia
+rs = ADRIA.load_results(CScapeResultSet, "a C~scape dataset of interest")
+```
 """
 function load_results(::Type{CScapeResultSet}, data_dir::String)::CScapeResultSet
     return load_results(CScapeResultSet, data_dir, joinpath(data_dir, "results"))

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -908,7 +908,7 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", rs::CScapeResultSet)
     rcps = rs.RCP
-    scens     = length(rs.outcomes[:relative_cover].scenarios)
+    scens = length(rs.outcomes[:relative_cover].scenarios)
     locations = length(rs.outcomes[:relative_cover].locations)
     tf = rs.env_layer_md.timeframe
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -283,9 +283,9 @@ function _create_inputs_dataframe(
     n_draws::Int =
         "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
 
-    dhws::Vector{Float64} = Float64.(fill(input_index, (n_draws,)))
-    cyclones::Vector{Float64} = Float64.(fill(input_index, (n_draws,)))
-    scenario_id::Vector{Int64} = Int64.(fill(scenario_spec.ID, (n_draws,)))
+    dhws::Vector{Float64} = Float64.(fill(input_index, n_draws))
+    cyclones::Vector{Float64} = Float64.(fill(input_index, n_draws))
+    scenario_id::Vector{Int64} = Int64.(fill(scenario_spec.ID, n_draws))
 
     # Thermal tolerance bins are stored as lb_interval_ub
     lb_t, int_t1, int_t2, ub_t =
@@ -346,23 +346,23 @@ function _create_inputs_dataframe(
         scenario_id=scenario_id,
         dhw_scenario=dhws,
         cyc_scenario=cyclones,
-        RCP=fill(rcp, (n_draws,)),
-        thermal_tol_lb=fill(lb_t, (n_draws,)),
-        thermal_tol_int1=fill(int_t1, (n_draws,)),
-        thermal_tol_int2=fill(int_t2, (n_draws,)),
-        thermal_tol_ub=fill(ub_t, (n_draws,)),
-        init_heat_tol_mean=fill(init_heat_tol_mean, (n_draws,)),
-        init_heat_tol_std=fill(init_heat_tol_std, (n_draws,)),
-        heritability1=fill(heritability1, (n_draws,)),
-        heritability2=fill(heritability2, (n_draws,)),
-        plasticity=fill(plasticity, (n_draws,)),
-        intervention_start=fill(intervention_start, (n_draws,)),
-        intervention_duration=fill(duration, (n_draws,)),
-        intervention_frequency=fill(frequency, (n_draws,)),
-        deployment_area=fill(deployment_area, (n_draws,)),
-        n_deployment_locations=fill(n_dep_locations, (n_draws,)),
-        enhancement_mean=fill(enhancement_mean, (n_draws,)),
-        enhancement_std=fill(enhancement_std, (n_draws,)),
+        RCP=fill(rcp, n_draws),
+        thermal_tol_lb=fill(lb_t, n_draws),
+        thermal_tol_int1=fill(int_t1, n_draws),
+        thermal_tol_int2=fill(int_t2, n_draws),
+        thermal_tol_ub=fill(ub_t, n_draws),
+        init_heat_tol_mean=fill(init_heat_tol_mean, n_draws),
+        init_heat_tol_std=fill(init_heat_tol_std, n_draws),
+        heritability1=fill(heritability1, n_draws),
+        heritability2=fill(heritability2, n_draws),
+        plasticity=fill(plasticity, n_draws),
+        intervention_start=fill(intervention_start, n_draws),
+        intervention_duration=fill(duration, n_draws),
+        intervention_frequency=fill(frequency, n_draws),
+        deployment_area=fill(deployment_area, n_draws),
+        n_deployment_locations=fill(n_dep_locations, n_draws),
+        enhancement_mean=fill(enhancement_mean, n_draws),
+        enhancement_std=fill(enhancement_std, n_draws),
         coral_dict...
     )
 end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -654,11 +654,11 @@ function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
 end
 
 """
-    _drop_sum(cube::YAXArray, red_dims)::YAXArray
+    _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
 
 Sum over given dimensions and drop the same given dimensions.
 """
-function _drop_sum(cube::YAXArray, red_dims)::YAXArray
+function _drop_sum(cube::YAXArray, red_dims::Tuple)::YAXArray
     return dropdims(sum(cube, dims=red_dims), dims=red_dims)
 end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -78,8 +78,6 @@ function load_results(
     gpkg_path = _get_gpkg_path(data_dir)
     geodata = GDF.read(gpkg_path)
 
-    geodata = _manual_site_additions(geodata, location_ids, raw_set)
-
     connectivity_path = joinpath(data_dir, "connectivity/connectivity.csv")
     connectivity = CSV.read(connectivity_path, DataFrame; comment="#", header=true)
 
@@ -155,50 +153,6 @@ function load_results(
         outcomes,
         reformat_cube(raw_set.coral_size_diameter)
     )
-end
-
-"""
-    _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
-
-Add missing sites to geopackage
-"""
-function _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
-    row_indx::Int64 = findfirst(x -> x == "Moore_MR_S_39", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Moore_MR_S_40", loc_ids)
-    geodata[end, :site_id] = "MR_S_40"
-    geodata[end, :reef_siteid] = "Moore_MR_S_40"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Milln_MR_OF_3", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Milln_MR_OF_4", loc_ids)
-    geodata[end, :site_id] = "MR_OF_4"
-    geodata[end, :reef_siteid] = "Milln_MR_OF_4"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Elford_ER_S_50", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Elford_ER_S_51", loc_ids)
-    geodata[end, :site_id] = "ER_S_51"
-    geodata[end, :reef_siteid] = "Elford_ER_S_51"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-
-    row_indx = findfirst(x -> x == "Elford_ER_S_50", geodata.reef_siteid)
-    row_cpy = copy(geodata[row_indx, :])
-    push!(geodata, row_cpy)
-    data_indx = findfirst(x -> x == "Elford_ER_S_52", loc_ids)
-    geodata[end, :site_id] = "ER_S_52"
-    geodata[end, :reef_siteid] = "Elford_ER_S_52"
-    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx]; dims=:intervened)[1]
-    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
-    return geodata
 end
 
 """

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -285,6 +285,7 @@ function _create_inputs_dataframe(
 
     dhws::Vector{Float64} = Float64.(repeat([input_index], n_draws))
     cyclones::Vector{Float64} = Float64.(repeat([input_index], n_draws))
+    scenario_id::Vector{Int64} = Int64.(repeat([scenario_spec.ID], n_draws))
 
     # Thermal tolerance bins are stored as lb_interval_ub
     lb_t, int_t1, int_t2, ub_t =
@@ -342,6 +343,7 @@ function _create_inputs_dataframe(
     coral_dict = merge(settle_probs_kwargs, corals_deployed)
 
     return DataFrame(;
+        scenario_id=scenario_id,
         dhw_scenario=dhws,
         cyc_scenario=cyclones,
         RCP=repeat([rcp], n_draws),
@@ -391,6 +393,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
 
     # Construct default model spec
     fieldname::Vector{Symbol} = [
+        :scenario_id,
         :dhw_scenario, # Environment Layer
         :cyc_scenario,
         :thermal_tol_lb, # Corals
@@ -413,6 +416,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         seeded_names... # Intervention
     ]
     descriptions::Vector{String} = [
+        "Scenario ID",
         "DHW Scenario",
         "Cyclone Scenario",
         "Natural thermal tolerance lower bound",
@@ -435,6 +439,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         seeded_readable...
     ]
     human_names::Vector{String} = [
+        "Scenario ID",
         "DHW scenario",
         "Cyclone scenario",
         "Thermal Tolerance Lower Bound",
@@ -459,6 +464,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
     ptype::Vector{String} = [
         "unordered categorical",
         "unordered categorical",
+        "unordered categorical",
         "continuous",
         "continuous",
         "continuous",
@@ -481,6 +487,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
     lower_bound::Vector{Float64} = [
         1.0,
         1.0,
+        1.0,
         -6.0,
         0.0,
         0.0,
@@ -501,6 +508,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         seeded_lb...
     ]
     upper_bound::Vector{Float64} = [
+        150000.0,
         50.0,
         50.0,
         0.0,
@@ -526,7 +534,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         string((lb, ub)) for (lb, ub) in zip(lower_bound, upper_bound)
     ]
     component::Vector{String} = vcat(
-        repeat(["EnvironmentalLayer"], 2),
+        repeat(["EnvironmentalLayer"], 3),
         repeat(["Coral"], 9),
         repeat(["Intervention"], 7),
         repeat(["Coral"], length(settle_names)),

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -548,13 +548,14 @@ end
     _get_result_paths(result_dir::String)::Vector{String}
 
 Get the names of all result netcdf result files in the given directory. Assumes filenames
-match "NetCDF_Scn.*.nc.
+match "NetCDF_Scn.*.nc".
 """
 function _get_result_paths(result_dir::String)::Vector{String}
     possible_files = filter(isfile, readdir(result_dir; join=true))
     possible_files = filter(x -> occursin(r"NetCDF_Scn.*.nc", x), possible_files)
     if length(possible_files) == 0
-        error("Unable to find result netcdf file in subdirectory $(res_subdir)")
+        msg = "Unable to find result netcdf file in subdirectory \"$(result_dir)\""
+        throw(ArgumentError(msg))
     end
     return possible_files
 end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -9,13 +9,13 @@ struct CScapeResultSet <: ResultSet
     name::String
     RCP::String
 
-    site_ids
-    site_area::Vector{Float64}
-    site_max_coral_cover::Vector{Float64}
-    site_centroids
+    loc_ids
+    loc_area::Vector{Float64}
+    loc_max_coral_cover::Vector{Float64}
+    loc_centroids
     env_layer_md::EnvLayer
     connectivity_data
-    site_data
+    loc_data
     scenario_groups
     raw_data::Vector{Dataset}
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -732,7 +732,8 @@ function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
     # all(diff(cumsum(n_scens)) .== 1)
 
     start_end_pos = _data_position(n_scens)
-    @showprogress desc="Loading datasets" for (ds_idx, dataset) in zip(start_end_pos, datasets)
+    @showprogress desc = "Loading datasets" for (ds_idx, dataset) in
+                                                zip(start_end_pos, datasets)
         relative_cover[scenarios=ds_idx[1]:ds_idx[2]] = _cscape_relative_cover(dataset)
     end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -1,0 +1,774 @@
+using Core: Argument
+using ADRIA: EnvLayer, GDF, ZeroDataCube, DataCube
+using ArchGDAL: centroid
+using CSV
+using DataFrames
+using YAXArrays
+
+struct CScapeResultSet <: ResultSet
+    name::String
+    RCP::String
+
+    site_ids
+    site_area::Vector{Float64}
+    site_max_coral_cover::Vector{Float64}
+    site_centroids
+    env_layer_md::EnvLayer
+    connectivity_data
+    site_data
+    scenario_groups
+    raw_data::Vector{Dataset}
+
+    inputs
+    sim_constants
+    model_spec::DataFrame
+
+    # raw::AbstractArray
+    outcomes
+    # Cscape uses different size classes
+    coral_size_diameter::YAXArray
+end
+
+"""
+    load_results(::Type{CScapeResultSet}, data_dir::String)::CScapeResultSet
+    load_results(::Type{CscapeResultSet}, data_dir::String, result_dir::String)::CScapeResultSet
+    load_results(::Type{CScapeResultSet}, data_dir::String, result_files::Vector{String})::CScapeResultSet
+
+Interface for loading CScape model outputs.
+"""
+function load_results(::Type{CScapeResultSet}, data_dir::String)::CScapeResultSet
+    return load_results(CScapeResultSet, data_dir, joinpath(data_dir, "results"))
+end
+function load_results(::Type{CScapeResultSet}, data_dir::String, result_dir::String)::CScapeResultSet
+    return load_results(CScapeResultSet, data_dir, _get_result_paths(result_dir))
+end
+function load_results(::Type{CScapeResultSet}, data_dir::String, result_files::Vector{String})::CScapeResultSet
+    !isdir(data_dir) ? error("Expected a directory but received $(data_dir)") : nothing
+
+    scenario_spec_path::String = joinpath(data_dir, "ScenarioID.csv")
+    scenario_spec::DataFrame = DataFrame(CSV.File(scenario_spec_path))
+
+    datasets::Vector{Dataset} = open_dataset.(result_files)
+    inputs::DataFrame = _recreate_inputs_dataframe(datasets, scenario_spec)
+    model_spec::DataFrame = _create_model_spec(CScapeResultSet, inputs)
+
+    # Assume all result set have the same locations
+    raw_set = datasets[1]
+
+    res_name::String = _get_result_name(raw_set)
+    res_rcp::String = _get_rcp(raw_set)
+
+    init_cover_path = joinpath(data_dir, "initial_cover", "initial_cover.csv")
+    init_data::DataFrame = CSV.read(init_cover_path, DataFrame, header=true)
+
+    !haskey(raw_set.cubes, :reef_siteid) ? error("Unable to find location ids.") : nothing
+    location_ids = init_data.reef_siteid
+
+    gpkg_path = _get_gpkg_path(data_dir)
+    geodata = GDF.read(gpkg_path)
+
+    geodata = _manual_site_additions(geodata, location_ids, raw_set)
+
+    connectivity_path = joinpath(data_dir, "connectivity/connectivity.csv")
+    connectivity = CSV.read(connectivity_path, DataFrame, comment="#", header=true)
+
+    # There is missing location data in site data. Use intersection
+    gpkg_mask = BitVector([loc_name in location_ids for loc_name in geodata.reef_siteid])
+    conn_mask = BitVector([
+        (loc_name in location_ids) && (loc_name in geodata.reef_siteid)
+        for loc_name in names(connectivity)
+    ])
+
+    geodata = geodata[gpkg_mask, :]
+    conn_sites = names(connectivity)[conn_mask]
+    connectivity = connectivity[conn_mask[2:end], conn_mask]
+
+    # Re order data to match location ordering
+    geo_id_order = [first(findall(x .== geodata.reef_siteid)) for x in location_ids]
+    conn_id_order = [first(findall(x .== Vector(conn_sites))) for x in location_ids]
+
+    geodata = geodata[geo_id_order, :]
+    connectivity = connectivity[conn_id_order, conn_id_order]
+
+    timeframe = 2007:2099
+    if !haskey(raw_set.properties, "temporal_range")
+        @warn "Unable to find timeframe defaulting to $(timeframe[1]):$(timeframe[end])"
+    else
+        tf_str = split(raw_set.properties["temporal_range"], ":")
+        if tf_str[1] != "Inf"
+            timeframe = parse(Int, tf_str[1]):parse(Int, tf_str[2])
+        else
+            timeframe = raw_set.year[1]:raw_set.year[end]
+        end
+    end
+
+    env_layer_md::EnvLayer = EnvLayer(
+        data_dir,
+        gpkg_path,
+        "site_id",
+        "Reef",
+        "",
+        connectivity_path,
+        "",
+        "",
+        timeframe
+    )
+
+    location_max_coral_cover = 1 .- geodata.k ./ 100
+    location_centroids = [centroid(multipoly) for multipoly ∈ geodata.geom]
+
+    outcomes = Dict{Symbol, YAXArray}()
+    # add precomputed metrics for comptability
+    outcomes[:relative_cover] = _cscape_relative_cover(datasets)
+    # outcomes[:relative_taxa_cover] = _cscape_relative_taxa_cover(raw_set, geodata.area)
+
+    scen_groups = Dict(:counterfactual=>BitVector(true for _ in outcomes[:relative_cover].scenarios))
+
+    return CScapeResultSet(
+        res_name,
+        res_rcp,
+        location_ids,
+        geodata.area,
+        location_max_coral_cover,
+        location_centroids,
+        env_layer_md,
+        connectivity,
+        geodata,
+        scen_groups,
+        datasets,
+        inputs,
+        SimConstants(),
+        model_spec,
+        outcomes,
+        reformat_cube(raw_set.coral_size_diameter)
+    )
+end
+
+"""
+    _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
+
+Add missing sites to geopackage
+"""
+function _manual_site_additions(geodata::DataFrame, loc_ids, dataset::Dataset)::DataFrame
+    row_indx::Int64 = findfirst(x->x=="Moore_MR_S_39", geodata.reef_siteid)
+    row_cpy = copy(geodata[row_indx, :])
+    push!(geodata, row_cpy)
+    data_indx = findfirst(x->x=="Moore_MR_S_40", loc_ids)
+    geodata[end, :site_id] = "MR_S_40"
+    geodata[end, :reef_siteid] = "Moore_MR_S_40"
+    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx], dims=:intervened)[1]
+    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
+
+    row_indx = findfirst(x->x=="Milln_MR_OF_3", geodata.reef_siteid)
+    row_cpy = copy(geodata[row_indx, :])
+    push!(geodata, row_cpy)
+    data_indx = findfirst(x->x=="Milln_MR_OF_4", loc_ids)
+    geodata[end, :site_id] = "MR_OF_4"
+    geodata[end, :reef_siteid] = "Milln_MR_OF_4"
+    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx], dims=:intervened)[1]
+    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
+
+    row_indx = findfirst(x->x=="Elford_ER_S_50", geodata.reef_siteid)
+    row_cpy = copy(geodata[row_indx, :])
+    push!(geodata, row_cpy)
+    data_indx = findfirst(x->x=="Elford_ER_S_51", loc_ids)
+    geodata[end, :site_id] = "ER_S_51"
+    geodata[end, :reef_siteid] = "Elford_ER_S_51"
+    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx], dims=:intervened)[1]
+    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
+
+    row_indx = findfirst(x->x=="Elford_ER_S_50", geodata.reef_siteid)
+    row_cpy = copy(geodata[row_indx, :])
+    push!(geodata, row_cpy)
+    data_indx = findfirst(x->x=="Elford_ER_S_52", loc_ids)
+    geodata[end, :site_id] = "ER_S_52"
+    geodata[end, :reef_siteid] = "Elford_ER_S_52"
+    geodata[end, :area] = sum(dataset.area[reef_sites=data_indx], dims=:intervened)[1]
+    geodata[end, :k] = dataset.k[reef_sites=data_indx][1]
+    return geodata
+end
+
+"""
+    _get_scenario_id(datasets::Dataset)::Int
+
+Get the scenario id contained in the meta data of the netcdf. Transform to form expected in
+scenario id expected in scenario spec.
+
+1   -> 100001
+701 -> 100701
+"""
+function _get_scenario_id(dataset::Dataset)::Int
+    scenario_id = parse(Int, dataset.properties["scenario_ID"])
+    if scenario_id > 100000
+        return scenario_id
+    end
+    return scenario_id + 100000
+end
+
+"""
+    _get_functional_types(dataset::Dataset)::Vector{String}
+"""
+function _get_functional_types(dataset::Dataset)::Vector{String}
+    if !haskey(dataset.coral_size_diameter.properties, "column_names")
+        @warn "Unable to find names of functional types. Skipping."
+        return Vector{String}(undef, 0)
+    end
+    raw_names::String = dataset.coral_size_diameter.properties["column_names"]
+    return string.(split(raw_names, " "))
+end
+
+function _default_missing(value, default)
+    return ismissing(value) ? default : value
+end
+
+"""
+    _recreate_inputs_dataframe(datasets::Vector{Dataset}, scenario_spec::DataFrame)::DataFrame
+
+Construct the inputs datadrame from dataset properties and scenario table.
+"""
+function _recreate_inputs_dataframe(
+    datasets::Vector{Dataset}, scenario_spec::DataFrame
+)::DataFrame
+    # Get rows from scenario spec dataframe corresponding to the scenarios
+    scenario_idxs::Vector{Int} =
+        [findfirst(x->x==idx, scenario_spec.ID) for idx in _get_scenario_id.(datasets)]
+    scenario_rows::Vector{DataFrameRow} = [scenario_spec[idx + i * 100, :] for (i, idx) in enumerate(scenario_idxs)]
+
+    # Convert climate scenarios to factors
+    rcps::Vector{Float64} =
+        parse.(Float64, [dataset.properties["ssp"][end-1:end] for dataset in datasets])
+
+    # Convert climate models to factors
+    input_scenarios::Vector{Tuple{String, Int}} = [(
+        dataset.properties["climate model"], dataset.properties["climate_model_realisation_point"]
+    ) for dataset in datasets]
+    input_inds::Vector{Int} =
+        [findfirst(x -> x == scen, unique(input_scenarios)) for scen in input_scenarios]
+
+    fragmented_spec::Vector{DataFrame} = _create_inputs_dataframe.(
+        datasets, scenario_rows, rcps, input_inds
+    )
+    scenarios::DataFrame = reduce(vcat, fragmented_spec)
+    return scenarios
+end
+"""
+    _create_inputs_dataframe(dataset::Dataset, scenario_spec::DataFrameRow, rcp::Float64, input_index::Int)::DataFrame
+
+Construct inputs dataframe for a singular netcdf file.
+"""
+function _create_inputs_dataframe(
+    dataset::Dataset,
+    scenario_spec::DataFrameRow,
+    rcp::Float64,
+    input_index::Int
+)::DataFrame
+    functional_types::Vector{String} = _get_functional_types(dataset)
+    n_draws::Int = :draws in keys(dataset.axes) ? length(get(dataset.axes, :draws, [1])) : 1
+
+    dhws::Vector{Float64} = Float64.(repeat([input_index], n_draws))
+    cyclones::Vector{Float64} = Float64.(repeat([input_index], n_draws))
+
+    # Thermal tolerance bins are stored as lb_interval_ub
+    lb_t, int_t1, int_t2, ub_t = parse.(
+        Float64, split(scenario_spec.HeatToleranceGroups, "_")
+    )
+    init_heat_tol_mean, init_heat_tol_std = parse.(
+        Float64, split(scenario_spec.HeatToleranceInit, "_")
+    )
+    heritability1, heritability2 = parse.(
+        Float64, split(scenario_spec.Heritability, "_")
+    )
+    plasticity::Int64 = scenario_spec.Plasticity
+
+    settle_probability = parse.(Float64, split(scenario_spec.settle_prob, "_"))
+
+    settle_probs_kwargs = Dict(
+        Symbol(ft*"_settle_probability") => prob
+        for (ft, prob) in zip(functional_types, settle_probability)
+    )
+
+    # Intervention factors
+    deployment_area = _default_missing(scenario_spec[Symbol("Deployment area")], 0.0)
+    total_corals = _default_missing(scenario_spec.TotalCorals, 1.0)
+
+    n_seeded = [0.0, 0.0, 0.0, 0.0, 0.0]
+    taxa_deployed = ismissing(scenario_spec.species) ? [] : parse.(
+        Int64, split(scenario_spec.species, '_')
+    )
+    n_seeded[taxa_deployed] .= total_corals / length(taxa_deployed)
+    corals_deployed = Dict(
+        Symbol(ft*"_n_seeded") => n_corals
+        for (ft, n_corals) in zip(functional_types, n_seeded)
+    )
+
+    enhancement_mean, enhancement_std = parse.(
+        Float64, split(_default_missing(scenario_spec.Enhancement, "0_0"), '_')
+    )
+
+    intervention_start = _default_missing(
+        scenario_spec.InterventionYears_start, dataset.year[1]
+    ) - dataset.year[1]
+
+    duration = _default_missing(scenario_spec.duration, 0.0)
+    frequency = _default_missing(scenario_spec.frequency, 0.0)
+    n_dep_locations = count(x->x=='/', _default_missing(scenario_spec.Reef_siteids, ""))
+
+    coral_dict = merge(settle_probs_kwargs, corals_deployed)
+
+    return DataFrame(;
+        dhw_scenario=dhws,
+        cyc_scenario=cyclones,
+        RCP=repeat([rcp], n_draws),
+        thermal_tol_lb=repeat([lb_t], n_draws),
+        thermal_tol_int1=repeat([int_t1], n_draws),
+        thermal_tol_int2=repeat([int_t2], n_draws),
+        thermal_tol_ub=repeat([ub_t], n_draws),
+        init_heat_tol_mean=repeat([init_heat_tol_mean], n_draws),
+        init_heat_tol_std=repeat([init_heat_tol_std], n_draws),
+        heritability1=repeat([heritability1], n_draws),
+        heritability2=repeat([heritability2], n_draws),
+        plasticity=repeat([plasticity], n_draws),
+        intervention_start=repeat([intervention_start], n_draws),
+        intervention_duration=repeat([duration], n_draws),
+        intervention_frequency=repeat([frequency], n_draws),
+        deployment_area=repeat([deployment_area], n_draws),
+        n_deployment_locations=repeat([n_dep_locations], n_draws),
+        enhancement_mean=repeat([enhancement_mean], n_draws),
+        enhancement_std=repeat([enhancement_std], n_draws),
+        coral_dict...
+    )
+end
+
+"""
+    _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::DataFrame
+
+Create partial model specification from scenario specification.
+"""
+function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::DataFrame
+    # Retrieve coral factors
+    factor_names::Vector{String} = names(scenario_spec)
+    # Settler Probability
+    settle_names = filter(factor -> contains(factor, "settle_probability"), factor_names)
+    settle_readable = human_readable_name.(settle_names)
+    settle_names = Symbol.(settle_names)
+    settle_ptype = repeat(["continuous"], length(settle_names))
+    settle_lb = repeat([0.0], length(settle_names))
+    settle_ub = repeat([1.0], length(settle_names))
+
+    # Number of corals seeded
+    seeded_names = filter(factor -> contains(factor, "n_seeded"), factor_names)
+    seeded_readable = human_readable_name.(seeded_names)
+    seeded_names = Symbol.(seeded_names)
+    seeded_ptype = repeat(["continuous"], length(settle_names))
+    seeded_lb = repeat([0.0], length(seeded_names))
+    seeded_ub = repeat([5e7], length(seeded_names))
+
+    # Construct default model spec
+    fieldname::Vector{Symbol} = [
+        :dhw_scenario, # Environment Layer
+        :cyc_scenario,
+        :thermal_tol_lb, # Corals
+        :thermal_tol_int1,
+        :thermal_tol_int2,
+        :thermal_tol_ub,
+        :init_heat_tol_mean,
+        :init_heat_tol_std,
+        :heritability1,
+        :heritability2,
+        :plasticity,
+        :intervention_start, # Interventions
+        :intervention_duration,
+        :intervention_frequency,
+        :deployment_area,
+        :n_deployment_locations,
+        :enhancement_mean,
+        :enhancement_std,
+        settle_names..., # Corals
+        seeded_names... # Intervention
+    ]
+    descriptions::Vector{String} = [
+        "DHW Scenario",
+        "Cyclone Scenario",
+        "Natural thermal tolerance lower bound",
+        "Natural thermal tolerance int1",
+        "Natural thermal tolerance int2",
+        "Natural thermal tolerance upper bound",
+        "Initial natural thermal tolerance mean",
+        "Initial natural thermal tolerance standard deviation",
+        "Heritability mean",
+        "Heritability standard deviation",
+        "Plasticity",
+        "First Intervention Year",
+        "Duration of interventions (years)",
+        "Frequency of interventions after first year (years)",
+        "Area of coral deployments (m^2)",
+        "Number of locations intervened on",
+        "Artificial thermal tolerance enhancement mean",
+        "Artificial thermal tolerance enhancement standard deviation",
+        settle_readable...,
+        seeded_readable...
+    ]
+    human_names::Vector{String} = [
+        "DHW scenario",
+        "Cyclone scenario",
+        "Thermal Tolerance Lower Bound",
+        "Thermal Tolerance int1",
+        "Thermal Tolerance int2",
+        "Thermal Tolerance Upper Bound",
+        "Initial Thermal Tolerance Mean",
+        "Initial Thermal Tolerance Standard deviation",
+        "Heritability Mean",
+        "Heritability Standard Deviation",
+        "Plasticity",
+        "First Intervention Year",
+        "Duration of Interventions",
+        "Frequency of Interventions",
+        "Area of Deployments",
+        "Number of Deployment Locations",
+        "Enhancement Mean",
+        "Enhancement Standard Deviation",
+        settle_readable...,
+        seeded_readable...
+    ]
+    ptype::Vector{String} = [
+        "unordered categorical",
+        "unordered categorical",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "continuous",
+        "ordered categorical",
+        "ordered categorical",
+        "ordered categorical",
+        "continuous",
+        "ordered discrete",
+        "continuous",
+        "continuous",
+        settle_ptype...,
+        seeded_ptype...
+    ]
+    lower_bound::Vector{Float64} = [
+        1.0,
+        1.0,
+        -6.0,
+        0.0,
+        0.0,
+        8.0,
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        settle_lb...,
+        seeded_lb...
+    ]
+    upper_bound::Vector{Float64} = [
+        50.0,
+        50.0,
+        0.0,
+        40.0,
+        24.0,
+        30.0,
+        1.0,
+        3.0,
+        1.0,
+        0.5,
+        1.0,
+        25.0,
+        10.0,
+        10.0,
+        maximum(scenario_spec.deployment_area),
+        100.0,
+        30.0,
+        2.0,
+        settle_ub...,
+        seeded_ub...
+    ]
+    dist_params::Vector{String} = [
+        string((lb, ub)) for (lb, ub) in zip(lower_bound, upper_bound)
+    ]
+    component::Vector{String} = vcat(
+        repeat(["EnvironmentalLayer"], 2),
+        repeat(["Coral"], 9),
+        repeat(["Intervention"], 7),
+        repeat(["Coral"], length(settle_names)),
+        repeat(["Intervention"], length(seeded_names))
+    )
+    return DataFrame(
+        component=component,
+        fieldname=fieldname,
+        description=descriptions,
+        name=human_names,
+        ptype=ptype,
+        dist_params=dist_params,
+        lower_bound=lower_bound,
+        upper_bound=upper_bound
+    )
+end
+
+"""
+    _get_result_paths(result_dir::String)::Vector{String}
+
+Get the names of all result netcdf result files in the given directory. Assumes filenames
+match "NetCDF_Scn.*.nc.
+"""
+function _get_result_paths(result_dir::String)::Vector{String}
+    possible_files = filter(isfile, readdir(result_dir, join=true))
+    possible_files = filter(x -> occursin(r"NetCDF_Scn.*.nc", x), possible_files)
+    if length(possible_files) == 0
+        error("Unable to find result netcdf file in subdirectory $(res_subdir)")
+    end
+    return possible_files
+end
+
+"""
+    _get_gpkg_path(data_dir::String)
+
+Get the path to the gpkg file contained in the site_data subdirectory.
+"""
+function _get_gpkg_path(data_dir::String)
+    gpkg_dir = joinpath(data_dir, "site_data")
+    possible_files = filter(isfile, readdir(gpkg_dir, join=true))
+    possible_files = filter(x -> occursin(".gpkg", x), possible_files)
+    if length(possible_files) == 0
+        error("Unable to find site data in $(gpkg_dir)")
+    elseif length(possible_files) > 1
+        @warn "Found multiple gpkg files, using first."
+    end
+    return possible_files[1]
+end
+"""
+    _get_result_name()::String
+
+Get the name of the data set from the properties of the dataset.
+"""
+function _get_result_name(ds::Dataset)::String
+    name = "CScape Results"
+    if !haskey(ds.properties, "title")
+        @warn "Unable to find key `title` in dataset properties, \
+               defaulting to `CScape Results`"
+    else
+        name = ds.properties["title"]
+    end
+    return name
+end
+
+"""
+    _get_rcp(ds::Datset)::String
+
+Get the RCP from the ssp field in dataset properties. Assume RCP is last two numbers.
+"""
+function _get_rcp(ds::Dataset)::String
+    rcp = ""
+    if !haskey(ds.properties, "ssp")
+        @warn "Unable to find key `ssp` in dataset properties."
+    else
+        rcp = ds.properties["ssp"][end-1:end]
+    end
+    return rcp
+end
+
+"""
+    _get_reefids(ds::YAXArray)::String
+
+Reef IDs are stored in a space seperated list in the properties of reef_siteid cube.
+"""
+function _get_reefids(reef_cube::YAXArray)::Vector{String}
+    # Site IDs are necessary to extract the correct data from the geopackage
+    if !haskey(reef_cube.properties, "flag_meanings")
+        error("Unable to find key `flag_meanings` in Cube properties.")
+    end
+
+    reef_ids = split(reef_cube.properties["flag_meanings"], " ")
+    if (reef_ids[1] == reef_ids[2])
+        return reef_ids[2:end] # Possible first element duplication
+    end
+    return reef_ids
+end
+
+"""
+    reformat_cube(cscape_cube::YAXArray)::YAXArray
+
+Rename reorder the names of the dimensions to align with ADRIA's expected dimension names.
+"""
+function reformat_cube(cscape_cube::YAXArray, loc_mask::BitVector)
+    cscape_cube = reformat_cube(cscape_cube)
+    if :sites ∈ name.(cscape_cube.axes)
+        cscape_cube = cscape_cube[sites=loc_mask]
+    end
+    return cscape_cube
+end
+function reformat_cube(cscape_cube::YAXArray)::YAXArray
+    dim_names = name.(cscape_cube.axes)
+    cscape_names = [:year, :reef_sites, :ft, :draws]
+    adria_names = [:timesteps, :sites, :taxa, :scenarios]
+    final_ordering::Vector{Int} = Vector{Int}(undef, length(dim_names))
+    current_index = 1
+    # rename expected dimensions and update the permutation vector
+    for (cscape_nm, adria_nm) in zip(cscape_names, adria_names)
+        if cscape_nm ∉ dim_names
+            continue
+        end
+        cscape_cube = renameaxis!(cscape_cube, cscape_nm=>adria_nm)
+        final_ordering[current_index] = findfirst(x->x==cscape_nm, dim_names)
+        current_index += 1
+    end
+     # append the indices of non-adria axis to end of permutation vector
+    for dim_name in dim_names
+        if dim_name in cscape_names
+            continue
+        end
+        final_ordering[current_index] = findfirst(x->x==dim_name, dim_names)
+        current_index += 1;
+    end
+    if haskey(cscape_cube.properties, "units")
+        if cscape_cube.properties["units"] == "percent"
+            cscape_cube = cscape_cube ./ 100
+            cscape_cube.properties["units"] == "proportion [0, 1]"
+        end
+    end
+    cscape_cube = permutedims(cscape_cube, final_ordering)
+    return cscape_cube
+end
+
+function _throw_missing_variable(dataset::Dataset, var_name::Symbol)::Nothing
+    throw(ArgumentError("NetCDF $(dataset.properties["scenario_ID"]) does not \
+                         contain $(String.(var_name)) variable"))
+    return nothing
+end
+
+"""
+    drop_sum(cube::YAXArray, dims)::YAXArray
+
+Sum over given dimensions and drop the same given dimensions.
+"""
+function _drop_sum(cube::YAXArray, red_dims)::YAXArray
+    return dropdims(sum(cube, dims=red_dims), dims=red_dims)
+end
+
+"""
+    _cscape_relative_cover(dataset::Dataset; loc_mask::BitVector=[])::YAXArray
+
+Calculate relative cover metric for cscape data.
+"""
+function _cscape_relative_cover(dataset::Dataset)::Array
+    # Throw error and identify specific misformatted file.
+    if !haskey(dataset.cubes, :cover)
+        _throw_missing_variable(dataset, :cover)
+    end
+    if !haskey(dataset.cubes, :area)
+        _throw_missing_variable(dataset, :area)
+    end
+    if !haskey(dataset.cubes, :k)
+        _throw_missing_variable(dataset, :k)
+    end
+    dim_sum = (:ft, :thermal_tolerance)
+
+    multi_scenario::Bool = :draws in keys(dataset.axes)
+
+    n_scens = multi_scenario ? length(dataset.draws) : 0
+    n_tsteps::Int64 = length(dataset.year)
+    n_locs::Int64 = length(dataset.reef_sites)
+
+    if multi_scenario
+        relative_cover = zeros(n_scens, n_tsteps, n_locs)
+        reshape_tuple = (1, 1, n_locs)
+    else
+        relative_cover = zeros(n_tsteps, n_locs)
+        reshape_tuple = (1, n_locs)
+    end
+
+    # Calculate relative cover from non-intervened areas
+    # Force load with dimensions [intervened ⋅ reef_sites]
+    area = dataset.area.data[:, :]
+    relative_cover .= _drop_sum(
+        dataset.cover[intervened=1], dim_sum
+    ) .* reshape(
+        area[1, :] .* dataset.k[:],
+        reshape_tuple
+    ) ./ 100
+
+    relative_cover .+= _drop_sum(
+        dataset.cover[intervened=2], dim_sum
+    ) .* reshape(
+        area[2, :] .* dataset.k[:],
+        reshape_tuple
+    ) ./ 100
+
+    # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
+    if multi_scenario
+        return permutedims(relative_cover, (2, 3, 1))
+    end
+    return relative_cover
+end
+
+"""
+    _n_scenarios(dataset::Dataset)::Int64
+
+Get the number of scenario or draws in a dataset.
+"""
+function _n_scenarios(dataset::Dataset)::Int64
+    if :draws in keys(dataset.axes)
+        return length(dataset.draws)
+    end
+    return 1
+end
+
+function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
+    n_locs::Int64 = length(datasets[1].reef_sites)
+
+    # Assume same number of locations and timesteps for every dataset
+    n_scens::Vector{Int64} = _n_scenarios.(datasets)
+
+    relative_cover = ZeroDataCube(
+        T=Float64,
+        timesteps=datasets[1].year.val,
+        sites=1:n_locs,
+        scenarios=1:sum(n_scens)
+    )
+
+    cur_indx = 1
+    for (n_sc, dataset) in zip(n_scens, datasets)
+        if n_sc == 1
+            relative_cover[scenarios=cur_indx] = _cscape_relative_cover(
+                dataset
+            )
+        else
+            relative_cover[scenarios=cur_indx:(cur_indx+n_sc-1)] = _cscape_relative_cover(
+                dataset
+            )
+        end
+        cur_indx += n_sc
+    end
+    return relative_cover
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", rs::CScapeResultSet)
+    rcps = rs.RCP
+    scens = length(rs.outcomes[:relative_cover].scenarios)
+    sites = length(rs.outcomes[:relative_cover].sites)
+    tf = rs.env_layer_md.timeframe
+
+    println("""
+    Name: $(rs.name)
+
+    Results stored at: $(rs.env_layer_md.dpkg_path)
+
+    RCP(s) represented: $(rcps)
+    Scenarios run: $(scens)
+    Number of sites: $(sites)
+    Timesteps: $(tf)
+    """)
+end

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -759,7 +759,7 @@ function _n_scenarios(dataset::Dataset)::Int64
 end
 
 """
-    _data_position(n_per_dataset::Vector{Int})
+    _data_position(n_per_dataset::Vector{Int64})
 
 Determine the index positions of a set of data if they were collated into a single dataset.
 
@@ -783,10 +783,10 @@ start_pos, end_pos = _data_position(n_scens)
 # Returns
 The start and end position of each entry
 """
-function _data_position(n_per_dataset::Vector{Int})::Vector{Tuple{Int64, Int64}}
+function _data_position(n_per_dataset::Vector{Int64})::Vector{Tuple{Int64, Int64}}
     n = length(n_per_dataset)
-    starts = Vector{Int}(undef, n)
-    ends = Vector{Int}(undef, n)
+    starts = Vector{Int64}(undef, n)
+    ends = Vector{Int64}(undef, n)
 
     starts[1] = 1
     ends[1] = n_per_dataset[1]

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -671,8 +671,8 @@ Rename reorder the names of the dimensions to align with ADRIA's expected dimens
 """
 function reformat_cube(cscape_cube::YAXArray)::YAXArray
     dim_names = name.(cscape_cube.axes)
-    cscape_names = [:year, :reef_sites, :ft, :draws]
-    adria_names = [:timesteps, :locations, :species, :scenarios]
+    cscape_names = [:year, :ft, :reef_sites, :draws]
+    adria_names = [:timesteps, :species, :locations, :scenarios]
     final_ordering::Vector{Int} = Vector{Int}(undef, length(dim_names))
     current_index = 1
     # rename expected dimensions and update the permutation vector

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -721,9 +721,10 @@ function _cscape_relative_cover(dataset::Dataset)::Array
     return relative_cover
 end
 function _cscape_relative_cover(datasets::Vector{Dataset})::YAXArray
+    # Assume same number of locations and timesteps for every dataset
     n_locs::Int64 = length(datasets[1].reef_sites)
 
-    # Assume same number of locations and timesteps for every dataset
+    # Determine the number of entries for each file
     n_scens::Vector{Int64} = _n_scenarios.(datasets)
 
     relative_cover = ZeroDataCube(

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -698,6 +698,14 @@ function _cscape_relative_cover(dataset::Dataset)::Array
 
     # Calculate relative cover from non-intervened areas
     # Force load with dimensions [intervened ⋅ reef_sites]
+
+    # We want to read in data before any calculations are conducted to maintain
+    # speed/performance. Using `read()` converts data into a base Matrix, so we
+    # use a dummy selector to retain the nice YAXArray data type while also reading
+    # the data into memory.
+    n_dims = length(dims(dataset.cover))
+    dummy_selector = fill((:), n_dims-1)
+
     area = dataset.area.data[:, :]
     relative_cover .= _drop_sum(
         dataset.cover[intervened=1], dim_sum

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -285,7 +285,7 @@ function _create_inputs_dataframe(
 
     dhws::Vector{Float64} = Float64.(fill(input_index, n_draws))
     cyclones::Vector{Float64} = Float64.(fill(input_index, n_draws))
-    scenario_id::Vector{Int64} = Int64.(fill(scenario_spec.ID, n_draws))
+    scenario_id::Vector{Float64} = Int64.(fill(scenario_spec.ID, n_draws))
 
     # Thermal tolerance bins are stored as lb_interval_ub
     lb_t, int_t1, int_t2, ub_t =
@@ -299,7 +299,7 @@ function _create_inputs_dataframe(
     heritability1, heritability2 = parse.(
         Float64, split(scenario_spec.Heritability, "_")
     )
-    plasticity::Int64 = scenario_spec.Plasticity
+    plasticity::Float64 = scenario_spec.Plasticity
 
     settle_probability = parse.(Float64, split(scenario_spec.settle_prob, "_"))
 
@@ -310,7 +310,7 @@ function _create_inputs_dataframe(
 
     # Intervention factors
     deployment_area = _default_missing(scenario_spec[Symbol("Deployment area")], 0.0)
-    total_corals = _default_missing(scenario_spec.TotalCorals, 1.0)
+    total_corals = Float64.(_default_missing(scenario_spec.TotalCorals, 1.0))
 
     n_seeded = [0.0, 0.0, 0.0, 0.0, 0.0]
     taxa_deployed = if ismissing(scenario_spec.species)
@@ -332,13 +332,13 @@ function _create_inputs_dataframe(
         )
 
     intervention_start =
-        _default_missing(
+        Float64.(_default_missing(
             scenario_spec.InterventionYears_start, nc_handle["year"][1]
-        ) - nc_handle["year"][1]
+        ) - nc_handle["year"][1])
 
-    duration = _default_missing(scenario_spec.duration, 0.0)
-    frequency = _default_missing(scenario_spec.frequency, 0.0)
-    n_dep_locations = count(x -> x == '/', _default_missing(scenario_spec.Reef_siteids, ""))
+    duration = Float64.(_default_missing(scenario_spec.duration, 0.0))
+    frequency = Float64.(_default_missing(scenario_spec.frequency, 0.0))
+    n_dep_locations = Float64.(count(x -> x == '/', _default_missing(scenario_spec.Reef_siteids, "")))
 
     coral_dict = merge(settle_probs_kwargs, corals_deployed)
 
@@ -540,6 +540,7 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         repeat(["Coral"], length(settle_names)),
         repeat(["Intervention"], length(seeded_names))
     )
+    is_constant::Vector{Bool} = fill(false, length(component))
     return DataFrame(;
         component=component,
         fieldname=fieldname,
@@ -548,7 +549,8 @@ function _create_model_spec(::Type{CScapeResultSet}, scenario_spec::DataFrame)::
         ptype=ptype,
         dist_params=dist_params,
         lower_bound=lower_bound,
-        upper_bound=upper_bound
+        upper_bound=upper_bound,
+        is_constant=is_constant
     )
 end
 

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -714,12 +714,15 @@ function _cscape_relative_cover(dataset::Dataset)::Array
         reshape_tuple
     ) ./ 100.0
 
-    relative_cover .+= _drop_sum(
-        dataset.cover[intervened=2], dim_sum
-    ) .* reshape(
-        area[2, :] .* dataset.k[:],
-        reshape_tuple
-    ) ./ 100.0
+    # Only calculate if there are area values > 0
+    if !any(area[2, :] .> 0.0)
+        relative_cover .+= _drop_sum(
+            dataset.cover[intervened=2][dummy_selector...], dim_sum
+        ) .* reshape(
+            area[2, :] .* dataset.k[:],
+            reshape_tuple
+        ) ./ 100.0
+    end
 
     # ADRIA assumes a shape of [timesteps ⋅ locations ⋅ scenarios]
     if multi_scenario

--- a/src/io/cscape_result_io.jl
+++ b/src/io/cscape_result_io.jl
@@ -283,9 +283,9 @@ function _create_inputs_dataframe(
     n_draws::Int =
         "draws" in keys(nc_handle.dim) ? length(get(nc_handle.dim, "draws", [1])) : 1
 
-    dhws::Vector{Float64} = Float64.(repeat([input_index], n_draws))
-    cyclones::Vector{Float64} = Float64.(repeat([input_index], n_draws))
-    scenario_id::Vector{Int64} = Int64.(repeat([scenario_spec.ID], n_draws))
+    dhws::Vector{Float64} = Float64.(fill(input_index, (n_draws,)))
+    cyclones::Vector{Float64} = Float64.(fill(input_index, (n_draws,)))
+    scenario_id::Vector{Int64} = Int64.(fill(scenario_spec.ID, (n_draws,)))
 
     # Thermal tolerance bins are stored as lb_interval_ub
     lb_t, int_t1, int_t2, ub_t =
@@ -346,23 +346,23 @@ function _create_inputs_dataframe(
         scenario_id=scenario_id,
         dhw_scenario=dhws,
         cyc_scenario=cyclones,
-        RCP=repeat([rcp], n_draws),
-        thermal_tol_lb=repeat([lb_t], n_draws),
-        thermal_tol_int1=repeat([int_t1], n_draws),
-        thermal_tol_int2=repeat([int_t2], n_draws),
-        thermal_tol_ub=repeat([ub_t], n_draws),
-        init_heat_tol_mean=repeat([init_heat_tol_mean], n_draws),
-        init_heat_tol_std=repeat([init_heat_tol_std], n_draws),
-        heritability1=repeat([heritability1], n_draws),
-        heritability2=repeat([heritability2], n_draws),
-        plasticity=repeat([plasticity], n_draws),
-        intervention_start=repeat([intervention_start], n_draws),
-        intervention_duration=repeat([duration], n_draws),
-        intervention_frequency=repeat([frequency], n_draws),
-        deployment_area=repeat([deployment_area], n_draws),
-        n_deployment_locations=repeat([n_dep_locations], n_draws),
-        enhancement_mean=repeat([enhancement_mean], n_draws),
-        enhancement_std=repeat([enhancement_std], n_draws),
+        RCP=fill(rcp, (n_draws,)),
+        thermal_tol_lb=fill(lb_t, (n_draws,)),
+        thermal_tol_int1=fill(int_t1, (n_draws,)),
+        thermal_tol_int2=fill(int_t2, (n_draws,)),
+        thermal_tol_ub=fill(ub_t, (n_draws,)),
+        init_heat_tol_mean=fill(init_heat_tol_mean, (n_draws,)),
+        init_heat_tol_std=fill(init_heat_tol_std, (n_draws,)),
+        heritability1=fill(heritability1, (n_draws,)),
+        heritability2=fill(heritability2, (n_draws,)),
+        plasticity=fill(plasticity, (n_draws,)),
+        intervention_start=fill(intervention_start, (n_draws,)),
+        intervention_duration=fill(duration, (n_draws,)),
+        intervention_frequency=fill(frequency, (n_draws,)),
+        deployment_area=fill(deployment_area, (n_draws,)),
+        n_deployment_locations=fill(n_dep_locations, (n_draws,)),
+        enhancement_mean=fill(enhancement_mean, (n_draws,)),
+        enhancement_std=fill(enhancement_std, (n_draws,)),
         coral_dict...
     )
 end

--- a/src/metrics/cscape.jl
+++ b/src/metrics/cscape.jl
@@ -14,7 +14,7 @@ function _total_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArr
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year,)
-    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(2, 3, 4, 5)); dims=(2, 3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :internal_received_larvae
@@ -23,9 +23,9 @@ function _total_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArr
     )
 end
 total_internal_larvae = Metric(
-    _total_internal_larvae, 
-    (:timesteps, :scenarios), 
-    "Total Internal Larvae", 
+    _total_internal_larvae,
+    (:timesteps, :scenarios),
+    "Total Internal Larvae",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -44,7 +44,7 @@ function _loc_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year, :reef_sites)
-    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(3, 4, 5)); dims=(3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :internal_received_larvae
@@ -53,9 +53,9 @@ function _loc_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray
     )
 end
 loc_internal_larvae = Metric(
-    _loc_internal_larvae, 
-    (:timesteps, :locations, :scenarios), 
-    "Location Internal Larvae", 
+    _loc_internal_larvae,
+    (:timesteps, :locations, :scenarios),
+    "Location Internal Larvae",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -74,7 +74,7 @@ function _total_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArr
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year,)
-    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(2, 3, 4, 5)); dims=(2, 3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :external_larvae
@@ -83,9 +83,9 @@ function _total_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArr
     )
 end
 total_external_larvae = Metric(
-    _total_external_larvae, 
-    (:timesteps, :scenarios), 
-    "Total External Larvae", 
+    _total_external_larvae,
+    (:timesteps, :scenarios),
+    "Total External Larvae",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -104,7 +104,7 @@ function _loc_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year, :reef_sites)
-    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(3, 4, 5)); dims=(3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :external_larvae
@@ -113,9 +113,9 @@ function _loc_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray
     )
 end
 loc_external_larvae = Metric(
-    _loc_external_larvae, 
-    (:timesteps, :locations, :scenarios), 
-    "Location External Larvae", 
+    _loc_external_larvae,
+    (:timesteps, :locations, :scenarios),
+    "Location External Larvae",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -134,7 +134,7 @@ function _total_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year,)
-    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(2, 3, 4, 5)); dims=(2, 3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :eggs
@@ -143,9 +143,9 @@ function _total_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray
     )
 end
 total_eggs_produced = Metric(
-    _total_eggs_produced, 
-    (:timesteps, :scenarios), 
-    "Total Eggs Produced", 
+    _total_eggs_produced,
+    (:timesteps, :scenarios),
+    "Total Eggs Produced",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -164,7 +164,7 @@ function _loc_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year, :reef_sites)
-    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(3, 4, 5)); dims=(3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :eggs
@@ -173,9 +173,9 @@ function _loc_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<
     )
 end
 loc_eggs_produced = Metric(
-    _loc_eggs_produced, 
-    (:timesteps, :locations, :scenarios), 
-    "Location Eggs Produced", 
+    _loc_eggs_produced,
+    (:timesteps, :locations, :scenarios),
+    "Location Eggs Produced",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -194,7 +194,7 @@ function _total_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Re
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year,)
-    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(2, 3, 4, 5)); dims=(2, 3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :settlers
@@ -203,9 +203,9 @@ function _total_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Re
     )
 end
 total_settlers = Metric(
-    _total_settlers, 
-    (:timesteps, :scenarios), 
-    "Total Settlers", 
+    _total_settlers,
+    (:timesteps, :scenarios),
+    "Total Settlers",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -224,7 +224,7 @@ function _loc_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year, :reef_sites)
-    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(3, 4, 5)); dims=(3, 4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :settlers
@@ -233,9 +233,9 @@ function _loc_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real
     )
 end
 loc_settlers = Metric(
-    _loc_settlers, 
-    (:timesteps, :locations, :scenarios), 
-    "Location Settlers", 
+    _loc_settlers,
+    (:timesteps, :locations, :scenarios),
+    "Location Settlers",
     IS_NOT_RELATIVE,
     "count"
 )
@@ -248,7 +248,7 @@ function _relative_loc_taxa_cover(rs::CScapeResultSet; show_progress=true)::YAXA
 
     # Expected dimensions after aggregation excluding dimensions
     out_dims::Tuple = (:year, :reef_sites, :ft)
-    agg_f = x -> dropdims(sum(x, dims=(4, 5)), dims=(4, 5))
+    agg_f = x -> dropdims(sum(x; dims=(4, 5)); dims=(4, 5))
 
     # name of variable to be used for calculation
     input_var_name::Symbol = :cover
@@ -266,9 +266,10 @@ function _relative_taxa_cover(rs::CScapeResultSet; show_progress=true)::YAXArray
 
     _site_k_area = reshape(site_k_area(rs), (1, :, 1, 1))
     loc_taxa_cover::YAXArray = relative_loc_taxa_cover(rs; show_progress=show_progress)
-    taxa_cover = dropdims(sum(
-        loc_taxa_cover .* _site_k_area, dims=:locations
-    ) ./ sum(_site_k_area), dims=:locations)
+    taxa_cover = dropdims(
+        sum(
+            loc_taxa_cover .* _site_k_area; dims=:locations
+        ) ./ sum(_site_k_area); dims=:locations)
     rs.outcomes[outcome_name] = taxa_cover
 
     return taxa_cover
@@ -284,7 +285,7 @@ function _relative_cover(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Re
     # confusion.
     @info "Calculating relative species cover for relative cover."
     rel_taxa_loc_cover = relative_loc_taxa_cover(rs; show_progress=show_progress)
-    rel_cover = dropdims(sum(rel_taxa_loc_cover, dims=:species), dims=:species)
+    rel_cover = dropdims(sum(rel_taxa_loc_cover; dims=:species); dims=:species)
     rs.outcomes[outcome_name] = rel_cover
 
     return rs.outcomes[outcome_name]

--- a/src/metrics/cscape.jl
+++ b/src/metrics/cscape.jl
@@ -1,0 +1,275 @@
+using ADRIA: CScapeResultSet, _load_variable!
+
+"""
+    _total_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of internal received larvae across the entire domain. Calculated from the
+NetCDF variable "internal_received_larvae".
+"""
+function _total_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :total_internal_larvae
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year,)
+    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :internal_received_larvae
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+total_internal_larvae = Metric(
+    _total_internal_larvae, 
+    (:timesteps, :scenarios), 
+    "Total Internal Larvae", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _loc_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of internal received larvae for each location. Calculated from the NetCDF 
+variable "internal_received_larvae".
+"""
+function _loc_internal_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :loc_internal_larvae
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year, :reef_sites)
+    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :internal_received_larvae
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+loc_internal_larvae = Metric(
+    _loc_internal_larvae, 
+    (:timesteps, :locations, :scenarios), 
+    "Location Internal Larvae", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _total_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of external larvae used by cscape across the entire domain. Calculated from
+the NetCDF "external_larvae".
+"""
+function _total_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :total_external_larvae
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year,)
+    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :external_larvae
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+total_external_larvae = Metric(
+    _total_external_larvae, 
+    (:timesteps, :scenarios), 
+    "Total External Larvae", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _loc_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of external larvae used in the cscape model for each location. Calculated
+from the NetCDF variable "external_larvae".
+"""
+function _loc_external_larvae(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :loc_external_larvae
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year, :reef_sites)
+    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :external_larvae
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+loc_external_larvae = Metric(
+    _loc_external_larvae, 
+    (:timesteps, :locations, :scenarios), 
+    "Location External Larvae", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _total_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of eggs produced across the entire domain. Calculated from the NetCDF variable
+"eggs".
+"""
+function _total_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :total_eggs_produced
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year,)
+    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :eggs
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+total_eggs_produced = Metric(
+    _total_eggs_produced, 
+    (:timesteps, :scenarios), 
+    "Total Eggs Produced", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _loc_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of eggs produced at each location of the domain. Calculated from the NetCDF 
+variable "eggs".
+"""
+function _loc_eggs_produced(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :loc_eggs_produced
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year, :reef_sites)
+    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :eggs
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+loc_eggs_produced = Metric(
+    _loc_eggs_produced, 
+    (:timesteps, :locations, :scenarios), 
+    "Location Eggs Produced", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _total_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of coral settlers across the entire domain. Calculated from 
+NetCDF variable "settlers".
+"""
+function _total_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :total_settlers
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year,)
+    agg_f = x -> dropdims(sum(x, dims=(2, 3, 4, 5)), dims=(2, 3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :settlers
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+total_settlers = Metric(
+    _total_settlers, 
+    (:timesteps, :scenarios), 
+    "Total Settlers", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+"""
+    _loc_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+
+Get the number of coral settlers at each location. Calculated from NetCDF variable 
+"settlers".
+"""
+function _loc_settlers(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :loc_settlers
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year, :reef_sites)
+    agg_f = x -> dropdims(sum(x, dims=(3, 4, 5)), dims=(3, 4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :settlers
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name; show_progress=show_progress
+    )
+end
+loc_settlers = Metric(
+    _loc_settlers, 
+    (:timesteps, :locations, :scenarios), 
+    "Location Settlers", 
+    IS_NOT_RELATIVE,
+    "count"
+)
+
+function _relative_loc_taxa_cover(rs::CScapeResultSet; show_progress=true)::YAXArray{<:Real}
+    outcome_name::Symbol = :relative_loc_taxa_cover
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    # Expected dimensions after aggregation excluding dimensions
+    out_dims::Tuple = (:year, :reef_sites, :ft)
+    agg_f = x -> dropdims(sum(x, dims=(4, 5)), dims=(4, 5))
+
+    # name of variable to be used for calculation
+    input_var_name::Symbol = :cover
+    return _load_variable!(
+        rs, input_var_name, out_dims, agg_f, outcome_name;
+        use_combined_cover=true, show_progress=show_progress
+    )
+end
+
+function _relative_taxa_cover(rs::CScapeResultSet)::YAXArray{<:Real}
+    outcome_name::Symbol = :relative_taxa_cover
+    if outcome_name in keys(rs.outcomes)
+        return rs.outcomes[outcome_name]
+    end
+
+    _site_k_area = reshape(site_k_area(rs), (1, :, 1, 1))
+    loc_taxa_cover::YAXArray = relative_loc_taxa_cover(rs; show_progress=false)
+    taxa_cover = dropdims(sum(
+        loc_taxa_cover .* _site_k_area, dims=:locations
+    ) ./ sum(_site_k_area), dims=:locations)
+    rs.outcomes[outcome_name] = taxa_cover
+
+    return taxa_cover
+end

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -731,6 +731,7 @@ relative_shelter_volume = Metric(
     IS_RELATIVE
 )
 
+include("cscape.jl")
 include("metadata.jl")
 include("pareto.jl")
 include("ranks.jl")


### PR DESCRIPTION
It would probably be best to go over this pull request in a meeting due to its size.

## Loading C~scape Results

Results from C~scape can be loaded with the `load_results` function.

```julia
# Assumes NetCDFs are contained in result subdirectory (see example directory tree below)
rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>")

# Retrieves NetCDFs from separate directory
rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", "<path to result directory>")

# Manually pass in a list of files to load as results
rs = ADRIA.load_results(CScapeResultSet, "<path to data dir>", ["netcdf_fn1", "netcdf_fn2", ...])
```

## Functionality

[result_interface.pdf](https://github.com/user-attachments/files/18728327/result_interface.pdf)

##  Available Metrics

- Total Internal Larvae - `ADRIA.metrics.total_internal_larvae(rs)`
- Location Internal Larvae - `ADRIA.metrics.loc_internal_larvae(rs)`
- Total External Larvae - `ADRIA.metrics.total_external_larvae(rs)`
- Location External Larvae - `ADRIA.metrics.loc_external_larvae(rs)`
- Total Eggs Produced - `ADRIA.metrics.total_eggs_produced(rs)`
- Location Eggs Produced - `ADRIA.metrics.loc_eggs_produced(rs)`
- Total Settlers  - `ADRIA.metrics.total_settlers(rs)`
- Location Settlers - `ADRIA.metrics.loc_settlers(rs)`
- Relative Location Taxa Cover - `ADRIA.metrics.relative_loc_taxa_cover(rs)`
- Relative Taxa Cover - `ADRIA.metrics.relative_taxa_cover(rs)`
- Relative Cover - `ADRIA.metrics.relative_cover(rs)`

Any metric that depends on the above also works.

