### PR TITLE
Tentative Plotlylight Extension package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -72,9 +72,11 @@ BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
 
 [extensions]
 AvizExt = ["Makie", "GeoMakie", "GraphMakie"]
+PlotlyLightExt = ["PlotlyLight"]
 
 [compat]
 Aqua = "0.8, 0.9"
@@ -91,7 +93,7 @@ DataFrames = "1"
 DataStructures = "0.18, 0.2"
 Dates = "1"
 DimensionalData = "0.25, 0.26, 0.27"
-DiskArrays = "=0.3.23, ^0.4.5"
+DiskArrays = "^0.4.5"
 Distances = "0.10"
 Distributed = "1"
 Distributions = "0.25"
@@ -123,6 +125,7 @@ NetCDF = "0.11, 0.12"
 OnlineStats = "1.5"
 OrderedCollections = "1"
 PkgVersion = "0.2, 0.3"
+PlotlyLight = "0.11"
 PrecompileTools = "1"
 Printf = "1"
 ProgressMeter = "1"
@@ -151,6 +154,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+PlotlyLight = "ca7969ec-10b3-423e-8d99-40f33abb42bf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 

--- a/ext/PlotlyLightExt/PlotlyLightExt.jl
+++ b/ext/PlotlyLightExt/PlotlyLightExt.jl
@@ -1,0 +1,80 @@
+module PlotlyLightExt
+
+using PlotlyLight
+using YAXArrays
+using ADRIA
+using ADRIA: ResultSet
+
+# TODO: All common helper methods should be moved into main `viz` module.
+
+"""
+    _calc_confint(ci)
+
+Helper method to determine quantile-based confidence bounds.
+
+# Arguments
+- `ci` : Desired quantile-based confidence bound (e.g., 0.95)
+
+# Returns
+Tuple, lower and upper CI bounds.
+"""
+function _calc_confint(ci::T)::Tuple{T,T} where {T<:AbstractFloat}
+    d = (1.0 - ci) / 2.0
+    return (d, 1.0 - d)
+end
+
+"""
+    _get_guided_labels()::Vector{String}
+
+Returns labels for categories of the `guided` factor.
+"""
+function _get_guided_labels()::Vector{String}
+    return [
+        "Counterfactual",
+        "Semi-guided",
+        last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...
+    ]
+end
+
+function outcome_label(
+    outcomes::YAXArray; metadata_key::Symbol=:metric_feature, label_case=titlecase
+)::String
+    outcome_metadata = outcomes.properties
+
+    _outcome_label = if all(haskey.([outcome_metadata], [metadata_key, :metric_unit]))
+        _metric_feature = label_case(outcome_metadata[metadata_key])
+        _metric_unit = outcome_metadata[:metric_unit]
+        _metric_label = !isempty(_metric_unit) ? "[$(_metric_unit)]" : ""
+        "$(_metric_feature) $(_metric_label)"
+    else
+        ""
+    end
+
+    return _outcome_label
+end
+
+"""
+    _guided_colors()
+
+Unique colors for scenario types.
+
+TODO: Move to common theme module and make colorblind friendly.
+"""
+function _guided_colors()
+    # Extracted "Set1" colorway from Plotly
+    return [
+        "#e41a1c",  # red
+        "#377eb8",  # blue
+        "#4daf4a",  # green
+        "#984ea3",  # purple
+        "#ff7f00",  # orange
+        "#ffff33",  # yellow
+        "#a65628",  # brown
+        "#f781bf",  # pink
+        "#999999"   # gray
+    ]
+end
+
+include("./viz/scenarios.jl")
+
+end

--- a/ext/PlotlyLightExt/PlotlyLightExt.jl
+++ b/ext/PlotlyLightExt/PlotlyLightExt.jl
@@ -36,6 +36,13 @@ function _get_guided_labels()::Vector{String}
     ]
 end
 
+"""
+    outcome_label(
+        outcomes::YAXArray; metadata_key::Symbol=:metric_feature, label_case=titlecase
+    )::String
+
+Smartly create labels for visualizations based on metadata/properties.
+"""
 function outcome_label(
     outcomes::YAXArray; metadata_key::Symbol=:metric_feature, label_case=titlecase
 )::String

--- a/ext/PlotlyLightExt/viz/scenarios.jl
+++ b/ext/PlotlyLightExt/viz/scenarios.jl
@@ -1,6 +1,5 @@
 using Statistics
 
-
 """
     ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
 
@@ -22,15 +21,16 @@ function ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
         scen_sel = rs.inputs.guided .== g_id
         subset = outcomes[:, scen_sel]
 
-        q50 = median(subset, dims=:scenarios)[:]
-        ci_bounds = Matrix(mapreduce(
-            collect,
-            hcat,
-            quantile.(eachrow(subset), [_calc_confint(0.95)]))'
+        q50 = median(subset; dims=:scenarios)[:]
+        ci_bounds = Matrix(
+            mapreduce(
+                collect,
+                hcat,
+                quantile.(eachrow(subset), [_calc_confint(0.95)]))'
         )
-        ci_bound_opts = Dict(:width=>0, :color=>guided_colors[i])
+        ci_bound_opts = Dict(:width => 0, :color => guided_colors[i])
 
-        res.scatter(
+        res.scatter(;
             x=ts,
             y=ci_bounds[:, 1],
             mode="lines",
@@ -38,7 +38,7 @@ function ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
             line=ci_bound_opts,
             showlegend=false,
             opacity=0.05
-        ).scatter(
+        ).scatter(;
             x=ts,
             y=ci_bounds[:, 2],
             mode="lines",
@@ -47,11 +47,11 @@ function ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
             showlegend=false,
             opacity=0.05,
             fill="tonexty"
-        ).scatter(
+        ).scatter(;
             x=ts,
             y=q50,
             name=g_str,
-            line=Dict(:color=>guided_colors[i])
+            line=Dict(:color => guided_colors[i])
         )
     end
 

--- a/ext/PlotlyLightExt/viz/scenarios.jl
+++ b/ext/PlotlyLightExt/viz/scenarios.jl
@@ -1,0 +1,62 @@
+using Statistics
+
+
+"""
+    ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
+
+Indicative scenario outcomes grouped by guidance type.
+"""
+function ADRIA.viz.scenarios(rs::ResultSet, outcomes::YAXArray)
+    # Metadata for scenario types
+    guided_id = sort(unique(rs.inputs.guided))
+    guided_idx = Int.(guided_id .+ 2)
+    guidance_type = _get_guided_labels()[guided_idx]
+    guided_colors = _guided_colors()
+
+    # Build plot for each scenario type
+    res = plot()
+
+    ts = outcomes.timesteps
+    for (i, (g_id, g_str)) in enumerate(zip(guided_id, guidance_type))
+        # Select subset of scenarios for each scenario type
+        scen_sel = rs.inputs.guided .== g_id
+        subset = outcomes[:, scen_sel]
+
+        q50 = median(subset, dims=:scenarios)[:]
+        ci_bounds = Matrix(mapreduce(
+            collect,
+            hcat,
+            quantile.(eachrow(subset), [_calc_confint(0.95)]))'
+        )
+        ci_bound_opts = Dict(:width=>0, :color=>guided_colors[i])
+
+        res.scatter(
+            x=ts,
+            y=ci_bounds[:, 1],
+            mode="lines",
+            name=g_str,
+            line=ci_bound_opts,
+            showlegend=false,
+            opacity=0.05
+        ).scatter(
+            x=ts,
+            y=ci_bounds[:, 2],
+            mode="lines",
+            name=g_str,
+            line=ci_bound_opts,
+            showlegend=false,
+            opacity=0.05,
+            fill="tonexty"
+        ).scatter(
+            x=ts,
+            y=q50,
+            name=g_str,
+            line=Dict(:color=>guided_colors[i])
+        )
+    end
+
+    res.layout.yaxis.title.text = outcome_label(outcomes)
+    res.layout.xaxis.title.text = "Years"
+
+    return res
+end


### PR DESCRIPTION
Initial support for visualizations based on PlotlyJS via [PlotlyLight](https://github.com/JuliaComputing/PlotlyLight.jl).

## Reason for this PR

Recently, the need to showcase some kind of results visualization to support RRAP-related work and future projects have been (re-)raised.

This PR provides an initial/tentative implementation of the `scenarios` visualization method.

I've elected to leverage Julia's extension package system to support a single plot type (scenario outcomes) using PlotlyLight given the issues outlined further below and the comparatively small visualization capability required. Analysts/Modellers can continue performing assessments "offline".

As it is an extension package, the usual workflow remains the same:

```julia
using PlotlyLight
using ADRIA

dom = ADRIA.load_domain(...)
scens = ADRIA.sample(dom, 128)
rs = ADRIA.run_scenarios(dom, scens, "45")

r_tac = ADRIA.metrics.scenario_total_cover(rs)
p = ADRIA.viz.scenarios(rs, r_tac)
```

![image](https://github.com/user-attachments/assets/f50e8fa2-d57b-4bf5-8915-1d39ec20b644)


## Further Background / Context

In the early days of ADRIA there was a strong push for some kind of user interface.

Attempts had been made previously in [MATLAB GUI](https://au.mathworks.com/discovery/matlab-gui.html) before my time on this project. In retrospect I should have pushed back on the idea of a UI completely as ADRIA was not mature enough to support anything of the sort at the time. ADRIA was barely more than a loose assortment of scripts and the underlying programmatic interfaces were constantly changing. Updates to formalize contracts/interfaces would most likely break the UI. Not to mention a likely change in languages.

The second "attempt" after the initial migration to Julia was a web-based dashboard written in Python Plotly. I do not know why Python was selected, as Plotly had become available for [Julia](https://plotly.com/julia/) some time before this (although based on some reports I saw at the time, it had some issues). But an initial Python implementation had been written (see [here](https://github.com/open-AIMS/ADRIA_dashboard)).

To support the web dashboard an Oxygen.jl web service was set up. What was lacking was a mature analysis/visualization pipeline. At the time, the analysis/visualization interfaces had not yet been fully written (what is now the `viz`, `metrics`, `analysis`, submodules), so again, the visualization methods were essentially a loose assortment of functions/scripts except now spread in two languages and, at times, with duplicate functionality. I tried to put in some structure but doing this and working on ADRIA itself, it was all a bit much.

Scenario data was being served by Oxygen for processing in Python. The full scenario set needed to be passed to Python/JS to support specific types of analyses which required the full dataset. While the data processing itself was not so time consuming (although at times orders of magnitude slower compared to Julia), the constant data passing and conversion of scenario outcomes from matrices to JSON was horrendously slow.

After this, I made to call to switch to Makie given time/effort were better spent:

1. Maturing analysis and assessment capabilities
2. Address issues with the ecosystem model
3. Building interfaces to support interoperability with other RRAP models
4. Data processing would ideally stay in Julia given the comparatively high volume of data
5. There wasn't actually a strong need for a user interface or interactivity at the time
6. Packages like PlotlyLight didn't exist at the time.

I was also banking on community efforts to support interactivity (either local or web-based) in the Makie ecosystem would mature in the intervening time (from memory this was ~3 years ago).

## Current state

The Makie ecosystem ADRIA depends on for visualizations, however, has not yet progressed to support client-side interactivity.
This was hoped to be done via WGLMakie and Bonito (then JSServe). While _possible_, WGLMakie requires an active Julia server/runtime to be running in the background for interactive 2D plots until functionality is ported across to Three.js.

Although we now have a fairly mature and stable set of methods to support analyses and assessments and a consistent set of visualization methods and a (semi)-standardized approach for their use, there are some concerns:

- Some methods have exploded in complexity (e.g., [taxonomy vizualizations](https://github.com/open-AIMS/ADRIA.jl/blob/dcd9a23c466335008554d512fb9d42055c6070cd/ext/AvizExt/viz/taxa_dynamics.jl#L91)) and could use a revisit/rewrite
- The Makie package itself is quite a heavy dependency
- The Plotly ecosystem is more mature and has greater support across languages

If this extension package is accepted, I suggest we only port/re-create the visualizations needed. It may be that we don't need web-based interactivity for the vast majority of plot types in the short-term.

PlotlyLight was selected over PlotlyJS.jl as @arlowhite is a javascript aficionado and the Javascript API is more mature compared to the Julia one and would hopefully ease cognitive burden.
