### PR TITLE
Replace and deprecate remaining use of `site_k_area`

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -211,7 +211,7 @@ plan_horizon = Int64(scen["plan_horizon"])
 decay = 0.99 .^ (1:(plan_horizon + 1)) .^ 2
 dhw_projection = ADRIA.decision.weighted_projection(dhw_scens, 1, plan_horizon, decay, 75)
 # Connectivity
-area_weighted_conn = dom.conn.data .* ADRIA.site_k_area(dom)
+area_weighted_conn = dom.conn.data .* ADRIA.loc_k_area(dom)
 conn_cache = similar(area_weighted_conn)
 in_conn, out_conn, network = ADRIA.connectivity_strength(
     area_weighted_conn, sum_cover, conn_cache

--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -89,7 +89,7 @@ export
     run_scenario, coral_spec,
     create_coral_struct, Intervention, SimConstants,
     SeedCriteriaWeights, FogCriteriaWeights,
-    loc_area, site_k_area,
+    loc_area, site_k_area, loc_k_area,
     Domain, ADRIADomain,
     metrics, select, timesteps, env_stats, viz
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -181,12 +181,14 @@ function loc_area(domain::Domain)::Vector{Float64}
     return domain.loc_data.area
 end
 
+@deprecate site_k_area(dom) loc_k_area(dom)
+
 """
-    site_k_area(domain::Domain)::Vector{Float64}
+    loc_k_area(domain::Domain)::Vector{Float64}
 
 Get maximum coral cover area for the given domain in absolute area.
 """
-function site_k_area(domain::Domain)::Vector{Float64}
+function loc_k_area(domain::Domain)::Vector{Float64}
     return location_k(domain) .* loc_area(domain)
 end
 

--- a/src/decision/dMCDA.jl
+++ b/src/decision/dMCDA.jl
@@ -10,7 +10,7 @@ using ADRIA:
     EcoModel,
     n_locations,
     loc_area,
-    site_k_area
+    loc_k_area
 
 using ADRIA:
     DiscreteOrderedUniformDist,

--- a/src/decision/location_selection.jl
+++ b/src/decision/location_selection.jl
@@ -5,7 +5,7 @@ using ADRIA:
     sample,
     connectivity_strength,
     relative_leftover_space,
-    site_k_area,
+    loc_k_area,
     n_locations,
     to_coral_spec,
     colony_mean_area,
@@ -59,7 +59,7 @@ function rank_locations(
     target_fog_locs=nothing
 )::YAXArray
     n_locs = n_locations(dom)
-    k_area_locs = site_k_area(dom)
+    k_area_locs = loc_k_area(dom)
 
     if isnothing(min_iv_locs)
         min_iv_locs = scenarios.min_iv_locations
@@ -103,7 +103,7 @@ function rank_locations(
 
     leftover_space_scens = relative_leftover_space(sum_cover) .* k_area_locs'
 
-    area_weighted_conn = dom.conn.data .* site_k_area(dom)
+    area_weighted_conn = dom.conn.data .* loc_k_area(dom)
     conn_cache = similar(area_weighted_conn)
 
     in_conn, out_conn, network = connectivity_strength(

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -381,22 +381,25 @@ function timesteps(rs::ResultSet)
     return rs.env_layer_md.timeframe
 end
 
+@deprecate site_k_area(rs) loc_k_area(rs)
+@deprecate site_k(rs) loc_k(rs)
+
 """
-    site_k_area(rs::ResultSet)::Vector{Float64}
+    loc_k_area(rs::ResultSet)::Vector{Float64}
 
 Extract vector of a location's coral carrying capacity in terms of absolute area.
 """
-function site_k_area(rs::ResultSet)::Vector{Float64}
+function loc_k_area(rs::ResultSet)::Vector{Float64}
     return rs.loc_max_coral_cover .* rs.loc_area
 end
 
 """
-    site_k(rs::ResultSet)::Vector{Float64}
+    loc_k(rs::ResultSet)::Vector{Float64}
 
 Extract vector of a location's coral carrying capacity in as a proportion relative to the
 location's total area.
 """
-function site_k(rs::ResultSet)::Vector{Float64}
+function loc_k(rs::ResultSet)::Vector{Float64}
     return rs.loc_max_coral_cover
 end
 

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -381,8 +381,8 @@ function timesteps(rs::ResultSet)
     return rs.env_layer_md.timeframe
 end
 
-@deprecate site_k_area(rs) loc_k_area(rs)
-@deprecate site_k(rs) loc_k(rs)
+@deprecate site_k_area(rs::ResultSet) loc_k_area(rs)
+@deprecate site_k(rs::ResultSet) loc_k(rs)
 
 """
     loc_k_area(rs::ResultSet)::Vector{Float64}

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -15,7 +15,7 @@ using ADRIA: n_sizes, group_indices
 using FLoops
 using DataFrames
 
-using ADRIA: coral_spec, colony_mean_area, ResultSet, timesteps, site_k_area, loc_area,
+using ADRIA: coral_spec, colony_mean_area, ResultSet, timesteps, loc_k_area, loc_area,
     planar_area_params
 
 abstract type Outcome end
@@ -96,7 +96,7 @@ function _total_absolute_cover(
     return relative_cover .* k_area'
 end
 function _total_absolute_cover(rs::ResultSet)::AbstractArray{<:Real}
-    return _total_absolute_cover(rs.outcomes[:relative_cover], site_k_area(rs))
+    return _total_absolute_cover(rs.outcomes[:relative_cover], loc_k_area(rs))
 end
 total_absolute_cover = Metric(
     _total_absolute_cover,
@@ -241,7 +241,7 @@ function _absolute_juveniles(
     return _relative_juveniles(X, coral_spec) .* k_area'
 end
 function _absolute_juveniles(rs::ResultSet)::AbstractArray{<:Real,3}
-    return rs.outcomes[:relative_juveniles] .* site_k_area(rs)'
+    return rs.outcomes[:relative_juveniles] .* loc_k_area(rs)'
 end
 absolute_juveniles = Metric(
     _absolute_juveniles,

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -62,7 +62,7 @@ Calculate the mean relative coral cover for each scenario for the entire domain.
 """
 function _scenario_relative_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     target_sites = haskey(kwargs, :locations) ? kwargs[:locations] : (:)
-    target_area = sum(site_k_area(rs)[target_sites])
+    target_area = sum(loc_k_area(rs)[target_sites])
 
     return _scenario_total_cover(rs; kwargs...) ./ target_area
 end
@@ -88,7 +88,7 @@ num_scens = 2^5
 scens = ADRIA.sample(dom, num_scens)
 
 _coral_spec = ADRIA.to_coral_spec(scens[1,:])
-_k_area = site_k_area(dom)
+_k_area = loc_k_area(dom)
 
 # X contains raw coral cover results for a single scenario
 ADRIA.metrics.scenario_relative_juveniles(X, _coral_spec, _k_area)
@@ -107,7 +107,7 @@ end
 function _scenario_relative_juveniles(rs::ResultSet; kwargs...)::YAXArray
     # Calculate relative domain-wide cover based on absolute values
     aj = absolute_juveniles(rs)
-    return dropdims(sum(aj; dims=:locations); dims=:locations) ./ sum(site_k_area(rs))
+    return dropdims(sum(aj; dims=:locations); dims=:locations) ./ sum(loc_k_area(rs))
 end
 scenario_relative_juveniles = Metric(
     _scenario_relative_juveniles,

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -43,7 +43,7 @@ function setup_cache(domain::Domain)::NamedTuple
         C_cover_t=zeros(n_groups, n_sizes, n_locs),  # Cover for previous timestep
         depth_coeff=zeros(n_locs),  # store for depth coefficient
         loc_area=Matrix{Float64}(loc_area(domain)'),  # area of locations
-        site_k_area=Matrix{Float64}(site_k_area(domain)'),  # location carrying capacity
+        habitable_area=Matrix{Float64}(loc_k_area(domain)'),  # location carrying capacity
         wave_damage=zeros(tf, n_group_and_size, n_locs),  # damage coefficient for each size class
         dhw_tol_mean_log=zeros(tf, n_group_and_size, n_locs)  # tmp log for mean dhw tolerances
     )
@@ -306,10 +306,10 @@ function run_scenario(
     vals[vals .< threshold] .= 0.0
     data_store.relative_cover[:, :, idx] .= vals
 
-    vals = absolute_shelter_volume(rs_raw, site_k_area(domain), scenario)
+    vals = absolute_shelter_volume(rs_raw, loc_k_area(domain), scenario)
     vals[vals .< threshold] .= 0.0
     data_store.absolute_shelter_volume[:, :, idx] .= vals
-    vals = relative_shelter_volume(rs_raw, site_k_area(domain), scenario)
+    vals = relative_shelter_volume(rs_raw, loc_k_area(domain), scenario)
     vals[vals .< threshold] .= 0.0
     data_store.relative_shelter_volume[:, :, idx] .= vals
 
@@ -318,16 +318,16 @@ function run_scenario(
     vals[vals .< threshold] .= 0.0
     data_store.relative_juveniles[:, :, idx] .= vals
 
-    vals = juvenile_indicator(rs_raw, coral_spec, site_k_area(domain))
+    vals = juvenile_indicator(rs_raw, coral_spec, loc_k_area(domain))
     vals[vals .< threshold] .= 0.0
     data_store.juvenile_indicator[:, :, idx] .= vals
 
-    vals = relative_taxa_cover(rs_raw, site_k_area(domain), domain.coral_growth.n_groups)
+    vals = relative_taxa_cover(rs_raw, loc_k_area(domain), domain.coral_growth.n_groups)
     vals[vals .< threshold] .= 0.0
     data_store.relative_taxa_cover[:, :, idx] .= vals
 
     vals = relative_loc_taxa_cover(
-        rs_raw, site_k_area(domain), domain.coral_growth.n_groups
+        rs_raw, loc_k_area(domain), domain.coral_growth.n_groups
     )
 
     vals = coral_evenness(vals.data)
@@ -500,7 +500,7 @@ function run_model(
     shade_years::Int64 = param_set[At("shade_years")]  # number of years to shade
     fog_years::Int64 = param_set[At("fog_years")]  # number of years to fog
 
-    loc_k_area::Matrix{Float64} = cache.site_k_area
+    habitable_areas::Matrix{Float64} = cache.habitable_area
     fec_params_per_m²::Matrix{Float64} = _to_group_size(
         domain.coral_growth, corals.fecundity
     ) # number of larvae produced per m²
@@ -531,7 +531,7 @@ function run_model(
     )
 
     # Locations that can support corals
-    vec_abs_k = site_k_area(domain)
+    vec_abs_k = loc_k_area(domain)
     habitable_locs::BitVector = location_k(domain) .> 0.0
     habitable_loc_areas = vec_abs_k[habitable_locs]
     habitable_loc_areas′ = reshape(habitable_loc_areas, (1, 1, length(habitable_locs)))
@@ -780,7 +780,7 @@ function run_model(
 
         # Reproduction
         # Calculates scope for coral fedundity for each size class and at each location
-        fecundity_scope!(fec_scope, fec_all, fec_params_per_m², C_cover_t, loc_k_area)
+        fecundity_scope!(fec_scope, fec_all, fec_params_per_m², C_cover_t, habitable_areas)
 
         loc_coral_cover = _loc_coral_cover(C_cover_t)
         leftover_space_m² = relative_leftover_space(loc_coral_cover) .* vec_abs_k
@@ -804,7 +804,7 @@ function run_model(
                 valid_sinks
             )[
                 :, habitable_locs
-            ] ./ loc_k_area[:, habitable_locs]
+            ] ./ habitable_areas[:, habitable_locs]
 
         settler_DHW_tolerance!(
             c_mean_t_1,

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1019,7 +1019,7 @@ function run_model(
 
         survival_rate_slices = [@view survival_rate_cache[:, :, loc] for loc in 1:n_locs]
         apply_mortality!.(functional_groups, survival_rate_slices)
-        recruitment .*= (view(survival_rate_cache, :, 1, :) .* loc_k_area)
+        recruitment .*= (view(survival_rate_cache, :, 1, :) .* habitable_areas)
 
         C_cover[tstep, :, :, :] .= C_cover_t
     end

--- a/test/mcda.jl
+++ b/test/mcda.jl
@@ -175,6 +175,7 @@ end
     # Calculate criteria vectors
     # Cover
     sum_cover = vec(sum(dom.init_coral_cover; dims=1).data)
+
     # DHWS
     dhw_scens = dom.dhw_scens[:, :, Int64(scen["dhw_scenario"])]
     plan_horizon = Int64(scen["plan_horizon"])
@@ -182,8 +183,9 @@ end
     dhw_projection = ADRIA.decision.weighted_projection(
         dhw_scens, 1, plan_horizon, decay, 75
     )
+
     # Connectivity
-    area_weighted_conn = dom.conn.data .* ADRIA.site_k_area(dom)
+    area_weighted_conn = dom.conn.data .* ADRIA.loc_k_area(dom)
     conn_cache = similar(area_weighted_conn)
     in_conn, out_conn, network = ADRIA.connectivity_strength(
         area_weighted_conn, sum_cover, conn_cache

--- a/test/run_scenarios.jl
+++ b/test/run_scenarios.jl
@@ -47,7 +47,7 @@ function test_rs()
     dom = ADRIA.load_domain(TEST_DOMAIN_PATH)
 
     # Set min_iv_locations upper to 10 as this is the number of locations used in tests
-    dom = ADRIA.set_factor_bounds(dom, :min_iv_locations, (5.0, 10.0))
+    dom = ADRIA.set_factor_bounds!(dom, :min_iv_locations, (5.0, 10.0))
 
     # Create some scenarios
     # The number of scenarios set here seem to be the rough minimum for SIRUS to produce


### PR DESCRIPTION
Replaces remaining instances of `site_k_area()` with `loc_k_area()`.

Deprecates `site_k_area()` so any use gets auto-forwarded to `loc_k_area()` (with `@deprecated`, a new macro I discovered).

Closes #564