### PR TITLE
Custom categorical distribution

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -75,7 +75,7 @@ function model_spec(d::Domain, filepath::String)::Nothing
 end
 function model_spec(m::Model)::DataFrame
     spec = DataFrame(m)
-    # Model parameter distributions have at last one argument
+    # Model parameter distributions have at least one argument
     spec[!, :dist_params] = Vector{Tuple{Float64,Vararg{Float64}}}(spec.dist_params)
 
     DataFrames.hcat!(

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -75,13 +75,12 @@ function model_spec(d::Domain, filepath::String)::Nothing
 end
 function model_spec(m::Model)::DataFrame
     spec = DataFrame(m)
-    dist_params = spec[!, :dist_params]
 
     DataFrames.hcat!(
         spec,
         DataFrame(
-            :lower_bound => first.(dist_params),
-            :upper_bound => getindex.(dist_params, 2)
+            :lower_bound => factor_lower_bounds.(eachrow(spec)),
+            :upper_bound => factor_upper_bounds.(eachrow(spec))
         )
     )
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -76,7 +76,7 @@ end
 function model_spec(m::Model)::DataFrame
     spec = DataFrame(m)
     # Model parameter distributions have at last one argument
-    spec[!, :dist_params] = Vector{Tuple{Float64, Vararg{Float64}}}(spec.dist_params)
+    spec[!, :dist_params] = Vector{Tuple{Float64,Vararg{Float64}}}(spec.dist_params)
 
     DataFrames.hcat!(
         spec,

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -75,6 +75,8 @@ function model_spec(d::Domain, filepath::String)::Nothing
 end
 function model_spec(m::Model)::DataFrame
     spec = DataFrame(m)
+    # Model parameter distributions have at last one argument
+    spec[!, :dist_params] = Vector{Tuple{Float64, Vararg{Float64}}}(spec.dist_params)
 
     DataFrames.hcat!(
         spec,

--- a/src/analysis/intervention.jl
+++ b/src/analysis/intervention.jl
@@ -1,5 +1,5 @@
 """
-    intervention_frequency(rs::ResultSet, scen_indices::NamedTuple, log_type::Symbol)::YAXArrayintervention.jl
+    intervention_frequency(rs::ResultSet, scen_indices::NamedTuple, log_type::Symbol)::YAXArray
 
 Count number of times a location of selected for intervention
 Count frequency of seeded sites for scenarios satisfying a condition.

--- a/src/analysis/intervention.jl
+++ b/src/analysis/intervention.jl
@@ -1,5 +1,5 @@
 """
-    intervention_frequency(rs::ResultSet, scen_indices::NamedTuple, log_type::Symbol)::YAXArray
+    intervention_frequency(rs::ResultSet, scen_indices::NamedTuple, log_type::Symbol)::YAXArrayintervention.jl
 
 Count number of times a location of selected for intervention
 Count frequency of seeded sites for scenarios satisfying a condition.

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -1,6 +1,5 @@
 module decision
 
-using Core: Argument
 using InteractiveUtils: subtypes
 using StatsBase
 using YAXArrays

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -79,9 +79,10 @@ end
 Get the integer encoding for the type of intervention to be used in the scenario dataframe.
 """
 function decision_method_encoding(method_name::String)::Int64
-    if method_name == "counterfactual"
+    method_name = uppercase(method_name)
+    if method_name == "COUNTERFACTUAL"
         return COUNTERFACTUAL_SCEN_ENCODING
-    elseif method_name == "unguided"
+    elseif method_name == "UNGUIDED"
         return UNGUIDED_SCEN_ENCODING
     end
 

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -54,13 +54,7 @@ end
 List of MCDA method names.
 """
 function mcda_method_names()::Vector{String}
-    return [
-        "Cocoso",
-        "Mairca",
-        "Moora",
-        "Piv",
-        "Vikor"
-    ]
+    return getindex.(split.(string.(mcda_methods()), "."), 2)
 end
 
 """
@@ -70,9 +64,9 @@ Find the scenario encoding of the given mcda method. Throws `ArgumentError` if m
 found.
 """
 function mcda_method_encoding(mcda_name::String)::Int64
-    method_idx = findfirst(mcda_method_names() .== mcda_name)
+    method_idx = findfirst(mcda_method_names() .== uppercase(mcda_name))
     if isnothing(method_idx)
-        msg = "Given MCDA method $(mcda_name) is not in list of mcda methods. "
+        msg = "Given MCDA method $(mcda_name) is not in list of mcda methods.\n"
         msg *= "Possible MCDA methods are $(mcda_method_names())"
         throw(ArgumentError(msg))
     end
@@ -89,10 +83,9 @@ function decision_method_encoding(method_name::String)::Int64
         return COUNTERFACTUAL_SCEN_ENCODING
     elseif method_name == "unguided"
         return UNGUIDED_SCEN_ENCODING
-    else
-        return mcda_method_encoding(method_name)
     end
-    return nothing
+
+    return mcda_method_encoding(method_name)
 end
 
 """

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -21,7 +21,6 @@ using
     DataFrames,
     JMcDM
 
-
 const COUNTERFACTUAL_SCEN_ENCODING::Int64 = -1
 const UNGUIDED_SCEN_ENCODING::Int64 = 0
 

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -60,8 +60,8 @@ function mcda_method_names()::Vector{String}
         "Cocoso",
         "Mairca",
         "Moora",
-        "PIV",
-        "VikorMethod"
+        "Piv",
+        "Vikor"
     ]
 end
 

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -1,5 +1,6 @@
 module decision
 
+using Core: Argument
 using InteractiveUtils: subtypes
 using StatsBase
 using YAXArrays
@@ -20,6 +21,10 @@ using
     Combinatorics,
     DataFrames,
     JMcDM
+
+
+const COUNTERFACTUAL_SCEN_ENCODING::Int64 = -1
+const UNGUIDED_SCEN_ENCODING::Int64 = 0
 
 # dummy functions to allow precompilation
 function unguided_selection() end
@@ -43,6 +48,53 @@ function mcda_methods()
         JMcDM.PIV.PIVMethod,
         JMcDM.VIKOR.VikorMethod
     ]
+end
+
+"""
+    mcda_method_names()::Vector{String}
+
+List of MCDA method names.
+"""
+function mcda_method_names()::Vector{String}
+    return [
+        "Cocoso",
+        "Mairca",
+        "Moora",
+        "PIV",
+        "VikorMethod"
+    ]
+end
+
+"""
+    mcda_method_encoding(mcda_name::String)::Union{Int64, Nothing}
+
+Find the scenario encoding of the given mcda method. Throws `ArgumentError` if method not 
+found.
+"""
+function mcda_method_encoding(mcda_name::String)::Int64
+    method_idx = findfirst(mcda_method_names() .== mcda_name)
+    if isnothing(method_idx)
+        msg = "Given MCDA method $(mcda_name) is not in list of mcda methods. "
+        msg *= "Possible MCDA methods are $(mcda_method_names())"
+        throw(ArgumentError(msg))
+    end
+    return method_idx
+end
+
+"""
+    decision_method_encoding(method_name::String)::Int64
+
+Get the integer encoding for the type of intervention to be used in the scenario dataframe.
+"""
+function decision_method_encoding(method_name::String)::Int64
+    if method_name == "counterfactual"
+        return COUNTERFACTUAL_SCEN_ENCODING
+    elseif method_name == "unguided"
+        return UNGUIDED_SCEN_ENCODING
+    else
+        return mcda_method_encoding(method_name)
+    end
+    return nothing
 end
 
 """

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -166,19 +166,19 @@ function DiscreteOrderedUniformDist(
     return DiscreteNonParametric(options, fill(1.0 / n_opts, n_opts))
 end
 
-struct CategoricalVariable{T}
+struct CategoricalDistribution{T}
     categories::Vector{T}
     distribution::Categorical
 end
 
 """
-    CategoricalVariable(categories::Vector{T}, weights::Vector{Float64})::CategoricalVariable{T} where T
-    CategoricalVariable(categories::Vector{T})::CategoricalVariable{T} where T
+    CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where T
+    CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
 
 Construct a categorical variable. Default to a uniform cateforical variable if the 
 probability weightings are not provided.
 """
-function CategoricalVariable(categories::Vector{T}, weights::Vector{Float64})::CategoricalVariable{T} where T
+function CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where T
     if length(unique(categories)) != length(categories)
         throw(ArgumentError("Categories in a categorical variable must be unique."))
     end
@@ -190,33 +190,33 @@ function CategoricalVariable(categories::Vector{T}, weights::Vector{Float64})::C
     if sum(weights) ≈ 1 && all(weights >= 0.0)
         throw(ArgumentError("Weights must sum to one."))
     end
-    return CategoricalVariable(
+    return CategoricalDistribution(
         categories,
         Categorical(weights))
 end
-function CategoricalVariable(categories::Vector{T})::CategoricalVariable{T} where T
+function CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
     n_categories::Int64 = length(categories)
-    return CategoricalVariable(categories, fill(1/n_categories, n_categories))
+    return CategoricalDistribution(categories, fill(1/n_categories, n_categories))
 end
 
-function Distributions.quantile(dist::CategoricalVariable{T}, q::Real)::T where T
+function Distributions.quantile(dist::CategoricalDistribution{T}, q::Real)::T where T
     underlying_idx::Int64 = Distributions.quantile(dist.distribution, q)
     return dist.categories[underlying_idx]
 end
 
 """
-    lower_bound(dist::CategoricalVariable{T})::T where T <: Real
+    lower_bound(dist::CategoricalDistribution{T})::T where T <: Real
 
 Return the lower bound of the underlying categories if they are numerical.
 """
-function lower_bound(dist::CategoricalVariable{T})::T where T <: Real
+function lower_bound(dist::CategoricalDistribution{T})::T where T <: Real
     return minimum(dist.categories)
 end
 """
-    upper_bound(dist::CategoricalVariable{T})::T where T <: Real
+    upper_bound(dist::CategoricalDistribution{T})::T where T <: Real
 
 Return the upper bound of the unerling categories if they are numerical.
 """
-function upper_bound(dist::CategoricalVariable{T})::T where T <: Real
+function upper_bound(dist::CategoricalDistribution{T})::T where T <: Real
     return maximum(dist.categories)
 end

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -165,3 +165,58 @@ function DiscreteOrderedUniformDist(
 
     return DiscreteNonParametric(options, fill(1.0 / n_opts, n_opts))
 end
+
+struct CategoricalVariable{T}
+    categories::Vector{T}
+    distribution::Categorical
+end
+
+"""
+    CategoricalVariable(categories::Vector{T}, weights::Vector{Float64})::CategoricalVariable{T} where T
+    CategoricalVariable(categories::Vector{T})::CategoricalVariable{T} where T
+
+Construct a categorical variable. Default to a uniform cateforical variable if the 
+probability weightings are not provided.
+"""
+function CategoricalVariable(categories::Vector{T}, weights::Vector{Float64})::CategoricalVariable{T} where T
+    if length(unique(categories)) != length(categories)
+        throw(ArgumentError("Categories in a categorical variable must be unique."))
+    end
+    if length(categories) != length(weights)
+        msg = "Length of categories and weightings do not match."
+        msg *= " Got $(length(categories)) and $(length(weights))."
+        throw(ArgumentError(msg))
+    end
+    if sum(weights) ≈ 1 && all(weights >= 0.0)
+        throw(ArgumentError("Weights must sum to one."))
+    end
+    return CategoricalVariable(
+        categories,
+        Categorical(weights))
+end
+function CategoricalVariable(categories::Vector{T})::CategoricalVariable{T} where T
+    n_categories::Int64 = length(categories)
+    return CategoricalVariable(categories, fill(1/n_categories, n_categories))
+end
+
+function Distributions.quantile(dist::CategoricalVariable{T}, q::Real)::T where T
+    underlying_idx::Int64 = Distributions.quantile(dist.distribution, q)
+    return dist.categories[underlying_idx]
+end
+
+"""
+    lower_bound(dist::CategoricalVariable{T})::T where T <: Real
+
+Return the lower bound of the underlying categories if they are numerical.
+"""
+function lower_bound(dist::CategoricalVariable{T})::T where T <: Real
+    return minimum(dist.categories)
+end
+"""
+    upper_bound(dist::CategoricalVariable{T})::T where T <: Real
+
+Return the upper bound of the unerling categories if they are numerical.
+"""
+function upper_bound(dist::CategoricalVariable{T})::T where T <: Real
+    return maximum(dist.categories)
+end

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -33,6 +33,19 @@ function Factor(val; kwargs...)::Param
     return Param((; val=val, nt...))
 end
 
+function factor_lower_bounds(factor::DataFrameRow)::Float64
+    if factor.dist == CategoricalDistribution
+        return minimum(factor.dist_params)
+    end
+    return first(factor.dist_params)
+end
+function factor_upper_bounds(factor::DataFrameRow)::Float64
+    if factor.dist == CategoricalDistribution
+        return maximum(factor.dist_params)
+    end
+    return getindex(factor.dist_params, 2)
+end
+
 function _set_factor_defaults(kwargs::NT) where {NT<:NamedTuple}
     missing_defaults = (; default_dist_params=kwargs.dist_params)
 

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -67,7 +67,9 @@ function CategoricalDistribution(
         categories,
         Categorical(weights))
 end
-function CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where {T}
+function CategoricalDistribution(
+    categories::Vector{T}
+)::CategoricalDistribution{T} where {T}
     n_categories::Int64 = length(categories)
     return CategoricalDistribution(categories, fill(1 / n_categories, n_categories))
 end

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -174,6 +174,7 @@ end
 """
     CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where T
     CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
+    CategoricalDistribution(categories...)::CategoricalDistribution
 
 Construct a categorical variable. Default to a uniform cateforical variable if the 
 probability weightings are not provided.
@@ -187,7 +188,7 @@ function CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64}
         msg *= " Got $(length(categories)) and $(length(weights))."
         throw(ArgumentError(msg))
     end
-    if sum(weights) ≈ 1 && all(weights >= 0.0)
+    if !(sum(weights) ≈ 1) && all(weights .>= 0.0)
         throw(ArgumentError("Weights must sum to one."))
     end
     return CategoricalDistribution(
@@ -197,6 +198,10 @@ end
 function CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
     n_categories::Int64 = length(categories)
     return CategoricalDistribution(categories, fill(1/n_categories, n_categories))
+end
+function CategoricalDistribution(categories...)::CategoricalDistribution
+    cats = collect(categories)
+    return CategoricalDistribution(cats)
 end
 
 function Distributions.quantile(dist::CategoricalDistribution{T}, q::Real)::T where T

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -39,14 +39,16 @@ struct CategoricalDistribution{T}
 end
 
 """
-    CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where T
-    CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
+    CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where {T}
+    CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where {T}
     CategoricalDistribution(categories...)::CategoricalDistribution
 
 Construct a categorical variable. Default to a uniform cateforical variable if the 
 probability weightings are not provided.
 """
-function CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64})::CategoricalDistribution{T} where T
+function CategoricalDistribution(
+    categories::Vector{T}, weights::Vector{Float64}
+)::CategoricalDistribution{T} where {T}
     if length(unique(categories)) != length(categories)
         throw(ArgumentError("Categories in a categorical variable must be unique."))
     end
@@ -62,34 +64,34 @@ function CategoricalDistribution(categories::Vector{T}, weights::Vector{Float64}
         categories,
         Categorical(weights))
 end
-function CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where T
+function CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where {T}
     n_categories::Int64 = length(categories)
-    return CategoricalDistribution(categories, fill(1/n_categories, n_categories))
+    return CategoricalDistribution(categories, fill(1 / n_categories, n_categories))
 end
 function CategoricalDistribution(categories...)::CategoricalDistribution
     cats = collect(categories)
     return CategoricalDistribution(cats)
 end
 
-function Distributions.quantile(dist::CategoricalDistribution{T}, q::Real)::T where T
+function Distributions.quantile(dist::CategoricalDistribution{T}, q::Real)::T where {T}
     underlying_idx::Int64 = Distributions.quantile(dist.distribution, q)
     return dist.categories[underlying_idx]
 end
 
 """
-    lower_bound(dist::CategoricalDistribution{T})::T where T <: Real
+    lower_bound(dist::CategoricalDistribution{T})::T where {T<:Real}
 
 Return the lower bound of the underlying categories if they are numerical.
 """
-function lower_bound(dist::CategoricalDistribution{T})::T where T <: Real
+function lower_bound(dist::CategoricalDistribution{T})::T where {T<:Real}
     return minimum(dist.categories)
 end
 """
-    upper_bound(dist::CategoricalDistribution{T})::T where T <: Real
+    upper_bound(dist::CategoricalDistribution{T})::T where {T<:Real}
 
 Return the upper bound of the unerling categories if they are numerical.
 """
-function upper_bound(dist::CategoricalDistribution{T})::T where T <: Real
+function upper_bound(dist::CategoricalDistribution{T})::T where {T<:Real}
     return maximum(dist.categories)
 end
 
@@ -105,22 +107,22 @@ end
 function distribution_lower_bound(
     ::Type{T}, dist_params
 )::Float64 where {T<:Union{DiscreteUniform,Uniform,TriangularDist}}
-    return first(dist_params) 
+    return first(dist_params)
 end
 function distribution_upper_bound(
     ::Type{T}, dist_params
 )::Float64 where {T<:Union{DiscreteUniform,Uniform,TriangularDist}}
-    return getindex(dist_params, 2) 
+    return getindex(dist_params, 2)
 end
 function distribution_lower_bound(
     ::T, dist_params
 )::Float64 where {T}
-    return first(dist_params) 
+    return first(dist_params)
 end
 function distribution_upper_bound(
     ::T, dist_params
 )::Float64 where {T}
-    return getindex(dist_params, 2) 
+    return getindex(dist_params, 2)
 end
 
 function factor_lower_bounds(factor::DataFrameRow)::Float64

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -43,7 +43,7 @@ end
     CategoricalDistribution(categories::Vector{T})::CategoricalDistribution{T} where {T}
     CategoricalDistribution(categories...)::CategoricalDistribution
 
-Construct a categorical variable. Default to a uniform cateforical variable if the 
+Construct a categorical variable. Default to a uniform categorical variable if the 
 probability weightings are not provided.
 """
 function CategoricalDistribution(
@@ -52,14 +52,17 @@ function CategoricalDistribution(
     if length(unique(categories)) != length(categories)
         throw(ArgumentError("Categories in a categorical variable must be unique."))
     end
+
     if length(categories) != length(weights)
         msg = "Length of categories and weightings do not match."
         msg *= " Got $(length(categories)) and $(length(weights))."
         throw(ArgumentError(msg))
     end
+
     if !(sum(weights) ≈ 1) && all(weights .>= 0.0)
         throw(ArgumentError("Weights must sum to one."))
     end
+
     return CategoricalDistribution(
         categories,
         Categorical(weights))

--- a/src/factors/Factors.jl
+++ b/src/factors/Factors.jl
@@ -33,17 +33,27 @@ function Factor(val; kwargs...)::Param
     return Param((; val=val, nt...))
 end
 
+# Some distributions have in built methods for bounds, however that would involve
+# constructing the distribution
+
+function distribution_lower_bound(::CategoricalDistribution, dist_params)::Float64
+    return minimum(dist_params)
+end
+function distribution_upper_bound(::CategoricalDistribution, dist_params)::Float64
+    return maximum(dist_params)
+end
+function distribution_lower_bound(::T, dist_params)::Float64 where T
+    return first(dist_params) 
+end
+function distribution_upper_bound(::T, dist_params)::Float64 where T
+    return getindex(dist_params, 2) 
+end
+
 function factor_lower_bounds(factor::DataFrameRow)::Float64
-    if factor.dist == CategoricalDistribution
-        return minimum(factor.dist_params)
-    end
-    return first(factor.dist_params)
+    return distribution_lower_bound(factor.dist, factor.dist_params)
 end
 function factor_upper_bounds(factor::DataFrameRow)::Float64
-    if factor.dist == CategoricalDistribution
-        return maximum(factor.dist_params)
-    end
-    return getindex(factor.dist_params, 2)
+    return distribution_upper_bound(factor.dist, factor.dist_params)
 end
 
 function _set_factor_defaults(kwargs::NT) where {NT<:NamedTuple}

--- a/src/interventions/Interventions.jl
+++ b/src/interventions/Interventions.jl
@@ -4,8 +4,8 @@ Base.@kwdef struct Intervention <: EcoModel
     guided::Param = Factor(
         0;
         ptype="unordered categorical",
-        dist=DiscreteUniform,
-        dist_params=(-1.0, Float64(length(decision.mcda_methods()))),
+        dist=CategoricalDistribution,
+        dist_params=(Tuple(-1:Float64(length(decision.mcda_methods())))),
         name="Guided",
         description="Choice of MCDA approach."
     )

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -489,6 +489,7 @@ end
 
 function _update_decision_method(dom, new_dist_params::Tuple)::Domain
     new_method_names::Vector{String} = collect(new_dist_params)
+
     # Get encoding method will throw if given params are not
     new_method_idxs = decision.decision_method_encoding.(new_method_names)
 

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -169,7 +169,7 @@ function sample(
     samples = QMC.sample(n, zeros(n_vary_params), ones(n_vary_params), sample_method)
 
     # Scale uniform samples to indicated distributions using the inverse CDF method
-    samples = Matrix(quantile.(vary_dists, samples)')
+    samples = Matrix(Distributions.quantile.(vary_dists, samples)')
 
     # Combine varying and constant values (constant params use their indicated default vals)
     full_df = hcat(fill.(spec.val, n)...)

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -487,10 +487,14 @@ function get_attr(dom::Domain, factor::Symbol, attr::Symbol)
     return ms[ms.fieldname .== factor, attr][1]
 end
 
+"""
+    _update_decision_method!(dom, new_dist_params::Tuple)::Domain
+
+Update the model spec with the tuple of DMCA methods to use.
+"""
 function _update_decision_method!(dom, new_dist_params::Tuple)::Domain
     new_method_names::Vector{String} = collect(new_dist_params)
 
-    # Get encoding method will throw if given params are not
     new_method_idxs = decision.decision_method_encoding.(new_method_names)
 
     ms = model_spec(dom)

--- a/src/io/sampling.jl
+++ b/src/io/sampling.jl
@@ -493,8 +493,11 @@ function _update_decision_method(dom, new_dist_params::Tuple)::Domain
     new_method_idxs = decision.decision_method_encoding.(new_method_names)
 
     ms = model_spec(dom)
-    ms[ms.fieldname .== :guided, :dist_params] .= [Tuple(new_method_idxs)]
+    guided_row = findfirst(ms.fieldname .== :guided)
+    @assert !isnothing(guided_row) "Guided variable not found in model spec."
 
+    ms[guided_row, :dist_params] = Tuple(new_method_idxs)
+    ms[guided_row, :val] = first(new_method_idxs)
     update!(dom, ms)
 
     return dom

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -118,7 +118,7 @@ end
             ("Cocoso", "Mairca", "Moora", "Piv", "Vikor")
         ]
         test_output = [
-            [1], [2], [-1, 0], [-1, 0, 4], [-1, 0, 1, 3, 4, 5], 
+            [1], [2], [-1, 0], [-1, 0, 4], [-1, 0, 1, 3, 4, 5]
         ]
 
         for (inp, out) in zip(test_inputs, test_output)

--- a/test/sampling.jl
+++ b/test/sampling.jl
@@ -20,41 +20,41 @@ end
             "Constant params are not constant!"
     end
 
-    #@testset "values are within expected bounds" begin
-    #    lb = values(ms[:, :lower_bound])
-    #    ub = values(ms[:, :upper_bound])
+    @testset "values are within expected bounds" begin
+        lb = values(ms[:, :lower_bound])
+        ub = values(ms[:, :upper_bound])
 
-    #    not_cw_mask =
-    #        ms.component .∉
-    #        [("SeedCriteriaWeights", "FogCriteriaWeights", "DepthThresholds")]
-    #    not_cw_lb, not_cw_ub = lb[not_cw_mask], ub[not_cw_mask]
+        not_cw_mask =
+            ms.component .∉
+            [("SeedCriteriaWeights", "FogCriteriaWeights", "DepthThresholds")]
+        not_cw_lb, not_cw_ub = lb[not_cw_mask], ub[not_cw_mask]
 
-    #    eco = (ms.component .== "Coral") .& .!(constant_params)
+        eco = (ms.component .== "Coral") .& .!(constant_params)
 
-    #    msg = "Sampled values were not in expected bounds!"
-    #    coral_msg = "Sampled coral values were not in expected bounds!"
-    #    for i in 1:num_samples
-    #        # Filter CriteriaWeights factors
-    #        scen_vals = values(scens[i, :])
-    #        not_cw_scen_vals = scen_vals[not_cw_mask]
+        msg = "Sampled values were not in expected bounds!"
+        coral_msg = "Sampled coral values were not in expected bounds!"
+        for i in 1:num_samples
+            # Filter CriteriaWeights factors
+            scen_vals = values(scens[i, :])
+            not_cw_scen_vals = scen_vals[not_cw_mask]
 
-    #        if scens[i, :guided] > 0
-    #            cond = not_cw_lb .<= not_cw_scen_vals .<= not_cw_ub
-    #            @test all(cond) ||
-    #                "$msg | $(ms[.!(cond), :]) | $(not_cw_scen_vals[.!(cond)])"
-    #            continue
-    #        end
+            if scens[i, :guided] > 0
+                cond = not_cw_lb .<= not_cw_scen_vals .<= not_cw_ub
+                @test all(cond) ||
+                    "$msg | $(ms[.!(cond), :]) | $(not_cw_scen_vals[.!(cond)])"
+                continue
+            end
 
-    #        # When no interventions are used, e.g., for counterfactual or unguided scenarios
-    #        # (guided ∈ [-1, 0]) intervention parameters are set to 0 so only check ecological values
-    #        cond = lb[eco] .<= scen_vals[eco] .<= ub[eco]
-    #        @test all(cond) ||
-    #            "$coral_msg | $(ms[.!(cond), :]) | $(scen_vals[eco][.!(cond)])"
+            # When no interventions are used, e.g., for counterfactual or unguided scenarios
+            # (guided ∈ [-1, 0]) intervention parameters are set to 0 so only check ecological values
+            cond = lb[eco] .<= scen_vals[eco] .<= ub[eco]
+            @test all(cond) ||
+                "$coral_msg | $(ms[.!(cond), :]) | $(scen_vals[eco][.!(cond)])"
 
-    #        # Note: Test to ensure all intervention factors are set to 0 is covered by the guided
-    #        # sampling test below
-    #    end
-    #end
+            # Note: Test to ensure all intervention factors are set to 0 is covered by the guided
+            # sampling test below
+        end
+    end
 end
 
 @testset "Targeted sampling" begin


### PR DESCRIPTION
Tentative Initial implementation of categorical variables in ADRIA.

```julia-repl
julia> dom = ADRIA.load_domain("<path to domain>")

julia> ADRIA.set_factor_bounds(dom, :guided, ("counterfactual", "Vikor", "Piv"))

julia> scens = ADRIA.sample(dom, <n_scenarios>)
32×317 DataFrame
 Row │ dhw_scenario  wave_scenario  cyclone_mortality_scenario  guided   N_seed_TA   N_seed_CA   N_seed_SM   min_iv_locations  cluster_max_member  fogging     SRM       a_adapt  seed_years  shade_years  fog_years  plan_horizon  see ⋯
     │ Float64       Float64        Float64                     Float64  Float64     Float64     Float64     Float64           Float64             Float64     Float64   Float64  Float64     Float64      Float64    Float64       Flo ⋯
─────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │         32.0           26.0                         6.0      5.0  400000.0         0.0    300000.0                11.0                 9.0  0.0485685   4.1175        2.5        65.0         32.0       25.0           2.0      ⋯
   2 │          7.0            8.0                        66.0     -1.0       0.0         0.0         0.0                 0.0                 0.0  0.0         0.0           0.0         0.0          0.0        0.0           0.0
   3 │         19.0           43.0                        38.0      4.0  650000.0    800000.0    200000.0                17.0                 3.0  0.10414     1.70274      11.0        37.0         49.0       35.0           7.0
...
```

Set factor bounds will need to be defined differently for different factors, but the underlying categorical distribution should be usable for dhw, cyclone and wave scenarios.