### PR TITLE
docs: minor clarification to Makie backend selection

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -31,15 +31,12 @@ To trigger compilation of the `viz` extension, we must **always** import the fol
 
 ```julia
 using GeoMakie, GraphMakie
-```
 
-You should then import your chosen backend, e.g. `WGLMakie`
-
-```julia
+# Then import the chosen backend, such as:
 using WGLMakie
 ```
 
-For example, the below scripts assume the following imports
+The example scripts below assume the following imports
 
 ```julia
 using ADRIA


### PR DESCRIPTION
Based on experience of configuring and swapping backends, proposes some clarifications to the required installs and `using` commands suggested in the docs.