### PR TITLE
fix: fix input type declaration for _render_legend

### DIFF
--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -326,7 +326,7 @@ function scenarios_hist(
 end
 
 function _render_legend(
-    g::Union{GridLayout,GridPosition},
+    g::Union{GridLayout,GridPosition,GridSubposition},
     scen_groups::Dict{Symbol,BitVector},
     legend_labels::Vector{Symbol};
     legend_opts::Dict{Symbol,Any}=Dict{Symbol,Any}()


### PR DESCRIPTION
Fixes the following error

```julia
ERROR: LoadError: MethodError: no method matching _render_legend(::GridSubposition, ::Dict{Symbol, BitVector}, ::Vector{Symbol})
The function `_render_legend` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  _render_legend(::Union{GridLayout, GridPosition}, ::Dict{Symbol, BitVector}, ::Vector{Symbol}; legend_opts)
   @ AvizExt ~/repos/ADRIA.jl/ext/AvizExt/viz/scenarios.jl:328
```

This doesn't resolve all the current failing tests.