### PR TITLE
Support independent scenarios viz legend rendering

### DIFF
--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -181,12 +181,38 @@ function ADRIA.viz.scenarios!(
     if get(opts, :legend, true)
         legend_position = get(opts, :histogram, true) ? (1, 3) : (1, 2)
         legend_labels = get(opts, :legend_labels, group_names)
-        _render_legend(g, scen_groups, legend_position, legend_labels)
+        _render_legend(g[legend_position...], scen_groups, legend_labels)
     end
 
     ax.xlabel = "Year"
     ax.ylabel = outcome_label(outcomes)
     return g
+end
+
+function ADRIA.viz.scenarios_legend!(
+    g::GridPosition, rs::ResultSet, outcomes::YAXArray; opts::OPT_TYPE=Dict{Symbol,Any}(),
+    legend_opts::OPT_TYPE=Dict{Symbol,Any}()
+)
+    by_RCP::Bool = get(opts, :by_RCP, false)
+    sort_by::Symbol = get(opts, :sort_by, :default)
+    default_names::Vector{Symbol} = get(opts, :legend_labels, [])
+
+    _scenarios = rs.inputs #copy(@view(scenarios[1:end .∈ [outcomes.scenarios], :]))
+    scen_groups = if by_RCP
+        ADRIA.analysis.scenario_rcps(_scenarios)
+    else
+        ADRIA.analysis.scenario_types(_scenarios)
+    end
+
+    group_names::Vector{Symbol} = _sort_keys(
+        scen_groups;
+        by_RCP=by_RCP, by=sort_by, outcomes=outcomes, default_names=default_names
+    )
+
+    legend_labels = get(opts, :legend_labels, group_names)
+    return _render_legend(
+        g, scen_groups, legend_labels; legend_opts=legend_opts
+    )
 end
 
 function _confints(
@@ -294,13 +320,14 @@ end
 function _render_legend(
     g::Union{GridLayout,GridPosition},
     scen_groups::Dict{Symbol,BitVector},
-    legend_position::Tuple{Int64,Int64},
-    legend_labels::Vector{Symbol}
+    legend_labels::Vector{Symbol};
+    legend_opts::Dict{Symbol,Any}=Dict{Symbol,Any}()
 )::Nothing
     _colors = colors(scen_groups)
     line_els::Vector{LineElement} = [LineElement(; color=_colors[n]) for n in legend_labels]
 
-    Legend(g[legend_position...], line_els, labels(legend_labels); framevisible=false)
+    title = pop!(legend_opts, :title, "Intervention scenarios")
+    Legend(g, line_els, labels(legend_labels), title; framevisible=false, legend_opts...)
 
     return nothing
 end

--- a/src/viz/viz.jl
+++ b/src/viz/viz.jl
@@ -14,6 +14,7 @@ function explore() end
 # Scenario plotting methods
 function scenarios() end
 function scenarios!() end
+function scenarios_legend!() end
 
 # Sensitivity analyses
 function pawn() end


### PR DESCRIPTION
This is a more flexible way of dealing with the legend when plotting distinct scenario metrics at the same time. For example, to obtain this plot:

<img width="990" height="405" alt="image" src="https://github.com/user-attachments/assets/4fb1678e-a602-4347-b586-25d05adb44c1" />

We can now do

```
fig = Figure(size=(1200, 500))  # size of figure
base_axis_opts::Dict{Symbol,Any} = Dict(:titlesize => 18)
base_opts = Dict{Symbol,Any}(:summarize => false, :legend => false)

# Implicitly create a single figure with 2 columns
ADRIA.viz.scenarios!(
    fig[1, 1],
    rs,
    s_tc;
    opts=merge(Dict(:legend => false), base_opts),
    axis_opts=merge(Dict(:title => "Total Cover [m²]"), base_axis_opts),
)
ADRIA.viz.scenarios!(
    fig[1, 2],
    rs,
    s_juves;
    opts=base_opts,
    axis_opts=merge(Dict(:title => "Relative Juveniles [%]"), base_axis_opts),
)

legend_opts = Dict{Symbol,Any}(:orientation => :horizontal,)
ADRIA.viz.scenarios_legend!(fig[2, :], rs, s_tc; legend_opts=legend_opts)

fig
```