### PR TITLE
Speed up timeseries clustering

### DIFF
--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -72,8 +72,8 @@ function complexity_invariance_distance(
     data::AbstractMatrix{<:Real};
     distance=:euclidean
 )::AbstractMatrix{Float64}
-    # Compute complexity vector
-    complexity = _complexity(data)
+    # Compute complexity vector (each element is the complexity of a distinct scenario)
+    complexity::Vector{Float64} = _complexity(data)
 
     # Create empty Matrix
     data_size = size(data, 2)

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -44,10 +44,17 @@ function correction_factor(ce_i::T, ce_j::T)::Float64 where {T<:Real}
     return max(ce_i, ce_j) / min(ce_i, ce_j)
 end
 
-# function _complexity_invariance((data_x, complexity_x), (data_y, complexity_y), dist_fn)
-function _complexity_invariance(data, complexity, i, j, dist_fn)::Float64
-    ed = dist_fn(data[:, i], data[:, j])
-    cf = correction_factor(complexity[i], complexity[j])
+"""
+    _complexity_invariance(data_i, data_j, complexity_i, complexity_j, dist_fn)::Float64
+
+Complexity invariance between two data series given their complexities and a custom distance
+function.
+"""
+function _complexity_invariance(
+    data_i, data_j, complexity_i, complexity_j, dist_fn
+)::Float64
+    ed = dist_fn(data_i, data_j)
+    cf = correction_factor(complexity_i, complexity_j)
     return ed * cf
 end
 
@@ -91,7 +98,9 @@ function complexity_invariance_distance(
     for i in 1:n_timesteps
         Threads.@threads for j in (i + 1):n_timesteps
             cid_matrix[i, j] =
-                cid_matrix[j, i] = _complexity_invariance(data, complexity, i, j, dist_fn)
+                cid_matrix[j, i] = _complexity_invariance(
+                    data[:, i], data[:, j], complexity[i], complexity[j], dist_fn
+                )
         end
     end
 

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -88,8 +88,8 @@ function complexity_invariance_distance(
 
     #? Do we want to normalize the amplitudes of all series?
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
-    for i in axes(data, 2)
-        @floop for j in axes(data, 2)
+    for i in 1:data_size
+        @floop for j in (i + 1):data_size
             cid_matrix[i, j] =
                 cid_matrix[j, i] = _complexity_invariance(data, complexity, i, j, dist_fn)
         end

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -89,14 +89,14 @@ function complexity_invariance_distance(
     local weights::Vector{Float64}
     if distance == :weuclidean
         # [1, 1/2, 1/3, ..., 1/n]
-        weights = sqrt.(1 ./ (1:n_scenarios))
+        weights = sqrt.(1 ./ (1:n_timesteps))
     end
     dist_fn(x, y) = (distance == :euclidean) ? euclidean(x, y) : weuclidean(x, y, weights)
 
     #? Do we want to normalize the amplitudes of all series?
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
-    for i in 1:n_timesteps
-        Threads.@threads for j in (i + 1):n_timesteps
+    for i in 1:n_scenarios
+        Threads.@threads for j in (i + 1):n_scenarios
             cid_matrix[i, j] =
                 cid_matrix[j, i] = _complexity_invariance(
                     data[:, i], data[:, j], complexity[i], complexity[j], dist_fn

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -89,7 +89,7 @@ function complexity_invariance_distance(
     #? Do we want to normalize the amplitudes of all series?
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
     for i in 1:n_timesteps
-        @floop for j in (i + 1):n_timesteps
+        Threads.@threads for j in (i + 1):n_timesteps
             cid_matrix[i, j] =
                 cid_matrix[j, i] = _complexity_invariance(data, complexity, i, j, dist_fn)
         end

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -44,6 +44,13 @@ function correction_factor(ce_i::T, ce_j::T)::Float64 where {T<:Real}
     return max(ce_i, ce_j) / min(ce_i, ce_j)
 end
 
+# function _complexity_invariance((data_x, complexity_x), (data_y, complexity_y), dist_fn)
+function _complexity_invariance(data, complexity, i, j, dist_fn)::Float64
+    ed = dist_fn(data[:, i], data[:, j])
+    cf = correction_factor(complexity[i], complexity[j])
+    return ed * cf
+end
+
 """
     complexity_invariance_distance(data::AbstractMatrix{<:Real}; distance=:euclidean)::AbstractMatrix{Float64}
 
@@ -83,9 +90,8 @@ function complexity_invariance_distance(
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
     for i in axes(data, 2)
         @floop for j in axes(data, 2)
-            ed = dist_fn(data[:, i], data[:, j])
-            cf = correction_factor(complexity[i], complexity[j])
-            cid_matrix[i, j] = cid_matrix[j, i] = ed * cf
+            cid_matrix[i, j] =
+                cid_matrix[j, i] = _complexity_invariance(data, complexity, i, j, dist_fn)
         end
     end
 

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -77,7 +77,7 @@ function complexity_invariance_distance(
 
     # Create empty Matrix
     n_timesteps, n_scenarios = size(data)
-    cid_matrix::AbstractMatrix{Float64} = zeros(n_timesteps, n_timesteps)
+    cid_matrix::Matrix{Float64} = zeros(n_scenarios, n_scenarios)
 
     local weights::Vector{Float64}
     if distance == :weuclidean

--- a/src/analysis/clustering.jl
+++ b/src/analysis/clustering.jl
@@ -76,20 +76,20 @@ function complexity_invariance_distance(
     complexity::Vector{Float64} = _complexity(data)
 
     # Create empty Matrix
-    data_size = size(data, 2)
-    cid_matrix::AbstractMatrix{Float64} = zeros(data_size, data_size)
+    n_timesteps, n_scenarios = size(data)
+    cid_matrix::AbstractMatrix{Float64} = zeros(n_timesteps, n_timesteps)
 
     local weights::Vector{Float64}
     if distance == :weuclidean
         # [1, 1/2, 1/3, ..., 1/n]
-        weights = sqrt.(1 ./ (1:size(data, 1)))
+        weights = sqrt.(1 ./ (1:n_scenarios))
     end
     dist_fn(x, y) = (distance == :euclidean) ? euclidean(x, y) : weuclidean(x, y, weights)
 
     #? Do we want to normalize the amplitudes of all series?
     # Iterate over data matrix to compute CID (Complexity Invariance Distance)
-    for i in 1:data_size
-        @floop for j in (i + 1):data_size
+    for i in 1:n_timesteps
+        @floop for j in (i + 1):n_timesteps
             cid_matrix[i, j] =
                 cid_matrix[j, i] = _complexity_invariance(data, complexity, i, j, dist_fn)
         end


### PR DESCRIPTION
This is essentially the same as #940 but I've created a separate PR because the other branch was too behind the main and a rebase was creating a few unwanted commits for some reason.

The two main changes here are:

1. Since the distance matrix is symmetric, the inner loop limits were changing to avoid going through the same matrix elements more than once
2. `@floop` was replaces by `Threads.@threads`. Not sure why, but a simple banchmark using Chairmarks showed that it actually works (in the dfigure below, the first benchmark was done using `@loops` and the second using `Threads.@threads`):
![image](https://github.com/user-attachments/assets/85a262ca-14a9-45bc-adf0-300f589fcb95)

Credits to @eco-ben who actually found this.