### PR TITLE
Speed up timeseries clustering by checking for already completed calculations

### DIFF
--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -44,6 +44,12 @@ function correction_factor(ce_i::T, ce_j::T)::Float64 where {T<:Real}
     return max(ce_i, ce_j) / min(ce_i, ce_j)
 end
 
+function _complexity_invariance((data_x, complexity_x), (data_y, complexity_y), dist_fn)
+    ed = dist_fn(data_x, data_y)
+    cf = correction_factor(complexity_x, complexity_y)
+    return ed * cf
+end
+
 """
     complexity_invariance_distance(data::AbstractMatrix{<:Real}; distance=:euclidean)::AbstractMatrix{Float64}
 
@@ -71,6 +77,7 @@ function complexity_invariance_distance(
     # Create empty Matrix
     data_size = size(data, 2)
     cid_matrix::AbstractMatrix{Float64} = zeros(data_size, data_size)
+    dist_complexity = [(data[:, i], complexity[i]) for i in 1:data_size]
 
     local weights::Vector{Float64}
     if distance == :weuclidean
@@ -81,12 +88,20 @@ function complexity_invariance_distance(
 
     #? Do we want to normalize the amplitudes of all series?
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
-    for i in axes(data, 2)
-        @floop for j in axes(data, 2)
-            ed = dist_fn(data[:, i], data[:, j])
-            cf = correction_factor(complexity[i], complexity[j])
-            cid_matrix[i, j] = cid_matrix[j, i] = ed * cf
+    for ii in axes(cid_matrix, 1)
+        Threads.@threads for jj in axes(cid_matrix, 2)
+            if ii == jj || !iszero(cid_matrix[ii, jj])
+                continue
+            end
+
+            @views cid_matrix[ii, jj] = _complexity_invariance(
+                dist_complexity[ii], 
+                dist_complexity[jj], 
+                dist_fn
+            )
         end
+
+        cid_matrix[:, ii] .= cid_matrix[ii, :]
     end
 
     return cid_matrix


### PR DESCRIPTION
Matrix calculation code (L91-105) copied from `EcoReefClustering.jl` repo (I tried to extend `EcoReefClustering.distance_matrix!()` function to extend to using `_complexity_invariance` as a function input, but wasn't able to complete requiring `dist_fn` as well. 

The main changes check if CID calculation has already been done for a pair of reefs, allowing for large increases in speed in `cluster_series()`.

I'm making a PR onto GBR-wide-domain branch because I am using it for GBR wide runs and clustering. I can swap and PR to main if that is more suitable.