### PR TITLE
Fix rounding problem, leading to coral overgrowth, when cover plus recruits fill an entire reef

### DIFF
--- a/src/ADRIA.jl
+++ b/src/ADRIA.jl
@@ -89,7 +89,7 @@ export
     run_scenario, coral_spec,
     create_coral_struct, Intervention, SimConstants,
     SeedCriteriaWeights, FogCriteriaWeights,
-    loc_area, site_k_area, loc_k_area,
+    loc_area, site_k_area, loc_k_area, loc_coral_cover, loc_recruits_cover,
     Domain, ADRIADomain,
     metrics, select, timesteps, env_stats, viz
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -344,7 +344,7 @@ end
 
 Sum coral cover across all functional groups and size classes of a single timestep for each location.
 """
-function loc_coral_cover(C_cover_t::Array{Float64,3})::Vector{Float64}
+function loc_coral_cover(C_cover_t::AbstractArray{Float64,3})::Vector{Float64}
     return dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
 end
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -322,21 +322,21 @@ function n_locations(domain::Domain)::Int64
 end
 
 """
-    relative_leftover_space(loc_coral_cover::AbstractArray)::AbstractArray
+    relative_leftover_space(loc_cover::AbstractArray)::AbstractArray
 
 Get proportion of leftover space, given site_k and proportional cover on each site, summed
 over species.
 
 # Arguments
-- `loc_coral_cover` : Proportion of coral cover relative to `k` (maximum carrying capacity).
+- `loc_cover` : Proportion of coral cover relative to `k` (maximum carrying capacity).
 
 # Returns
 Leftover space ∈ [0, 1]
 """
 function relative_leftover_space(
-    loc_coral_cover::AbstractArray
+    loc_cover::AbstractArray
 )::AbstractArray
-    return max.(1.0 .- loc_coral_cover, 0.0)
+    return max.(1.0 .- loc_cover, 0.0)
 end
 
 """

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -354,7 +354,7 @@ end
 Absolute cover of recruits on each location.
 """
 function loc_recruits_cover(recruits::Matrix{Float64})::Vector{Float64}
-    return dropdims(sum(recruits; dims=1); dims=1)
+    return vec(sum(recruits; dims=1))
 end
 
 """

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -340,6 +340,24 @@ function relative_leftover_space(
 end
 
 """
+    loc_coral_cover(C_cover_t::Array{Float64,3})::Vector{Float64}
+
+Sum coral cover across all functional groups and size classes of a single timestep for each location.
+"""
+function loc_coral_cover(C_cover_t::Array{Float64,3})::Vector{Float64}
+    return dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
+end
+
+"""
+    loc_recruits_cover(recruits::Matrix{Float64})::Vector{Float64}
+
+Absolute cover of recruits on each location.
+"""
+function loc_recruits_cover(recruits::Matrix{Float64})::Vector{Float64}
+    return dropdims(sum(recruits; dims=1); dims=1)
+end
+
+"""
     location_k(domain::Domain)::Vector{Float64}
 
 Get maximum coral habitable area as a proportion of a location's area (\$k ∈ [0, 1]\$).

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -930,7 +930,7 @@ function run_model(
         C_rel_cover = loc_coral_cover(C_cover_t) ./ habitable_loc_areas
         loc_recruits_rel_cover = loc_recruits_cover(recruitment) ./ habitable_loc_areas
 
-        # Set recruitment to 0 where C_cover_t is already round_threshold
+        # Set recruitment to 0 where C_cover_t is already above round_threshold
         cover_above_threshold_mask = C_rel_cover .> round_threshold
         recruitment[:, cover_above_threshold_mask] .= 0.0
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1042,8 +1042,8 @@ function run_model(
         # Calculates scope for coral fedundity for each size class and at each location
         fecundity_scope!(fec_scope, fec_all, fec_params_per_m², C_cover_t, habitable_areas)
 
-        loc_coral_cover = loc_coral_cover(C_cover_t)
-        leftover_space_m² = relative_leftover_space(loc_coral_cover) .* vec_abs_k
+        _loc_coral_cover = loc_coral_cover(C_cover_t)
+        leftover_space_m² = relative_leftover_space(_loc_coral_cover) .* vec_abs_k
 
         # Reset potential settlers to zero
         potential_settlers .= 0.0
@@ -1157,14 +1157,14 @@ function run_model(
             # Determine connectivity strength weighting by area.
             # Accounts for strength of connectivity where there is low/no coral cover
             in_conn, out_conn, _ = connectivity_strength(
-                area_weighted_conn, vec(loc_coral_cover), conn_cache
+                area_weighted_conn, vec(_loc_coral_cover), conn_cache
             )
 
             update_criteria_values!(
                 decision_mat;
                 heat_stress=dhw_projection[_valid_locs],
                 wave_stress=wave_projection[_valid_locs],
-                coral_cover=loc_coral_cover[_valid_locs],  # Coral cover relative to `k`
+                coral_cover=_loc_coral_cover[_valid_locs],  # Coral cover relative to `k`
                 in_connectivity=in_conn[_valid_locs],  # area weighted connectivities for time `t`
                 out_connectivity=out_conn[_valid_locs]
             )

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -19,6 +19,7 @@ using ADRIA.metrics:
 using ADRIA.metrics: relative_juveniles, relative_taxa_cover, juvenile_indicator
 using ADRIA.metrics: coral_evenness
 using ADRIA.decision
+using ADRIA: loc_coral_cover, loc_recruits_cover
 
 """
     setup_cache(domain::Domain)::NamedTuple

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -955,7 +955,7 @@ function run_model(
 
             # Rescale recruits in target locations to fit within error bounds
             recruitment[:, agg_cover_above_threshold_mask] .*= repeat(
-                recruits_scale_factor', 5
+                recruits_scale_factor', n_groups
             )
         end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1006,12 +1006,13 @@ function run_model(
         # Check if size classes are inappropriately out-growing habitable area
         if any(loc_coral_cover(C_cover_t)[habitable_locs] .> habitable_loc_areas)
             @warn "Cover outgrowing habitable area at tstep $tstep. Constraining."
-            msk = loc_coral_cover(C_cover_t)[habitable_locs] .> habitable_loc_areas
-            C_cover_t[:, :, habitable_locs .&& msk] .*=
+            outgrowing_locs_maks =
+                loc_coral_cover(C_cover_t)[habitable_locs] .> habitable_loc_areas
+            C_cover_t[:, :, outgrowing_locs_maks] .*=
                 reshape(
-                    vec_abs_k[msk .&& habitable_locs] ./
-                    loc_coral_cover(C_cover_t)[msk .&& habitable_locs],
-                    (1, 1, count(msk .&& habitable_locs))
+                    vec_abs_k[outgrowing_locs_maks] ./
+                    loc_coral_cover(C_cover_t)[outgrowing_locs_maks],
+                    (1, 1, count(outgrowing_locs_maks))
                 ) .* 0.999
         end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1008,13 +1008,13 @@ function run_model(
         # Check if size classes are inappropriately out-growing habitable area
         if any(loc_coral_cover(C_cover_t)[habitable_locs] .> habitable_loc_areas)
             @warn "Cover outgrowing habitable area at tstep $tstep. Constraining."
-            outgrowing_locs_maks =
+            outgrowing_locs_mask =
                 loc_coral_cover(C_cover_t)[habitable_locs] .> habitable_loc_areas
-            C_cover_t[:, :, outgrowing_locs_maks] .*=
+            C_cover_t[:, :, outgrowing_locs_mask] .*=
                 reshape(
-                    vec_abs_k[outgrowing_locs_maks] ./
-                    loc_coral_cover(C_cover_t)[outgrowing_locs_maks],
-                    (1, 1, count(outgrowing_locs_maks))
+                    vec_abs_k[outgrowing_locs_mask] ./
+                    loc_coral_cover(C_cover_t)[outgrowing_locs_mask],
+                    (1, 1, count(outgrowing_locs_mask))
                 ) .* 0.999
         end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -678,6 +678,7 @@ function run_model(
     habitable_locs::BitVector = location_k(domain) .> 0.0
     habitable_loc_areas = vec_abs_k[habitable_locs]
     habitable_loc_areas′ = reshape(habitable_loc_areas, (1, 1, length(habitable_locs)))
+    n_habitable_locs::Int64 = length(habitable_locs)
 
     # Avoid placing importance on sites that were not considered
     # Lower values are higher importance/ranks.
@@ -917,6 +918,7 @@ function run_model(
 
     apply_growth_acc_mask::BitVector = trues(n_locs)
     cache_habitable_max_projected_cover = copy(habitable_max_projected_cover)
+    agg_cover_above_threshold_mask::BitVector = falses(n_habitable_locs)
     for tstep::Int64 in 2:tf
         # Convert cover to absolute values to use within CoralBlox model
         C_cover_t[:, :, habitable_locs] .=
@@ -935,7 +937,7 @@ function run_model(
         recruitment[:, cover_above_threshold_mask] .= 0.0
 
         # Mask for locations with (C_cover + recruits) > threshold and C_cover <= threshold
-        agg_cover_above_threshold_mask =
+        agg_cover_above_threshold_mask .=
             (C_rel_cover .+ loc_recruits_rel_cover .> round_threshold) .&&
             .!cover_above_threshold_mask
 


### PR DESCRIPTION
In the rare case where adding the recruits to a location cover should fill an entire reef, so that the relative cover would be equal to 1, sometimes there's a rounding error causing the actual relative cover to be 1 plus a very tiny number (one of the times I've checked it was close to 1e10-11). That causes a few issues and the fix is to set a threshold (right now it's set to 0.95 but that can be changed) so that:

- If that location's relative cover is already above the threshold, we set the recruits to zero.
- If that location's relative cover is below the threshold but when adding the recruits it goes above the threshold, we rescale the recruits so that this sum is equal to the threshold
- Otherwise we do nothing

And that seems to fix the problem. 

Note that:

1. To cause this bug in the first place we seeded with a very high number of seeds and a very low number of locations (1e6 seeds to 15 locations).
2. There's also a non related issue with CoralBlox' `max_projected_cover` that can cause a bug precisely in this situations where a reef is filled with corals from a small size class. This issue doesn't cause the round error but also causes a coral overgrowth and that is going  to be fixed on a CoralBlox PR. Here's the link to the issue: https://github.com/open-AIMS/CoralBlox.jl/issues/33
