### PR TITLE
Fix conn data load location selection when force_single_reef is true

### DIFF
--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -498,7 +498,8 @@ function load_connectivity_csv(
     end
 
     # Ensure compatibility when `force_single_reef == true`
-    locs_selector = isnothing(force_single_reef) ? ([1], [1]) : (:, :)
+    locs_selector =
+        isnothing(force_single_reef) ? (:, :) : (force_single_reef, force_single_reef)
 
     n_locs = length(loc_ids)
     tmp_mat = zeros(n_locs, n_locs, length(conn_files))


### PR DESCRIPTION
This was introduced in PR#967 as suggested in the review [1].

[1] https://github.com/open-AIMS/ADRIA.jl/pull/967#discussion_r2271792525
