### PR TITLE
Fix LTMP Taxa Cover and Metric Metadata

### DIFF
--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -117,11 +117,10 @@ function _ltmp_cover(
 )::YAXArray{<:Real,2}
     lc = ADRIAIndicators.ltmp_cover(X, k_area, reef_area)
     axes_vals = _extract_axes_values(lc)
-    # return DataCube(rel_juv .* loc_k_area(rs)'; axes_vals...)
 
     return DataCube(
         ADRIAIndicators.ltmp_cover(X, k_area, reef_area),
-        (:timesteps, :locations)
+        axes_vals...
     )
 end
 function _ltmp_cover(
@@ -240,11 +239,13 @@ function _ltmp_taxa_cover(
     k_area = loc_k_area(rs)
     reef_area = loc_area(rs)
 
+    axes_vals = _extract_axes_values(rel_cover)
+
     return DataCube(
         ADRIAIndicators.relative_cover_to_ltmp_cover(
             rel_cover.data, k_area, reef_area, -1
-        ),
-        (:timesteps, :groups, :scenarios)
+        );
+        axes_vals...
     )
 end
 ltmp_taxa_cover = Metric(

--- a/src/metrics/scenario.jl
+++ b/src/metrics/scenario.jl
@@ -81,14 +81,16 @@ scenario_relative_cover = Metric(
 
 function _scenario_ltmp_cover(rs::ResultSet; kwargs...)::AbstractArray{<:Real}
     scenario_rc = _scenario_relative_cover(rs; kwargs...)
+    axes_info = _extract_axes_values(scenario_rc)
+
     return DataCube(
         ADRIAIndicators.relative_cover_to_ltmp_cover(
             scenario_rc.data,
             loc_k_area(rs),
             loc_area(rs),
             -1
-        ),
-        (:timesteps, :scenarios)
+        );
+        axes_info...
     )
 end
 scenario_ltmp_cover = Metric(


### PR DESCRIPTION
* Instead of constructing YAXArrays with timesteps `1:n_years` extract axis values from input array to maintain years.
* `ltmp_taxa_cover` was incorrectly wrapping the `_ltmp_cover` metric. This has been corrected to wrap the `_ltmp_taxa_cover` metric
* Remove infiltrate