### PR TITLE
Avoid reshape for performance

### DIFF
--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1019,8 +1019,7 @@ function run_model(
 
         survival_rate_slices = [@view survival_rate_cache[:, :, loc] for loc in 1:n_locs]
         apply_mortality!.(functional_groups, survival_rate_slices)
-        recruitment .*= reshape(survival_rate_cache[:, 1, :], (n_groups, n_locs))
-        recruitment .*= loc_k_area
+        recruitment .*= (view(survival_rate_cache, :, 1, :) .* loc_k_area)
 
         C_cover[tstep, :, :, :] .= C_cover_t
     end


### PR DESCRIPTION
Reshape and consecutive multiplication was triggering runtime dispatch.
Using the view of the matrix directly avoids triggering a runtime dispatch.

Collapsing the single dimension resulted in a [n_group * n_loc] matrix anyway.

This change results in a ~10% speed up, with a 512 scenario run going from ~8mins to just over 7mins for a small cluster.
GBR-scale runs may result in better runtime performance.

I confirm the change produces identical results:
![image](https://github.com/user-attachments/assets/1e5e0469-a6ce-43bf-af53-a7f5d293f41c)
