### PR TITLE
Fix wrong use of reactive strategy index

### DIFF
--- a/src/decision/Decision.jl
+++ b/src/decision/Decision.jl
@@ -45,11 +45,13 @@ export
     summary_stat_env,
     mcda_methods,
     # Strategies
+    DECISION_STRATEGY,
+    is_reactive,
+    is_periodic,
     is_decision_year,
     build_seed_strategy,
     build_fog_strategy,
     filter_candidate_locations,
     PeriodicStrategy,
     ReactiveStrategy
-
 end

--- a/src/decision/strategies/strategies.jl
+++ b/src/decision/strategies/strategies.jl
@@ -5,6 +5,13 @@ include("ReactiveStrategy.jl")
 # include("PreventativeStrategy.jl")
 include("strategy_builder.jl")
 
+const DECISION_STRATEGY = Dict(
+    :periodic => 1,
+    :reactive => 2,
+    1 => :periodic,
+    2 => :reactive
+)
+
 """
     is_decision_year(strategy::DecisionStrategy, timestep::Int64)::Bool
 
@@ -15,4 +22,18 @@ function is_decision_year(
     timestep::Int64
 )::Bool
     return true
+end
+
+function is_reactive(strategy_idx::T)::Bool where {T<:Real}
+    return strategy_idx == DECISION_STRATEGY[:reactive]
+end
+function is_reactive(strategy_idx::AbstractVector{T})::BitVector where {T<:Real}
+    return is_reactive.(strategy_idx)
+end
+
+function is_periodic(strategy_idx::T)::Bool where {T<:Real}
+    return strategy_idx == DECISION_STRATEGY[:periodic]
+end
+function is_periodic(strategy_idx::AbstractVector{T})::BitVector where {T<:Real}
+    return is_periodic.(strategy_idx)
 end

--- a/src/decision/strategies/strategy_builder.jl
+++ b/src/decision/strategies/strategy_builder.jl
@@ -42,7 +42,7 @@ end
 function return_seed_strategy(
     strategy_type::Int64, params::YAXArray, domain::Domain, locations::Vector{String}
 )::DecisionStrategy
-    if strategy_type == 1
+    if is_periodic(strategy_type)
         return PeriodicStrategy(
             locations,
             Int64(params[At("seed_year_start")]),
@@ -50,7 +50,7 @@ function return_seed_strategy(
             Int64(params[At("seed_deployment_freq")]),
             length(timesteps(domain))
         )
-    elseif strategy_type == 2
+    elseif is_reactive(strategy_type)
         return ReactiveStrategy(
             locations,
             Int64(params[At("seed_year_start")]),
@@ -86,7 +86,7 @@ function build_fog_strategy(
 )::DecisionStrategy
     strategy_type = Int64(params[At("fog_strategy")])
 
-    if strategy_type == 1
+    if is_periodic(strategy_type)
         # Periodic Strategy
         return PeriodicStrategy(
             locations,
@@ -95,7 +95,7 @@ function build_fog_strategy(
             Int64(params[At("fog_years")]),
             Int64(params[At("fog_deployment_freq")])
         )
-    elseif strategy_type == 2
+    elseif is_reactive(strategy_type)
         # Reactive Strategy
         return ReactiveStrategy(
             locations,

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -628,8 +628,6 @@ function run_model(
         MCDA_approach = mcda_methods()[Int64(param_set[At("guided")])]
     end
 
-    is_reactive = param_set[At("seed_strategy")] == 2 || param_set[At("fog_strategy")] == 2
-
     # Decisions should place more weight on environmental conditions
     # closer to the decision point
     α = 0.99
@@ -1381,7 +1379,8 @@ function run_model(
 
         # Track cover loss for reactive strategies
         max_lookback
-        if is_guided && is_reactive && (tstep > 1)
+        _is_reactive = any(is_reactive(param_set[At(["seed_strategy", "fog_strategy"])]))
+        if is_guided && _is_reactive && (tstep > 1)
             # Calculate proportional cover loss at each location
             # due to disturbances this timestep
             Δcover_loss_proportion = zeros(n_locs)


### PR DESCRIPTION
In a few different places, the indexes for `reactive` and `periodic` were inverted. This PR fixes that and introduces a constant a a few auxiliary functions to avoid this problem in the future.

Tests were already broken on the main branch. A separate PR will address that.