### PR TITLE
Fix incorrect use of single reef idx

### DIFF
--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -136,9 +136,14 @@ function load_domain(
     spatial_data = GDF.read(gpkg_path)
 
     # Adjust spatial data if `force_single_reef == true`
-    single_reef_idx = findall(spatial_data.UNIQUE_ID .== force_single_reef_id)
-    isempty(single_reef_idx) && push!(single_reef_idx, 1)
-    force_single_reef && (spatial_data = spatial_data[[1], :])
+    single_reef_idx = collect(1:nrow(spatial_data))  # select all locations by default
+    if force_single_reef
+        if !isempty(force_single_reef_id)
+            single_reef_idx = findall(spatial_data.UNIQUE_ID .== force_single_reef_id)
+        end
+
+        spatial_data = spatial_data[single_reef_idx, :]
+    end
 
     # Find initial coral cover start year
     initial_csv_files = readdir(joinpath(data_files, "initial_csv"))


### PR DESCRIPTION
This commit addresses an issue within the `RMEDomain`'s `load_domain` function where the `spatial_data` was not being correctly filtered when `force_single_reef` was enabled alongside a `force_single_reef_id`.

Specifically, the original logic could default to selecting the first reef or incorrectly apply the filtering. The fix ensures that:
-   `single_reef_idx` correctly reflects either all locations (by default), or the specific reef matching `force_single_reef_id` if provided.
-   `spatial_data` is consistently subsetted using the determined `single_reef_idx` when `force_single_reef` is true, leading to accurate domain loading for single reef scenarios.