### PR TITLE
Fix tests of viz/spatial and metrics/spatial

### DIFF
--- a/test/metrics/spatial.jl
+++ b/test/metrics/spatial.jl
@@ -1,4 +1,4 @@
-using ADRIA: metrics, metrics.cf_difference_loc
+using ADRIA: metrics
 using ADRIA: YAXArray
 
 if !@isdefined(TEST_RS)

--- a/test/viz/spatial.jl
+++ b/test/viz/spatial.jl
@@ -1,7 +1,7 @@
 using WGLMakie, GeoMakie, GraphMakie
 using ADRIA: viz
 using ADRIA: YAXArray
-using ADRIA: metrics, metrics.cf_difference_loc
+using ADRIA: metrics
 
 if !@isdefined(TEST_RS)
     const TEST_DOM, TEST_N_SAMPLES, TEST_SCENS, TEST_RS = test_rs()


### PR DESCRIPTION
Running metrics/spatial and viz/spatial tests raised this error: `ERROR: LoadError: UndefVarError: 'cf_difference_loc' not defined`. This error was caused because commit 46fd368 renamed the function cf_difference_loc to ensemble_loc_difference but it was still imported in the test function. The function was not being used.
This commit removes the import of cf_difference_loc function.