### PR TITLE
Support arbitrary number of time series clusters

### DIFF
--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -17,11 +17,14 @@ const COLORS::Dict{Symbol,Union{Symbol,String}} = Dict(
 
 function colors(
     scen_groups::Dict{Symbol,BitVector}
-)::Dict{Symbol,Union{Symbol,RGBA{Float32},String}}
+)::Dict{Symbol,Any}
     group_names = keys(scen_groups)
     if count(group_names .∉ [keys(COLORS)]) > 0
-        colormap = categorical_colors(:seaborn_bright, length(group_names))
-        return Dict(group => colormap[idx] for (idx, group) in enumerate(group_names))
+        colormap = cgrad(:brg, length(group_names); categorical=true).colors
+
+        return Dict(
+            group => colormap[idx] for (idx, group) in enumerate(group_names)
+        )
     else
         return Dict(group => COLORS[group] for group in group_names)
     end

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -247,9 +247,9 @@ function scenarios_confint!(
     ax::Axis,
     confints::AbstractArray,
     ordered_groups::Vector{Symbol},
-    _colors::Dict{Symbol,T};
+    _colors::Dict{Symbol,Any};
     x_vals::Union{Vector{Int64},Vector{Float64}}=collect(1:size(confints, 1))
-)::Nothing where {T<:Union{RGBA{Float32},String,Symbol}}
+)::Nothing
     for idx in eachindex(ordered_groups)
         band_color = (_colors[ordered_groups[idx]], 0.4)
         y_lower, y_upper = confints[:, idx, 1], confints[:, idx, 3]
@@ -267,7 +267,7 @@ function scenarios_confint!(
     scen_groups::Dict{Symbol,BitVector},
     group_names::Vector{Symbol}
 )::Nothing
-    _colors::Dict{Symbol,Union{Symbol,RGBA{Float32},String}} = colors(scen_groups)
+    _colors::Dict = colors(scen_groups)
     confints = _confints(outcomes, scen_groups, group_names)
     return scenarios_confint!(
         ax,


### PR DESCRIPTION
Previous approach relied on defined mapping set in COLORS constant, which becomes problematic if the number of clusters were larger than 10.
