### PR TITLE
Restrict minimum compatible Julia version to 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -145,7 +145,7 @@ Test = "1"
 WGLMakie = "0.11.10, 0.12, 0.13"
 YAXArrays = "0.5, 0.6"
 Zarr = "0.9"
-julia = "1.10, 1.11"
+julia = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
As in title. 