### PR TITLE
fix: Fix categorical bug where bounds are passed instead of categories

### DIFF
--- a/src/ecosystem/Ecosystem.jl
+++ b/src/ecosystem/Ecosystem.jl
@@ -24,7 +24,7 @@ function EnvironmentalLayer(
             1;
             ptype="unordered categorical",
             dist=CategoricalDistribution,
-            dist_params=(1.0, Float64(size(dhw, 3))),
+            dist_params=(Tuple(1:Float64(size(dhw, 3)))),
             name="DHW Scenario",
             description="DHW scenario member identifier."
         ),
@@ -32,7 +32,7 @@ function EnvironmentalLayer(
             1;
             ptype="unordered categorical",
             dist=CategoricalDistribution,
-            dist_params=(1.0, Float64(size(wave, 3))),
+            dist_params=(Tuple(1:Float64(size(wave, 3)))),
             name="Wave Scenario",
             description="Wave scenario member identifier."
         ),
@@ -40,7 +40,7 @@ function EnvironmentalLayer(
             1;
             ptype="unordered categorical",
             dist=CategoricalDistribution,
-            dist_params=(1.0, Float64(size(cyclone_mortality, 4))),
+            dist_params=(Tuple(1:Float64(size(cyclone_mortality, 4)))),
             name="Cyclone Mortality",
             description="Cyclone mortality scenario identifier."
         )


### PR DESCRIPTION
### Environmental Scenarios Sampling Issue
<img width="353" height="753" alt="categorical_bug" src="https://github.com/user-attachments/assets/5338e9be-52e4-4759-b73d-92d9084af829" />

### Fixed
<img width="576" height="757" alt="categorical_bug_fxi" src="https://github.com/user-attachments/assets/83801bd3-9eab-4aa2-be12-aba19e6397c1" />

Categorical Variables custom implementation needed to constructed using each category and not just bounds so that mcda methods can be included/excluded independently.