### PR TITLE
Enhances Zarr I/O, parallel writes, and depot path docs

### DIFF
--- a/docs/src/usage/getting_started.md
+++ b/docs/src/usage/getting_started.md
@@ -128,16 +128,38 @@ See [Analysis](@ref) for further examples of analysis and plots.
 If parallel runs are to be conducted, it is recommended to set a shared `JULIA_DEPOT_PATH`.
 This is so each individual worker does not race against each other to compile packages.
 
+This would be defined in your user `.bashrc` file (or equivalent) on Linux, or configured
+via the user environment variable control panel dialog on Windows.
+
+If runs outside of VS Code are not expected, the variable can be set using within
+`settings.json` by:
+
+- Opening settings in VS Code (Ctrl+,)
+- Search for terminal.integrated.env.windows
+- Add: "JULIA_DEPOT_PATH": "<path to depot>"
+
+`C:\Users\tiwanaga\development\julia_shared_depot`
+
+
+Below are instructions to set a temporary environment variable for a session.
+
 On Linux:
 
 ```shell
-export JULIA_DEPOT_PATH="/some_shared_accessible_directory"
+export JULIA_DEPOT_PATH="some_shared_accessible_directory"
 ```
 
-On Windows:
+On Windows (Command Prompt):
 
 ```shell
 set JULIA_DEPOT_PATH="some_shared_accessible_directory"
 ```
 
-https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH
+On Windows (Powershell):
+
+```powershell
+$Env:JULIA_DEPOT_PATH="some_shared_accessible_directory"
+```
+
+- https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH
+- https://pkgdocs.julialang.org/dev/depots/#Platform-specific-configuration

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -58,7 +58,7 @@ Load shading log from a Zarr log group, handling both the new combined format
 (`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
 """
 function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
-    if "shading_log" in keys(log_set)
+    if haskey(log_set, "shading_log")
         return DataCube(
             log_set["shading_log"],
             Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -256,6 +256,7 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), nrow(all_inputs))
     logs = (;
         zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
@@ -265,7 +266,8 @@ function combine_results(result_sets...)::ResultSet
                 size(rs1.seed_log, :timesteps),
                 size(rs1.seed_log, :locations),
                 size(rs1.seed_log, :coral_id),
-                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id),
+                batch_size
             )
         )...
     )

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -14,6 +14,13 @@ const MODEL_SPEC = "model_spec"
 const RESULTS = "results"
 const SPATIAL_DATA = "spatial"
 
+# Combined store name for the 6 location-based outcome metrics
+const LOC_METRICS = "loc_outcomes"
+const LOC_METRIC_NAMES = [
+    :relative_cover, :relative_shelter_volume, :absolute_shelter_volume,
+    :relative_juveniles, :juvenile_indicator, :coral_evenness
+]
+
 abstract type ResultSet end
 
 struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
@@ -41,10 +48,35 @@ struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
     ranks::A
     mc_log::B  # Values stored in m^2
     seed_log::B  # Values stored in m^2
-    fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
-    shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
+    shading_log::C  # Fog and shade intervention log, dims: (timesteps, locations, intervention, scenarios)
     coral_dhw_tol_log::D3
     coral_cover_log::D4
+end
+
+"""
+Load shading log from a Zarr log group, handling both the new combined format
+(`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
+"""
+function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
+    if "shading_log" in keys(log_set)
+        return DataCube(
+            log_set["shading_log"],
+            Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))
+        )
+    end
+
+    # Old format: two separate (T, L, N) arrays — load and stack into (T, L, 2, N)
+    fog_arr = log_set["fog"][:, :, :]
+    shade_arr = log_set["shade"][:, :, :]
+    tf, n_locs, n_scens = size(fog_arr)
+    combined = Array{Float32}(undef, tf, n_locs, 2, n_scens)
+    combined[:, :, 1, :] .= fog_arr
+    combined[:, :, 2, :] .= shade_arr
+    return DataCube(
+        combined;
+        timesteps=1:tf, locations=1:n_locs,
+        intervention=["fog", "shade"], scenarios=1:n_scens
+    )
 end
 
 function ResultSet(
@@ -84,8 +116,7 @@ function ResultSet(
             Symbol.(Tuple(log_set["moving_corals"].attrs["structure"]))
         ),
         DataCube(log_set["seed"], Symbol.(Tuple(log_set["seed"].attrs["structure"]))),
-        DataCube(log_set["fog"], Symbol.(Tuple(log_set["fog"].attrs["structure"]))),
-        DataCube(log_set["shade"], Symbol.(Tuple(log_set["shade"].attrs["structure"]))),
+        _load_shading_log(log_set),
         DataCube(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
@@ -226,79 +257,88 @@ function combine_results(result_sets...)::ResultSet
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_tol_log, :coral_cover_log],
+        zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
                 z_store,
                 rs1.loc_ids,
                 nrow(all_inputs),
-                n_timesteps,
-                n_locs,
-                n_groups,
-                n_sizes
+                size(rs1.seed_log, :timesteps),
+                size(rs1.seed_log, :locations),
+                size(rs1.seed_log, :coral_id),
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
             )
         )...
     )
 
-    # Copy logs over
+    # Copy logs over (all are 4D; try/catch handles the indexing generically)
     for log in keys(logs)
         scen_id = 1
         for rs in result_sets
             s_log = getfield(rs, log)
             n_log = getfield(logs, log)
-            rs_scen_len = size(s_log, :scenarios)
+            # coral_cover_log may be nothing for result sets loaded from old stores
+            rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
-            try
-                n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-            catch
-                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+            if !isnothing(s_log)
+                try
+                    n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                catch
+                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                end
             end
 
             scen_id = scen_id + rs_scen_len
         end
     end
 
-    metrics = keys(rs1.outcomes)
-    for m_name in metrics
-        m_dim_names = axes_names(rs1.outcomes[m_name])
-        properties = rs1.outcomes[m_name].properties
-        dim_struct = Dict{Symbol,Any}(
-            :structure => m_dim_names,
-            :metric_name => properties[:metric_name],
-            :metric_unit => properties[:metric_unit],
-            :axes_names => properties[:axes_names],
-            :axes_units => properties[:axes_units]
-        )
-        if :locations in m_dim_names
-            dim_struct[:unique_loc_ids] = rs1.loc_ids
-        end
-
-        result_dims = (size(rs1.outcomes[m_name])[1:(end - 1)]..., n_scenarios)
-        m_store = zcreate(
-            Float32,
-            result_dims...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(
-                z_store.folder,
-                RESULTS,
-                string(m_name)),
-            chunks=(result_dims[1:(end - 1)]..., 1),
-            attrs=dim_struct,
-            compressor=COMPRESSOR
-        )
-
-        # Copy results over
+    # Create combined location-based metrics store
+    tf_len = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :timesteps)
+    n_locs = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :locations)
+    n_loc_metrics = length(LOC_METRIC_NAMES)
+    loc_dims = (tf_len, n_locs, n_loc_metrics, n_scenarios)
+    loc_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
+            :unique_loc_ids => rs1.loc_ids,
+            :metrics => string.(LOC_METRIC_NAMES)
+        ),
+        compressor=COMPRESSOR
+    )
+    for (m_idx, m_name) in enumerate(LOC_METRIC_NAMES)
         scen_id = 1
         for rs in result_sets
             rs_scen_len = size(rs.outcomes[m_name], :scenarios)
-            try
-                m_store[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            catch
-                m_store[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            end
-
-            scen_id = scen_id + rs_scen_len
+            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[m_name]
+            scen_id += rs_scen_len
         end
+    end
+
+    # Taxa cover metric (groups axis instead of locations — kept as its own store)
+    taxa_name = :relative_taxa_cover
+    taxa_dims = (size(rs1.outcomes[taxa_name])[1:(end - 1)]..., n_scenarios)
+    taxa_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
+        chunks=(taxa_dims[1:(end - 1)]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "groups", "scenarios")
+        ),
+        compressor=COMPRESSOR
+    )
+    scen_id = 1
+    for rs in result_sets
+        rs_scen_len = size(rs.outcomes[taxa_name], :scenarios)
+        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[taxa_name]
+        scen_id += rs_scen_len
     end
 
     # Copy env stats

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -198,8 +198,6 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
     # Store ranked location
     n_interventions = length(interventions())
     rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, n_interventions, n_scens)  # locations, location id and rank, no. scenarios
-    fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_locs, n_scens)  # timeframe, location, no. scenarios
-
     # tf, no. species to seed, location id and rank, no. scenarios
     seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_groups, n_locs, n_scens)
 
@@ -244,29 +242,20 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         attrs=attrs
     )
 
-    attrs = Dict(
-        :structure => ("timesteps", "locations", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
-    )
-    fog_log = zcreate(
+    shading_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, 2, n_scens)
+    shading_log = zcreate(
         Float32,
-        fog_dims...;
-        name="fog",
+        shading_dims...;
+        name="shading_log",
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
-    )
-    shade_log = zcreate(
-        Float32,
-        fog_dims...;
-        name="shade",
-        fill_value=nothing,
-        fill_as_missing=false,
-        path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
+        chunks=(shading_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "intervention", "scenarios"),
+            :interventions => ["fog", "shade"],
+            :unique_loc_ids => unique_loc_ids
+        )
     )
 
     # TODO: Could log bleaching mortality
@@ -319,33 +308,33 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             n_locs,
             n_scens;
             name="coral_cover_log",
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, 1),
             attrs=attrs
         )
     else
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             1,
             n_scens;
             name="coral_cover_log",
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_group_and_size, 1, 1),
             attrs=attrs
         )
     end
 
-    return ranks, mc_log, seed_log, fog_log, shade_log, coral_dhw_log, coral_cover_log
+    return ranks, mc_log, seed_log, shading_log, coral_dhw_log, coral_cover_log
 end
 
 """
@@ -446,70 +435,57 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     tf, n_locations, _ = size(domain.dhw_scens)
     n_scenarios = nrow(scen_spec)
 
-    # Set up stores for each metric
-    function dim_lengths(metric_structure::Vector{Symbol})
-        dl = []
-        for d in metric_structure
-            if d == :timesteps
-                append!(dl, tf)
-            elseif d == :groups
-                append!(dl, domain.coral_growth.n_groups)
-            elseif d == :locations
-                append!(dl, n_locations)
-            elseif d == :scenarios
-                append!(dl, n_scenarios)
-            end
-        end
+    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
+    n_groups = domain.coral_growth.n_groups
 
-        return (dl...,)
-    end
-
-    outcome_metrics::Vector{metrics.Metric} = [
+    # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
+    loc_outcome_metrics::Vector{metrics.Metric} = [
         metrics.relative_cover,
         metrics.relative_shelter_volume,
         metrics.absolute_shelter_volume,
         metrics.relative_juveniles,
         metrics.juvenile_indicator,
-        metrics.coral_evenness,
-        metrics.relative_taxa_cover
+        metrics.coral_evenness
     ]
-
-    metric_symbols::Vector{Symbol} = metrics.to_symbol.(outcome_metrics)
-    metric_names::Vector{String} = metrics.to_string.(outcome_metrics; is_titlecase=true)
-    metric_units::Vector{String} = getfield.(outcome_metrics, :unit)
-    axis_names::Vector{Vector{Symbol}} = fill(
-        [:timesteps, :locations, :scenarios], length(outcome_metrics) - 1
-    )
-    # Add axis names relative to the last metric (relative_taxa_cover) separate as they are
-    # different from the other metrics
-    push!(axis_names, [:timesteps, :groups, :scenarios])
-    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
-
-    outcomes_attrs::Vector{Dict{Symbol,Any}} = [
-        Dict(
+    n_loc_metrics = length(loc_outcome_metrics)
+    loc_dims = (tf, n_locations, n_loc_metrics, n_scenarios)
+    loc_outcomes_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
-            :structure => axis_names[idx],
-            :metric_name => metric_names[idx],
-            :metric_unit => metric_units[idx],
-            :axes_names => axis_names[idx],
-            :axes_units => metrics.axes_units(axis_names[idx])
-        ) for (idx, _) in enumerate(metric_symbols)
-    ]
-    result_dims::Vector{NTuple{3,Int64}} = dim_lengths.(axis_names)
+            :metrics => string.(LOC_METRIC_NAMES),
+            :metric_names => metrics.to_string.(loc_outcome_metrics; is_titlecase=true),
+            :metric_units => getfield.(loc_outcome_metrics, :unit),
+            :axes_units => metrics.axes_units([:timesteps, :locations, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
-    # Create stores for each metric
-    stores = [
-        zcreate(
-            Float32,
-            result_dims[idx]...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(z_store.folder, RESULTS, string(m_name)),
-            chunks=(result_dims[idx][1:(end - 1)]..., 1),
-            attrs=outcomes_attrs[idx],
-            compressor=COMPRESSOR
-        ) for (idx, m_name) in enumerate(metric_symbols)
-    ]
+    # Separate store for relative_taxa_cover (timesteps × groups × scenarios)
+    taxa_cover_metric = metrics.relative_taxa_cover
+    taxa_dims = (tf, n_groups, n_scenarios)
+    taxa_cover_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
+        chunks=(taxa_dims[1:2]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "groups", "scenarios"),
+            :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
+            :metric_unit => taxa_cover_metric.unit,
+            :axes_names => [:timesteps, :groups, :scenarios],
+            :axes_units => metrics.axes_units([:timesteps, :groups, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
     # dhw and wave zarrays
     dhw_stats = []
@@ -557,7 +533,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Group all data stores
     stores = [
-        stores...,
+        loc_outcomes_store,
+        taxa_cover_store,
         dhw_stats...,
         wave_stats...,
         connectivity...,
@@ -567,7 +544,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             nrow(scen_spec),
             tf,
             n_locations,
-            domain.coral_growth.n_groups,
+            n_groups,
             domain.coral_growth.n_sizes
         )...
     ]
@@ -576,14 +553,14 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     (;
         zip(
             (
-                metric_symbols...,
+                :loc_outcomes,
+                :relative_taxa_cover,
                 stat_store_names...,
                 conn_names...,
                 :site_ranks,
                 :mc_log,
                 :seed_log,
-                :fog_log,
-                :shade_log,
+                :shading_log,
                 :coral_dhw_log,
                 :coral_cover_log
             ),
@@ -730,10 +707,27 @@ function load_results(result_loc::String)::ResultSet
     outcome_properties = [:metric_name, :metric_unit, :axes_names, :axes_units]
     subdirs = filter(isdir, readdir(joinpath(result_loc, RESULTS); join=true))
     for sd in subdirs
+        sd_name = Symbol(basename(sd))
         data = zopen(sd; fill_as_missing=false)
         data_size = size(data)
 
-        # Construct dimension names and metadata
+        if sd_name == Symbol(LOC_METRICS)
+            # New combined format: split lazily back into individual named outcomes
+            metric_syms = Symbol.(data.attrs["metrics"])
+            combined = DataCube(
+                data;
+                timesteps=input_set.attrs["timeframe"],
+                locations=data.attrs["unique_loc_ids"],
+                metrics=string.(metric_syms),
+                scenarios=1:data_size[4]
+            )
+            for m_name in metric_syms
+                outcomes[m_name] = combined[metrics=At(string(m_name))]
+            end
+            continue
+        end
+
+        # Construct dimension names and metadata (handles relative_taxa_cover and old-format stores)
         dim_names = []
         for (idx, dim_name) in enumerate(data.attrs["structure"])
             if dim_name == "timesteps"
@@ -746,10 +740,11 @@ function load_results(result_loc::String)::ResultSet
         end
 
         try
-            outcomes[Symbol(basename(sd))] = DataCube(
+            outcomes[sd_name] = DataCube(
                 data;
                 properties=Dict(
                     p => data.attrs[string(p)] for p in outcome_properties
+                    if haskey(data.attrs, string(p))
                 ),
                 zip(Symbol.(data.attrs["structure"]), dim_names)...
             )
@@ -761,7 +756,7 @@ function load_results(result_loc::String)::ResultSet
                 Structure: $(data.attrs["structure"])
                 Generated: $(Array([i[1] for i in size.(dim_names)]))
                 """
-                outcomes[Symbol(basename(sd))] = DataCube(
+                outcomes[sd_name] = DataCube(
                     data;
                     zip(Symbol.(data.attrs["structure"]), [1:s for s in size(data)])...
                 )

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -175,9 +175,9 @@ function scenario_attributes(domain::Domain, param_df::DataFrame)::Dict{Symbol,A
 end
 
 """
-    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
 
-Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
+Setup logs for ranks, seed_log, shading_log, coral_dhw_log, and coral_cover_log.
 
 # Arguments
 - `z_store` : ZArray
@@ -187,10 +187,12 @@ Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
 - `n_locs` : number of location
 - `n_groups` : number of functional groups
 - `n_sizes` : number of size classes
+- `batch_size` : chunk size along the scenarios dimension; set to the write batch size so
+  that each batch write lands in exactly one chunk file per array.
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
     # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -213,7 +215,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(rank_dims[1:3]..., 1),
+        chunks=(rank_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -228,7 +230,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
     mc_log = zcreate(
@@ -238,7 +240,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -250,7 +252,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(shading_dims[1:3]..., 1),
+        chunks=(shading_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "intervention", "scenarios"),
             :interventions => ["fog", "shade"],
@@ -284,7 +286,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_groups * n_sizes, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -298,7 +300,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_groups * n_sizes, 1, batch_size),
             attrs=attrs
         )
     end
@@ -315,7 +317,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -329,7 +331,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, 1, 1),
+            chunks=(tf, n_group_and_size, 1, batch_size),
             attrs=attrs
         )
     end
@@ -349,20 +351,17 @@ Sets up an on-disk result store.
 ├───env_stats
 ├───inputs
 ├───logs
-|   ├───coral_cover_log
-|   ├───coral_dhw_log
-│   ├───fog
+│   ├───coral_cover_log  (full shape when ADRIA_LOG_COVER=true, 1-location dummy otherwise)
+│   ├───coral_dhw_log    (full shape when ADRIA_LOG_DHW_TOLS=true, 1-location dummy otherwise)
+│   ├───moving_corals
 │   ├───rankings
 │   ├───seed
-│   └───shade
+│   └───shading_log      (fog and shade combined along an intervention axis)
 ├───model_spec
 ├───results
-|   ├───absolute_shelter_volume
-|   ├───coral_evenness
-|   ├───juvenile_indicator
-│   ├───relative_cover
-|   ├───relative_juveniles
-│   ├───relative_shelter_volume
+│   ├───loc_outcomes     (relative_cover, relative_shelter_volume, absolute_shelter_volume,
+│   │                     relative_juveniles, juvenile_indicator, coral_evenness combined
+│   │                     along a metrics axis)
 │   └───relative_taxa_cover
 └───spatial
 ```
@@ -374,14 +373,17 @@ Sets up an on-disk result store.
 # Notes
 - `domain` is replaced with an identical copy with an updated scenario invoke time.
 - -9999.0 is used as an arbitrary fill value.
+- `loc_outcomes` is split back into individually named outcomes on load (see `load_results`).
+- `shading_log` has shape `(timesteps, locations, intervention, scenarios)` where the
+  intervention axis holds `["fog", "shade"]` in that order.
 
 # Arguments
 - `domain` : ADRIA scenario domain
 - `scen_spec` : ADRIA scenario specification
 
 # Returns
-domain, (relative_cover, relative_shelter_volume, absolute_shelter_volume, relative_juveniles,
-juvenile_indicator, relative_taxa_cover, site_ranks, seed_log, fog_log, shade_log)
+domain, (loc_outcomes, relative_taxa_cover, site_ranks, mc_log, seed_log, shading_log,
+coral_dhw_log, coral_cover_log)
 """
 function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     @set! domain.scenario_invoke_time = replace(
@@ -437,6 +439,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
     n_groups = domain.coral_growth.n_groups
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), n_scenarios)
 
     # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
     loc_outcome_metrics::Vector{metrics.Metric} = [
@@ -455,7 +458,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
-        chunks=(loc_dims[1:3]..., 1),
+        chunks=(loc_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
@@ -476,7 +479,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
-        chunks=(taxa_dims[1:2]..., 1),
+        chunks=(taxa_dims[1:2]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "groups", "scenarios"),
             :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
@@ -545,7 +548,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             tf,
             n_locations,
             n_groups,
-            domain.coral_growth.n_sizes
+            domain.coral_growth.n_sizes,
+            batch_size
         )...
     ]
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -192,6 +192,9 @@ function run_scenarios(
     env_num_cores = ENV["ADRIA_NUM_CORES"]
     @info "ADRIA_NUM_CORES = $env_num_cores"
 
+    batch_size::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32"))
+    @info "ADRIA_BATCH_SIZE = $batch_size"
+
     is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
     para_threshold::Int64 = is_RME_based ? 8 : 20
     active_cores::Int64 = parse(Int64, env_num_cores)
@@ -201,45 +204,45 @@ function run_scenarios(
         spinup_time = @elapsed begin
             _setup_workers()
 
-            # Load ADRIA on workers and define helper function
-            # Note: Workers do not share the same cache in parallel workloads.
-            #       Previously, cache would be reserialized so each worker has access to
-            #       a separate cache.
-            #       Using CachingPool() resolves the the repeated reserialization but it
-            #       seems each worker was then attempting to use the same cache, causing the
-            #       Julia kernel to crash in multi-processing contexts.
-            #       Getting each worker to create its own cache reduces serialization time
-            #       (at the cost of increased run time) but resolves the kernel crash issue.
+            # Load ADRIA on workers. Workers only run _collect_scenario_results; all
+            # disk I/O is done on the main process via _write_batch!, so data_store is
+            # never serialised to workers and there are no concurrent chunk writes.
             @sync @async @everywhere @eval begin
                 using ADRIA
-                func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
             end
         end
 
         @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
-    if parallel
-        # Define local helper
-        func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
+    # collect_func captures only functional_groups (no data_store) so serialisation cost
+    # to workers is minimal and disk writes are always single-threaded.
+    collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
 
+    if parallel
         try
             for rcp in RCP
                 run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-                # Switch RCPs so correct data is loaded
                 dom = switch_RCPs!(dom, rcp)
                 target_rows = findall(
                     scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
                 )
-                scen_args = _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                scen_args = collect(
+                    _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                )
 
+                batches = Iterators.partition(scen_args, batch_size)
                 if show_progress
-                    @showprogress desc = run_msg dt = 4 pmap(
-                        func, CachingPool(workers()), scen_args
-                    )
+                    @showprogress desc = run_msg dt = 4 for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 else
-                    pmap(func, CachingPool(workers()), scen_args)
+                    for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 end
             end
         catch err
@@ -248,22 +251,25 @@ function run_scenarios(
             rethrow(err)
         end
     else
-        # Define local helper
-        func = dfx -> run_scenario(dfx..., functional_groups, data_store)
-
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-            # Switch RCPs so correct data is loaded
             dom = switch_RCPs!(dom, rcp)
-            scen_args = _scenario_args(
-                dom, scenarios_matrix, rcp, size(scenarios_matrix, 1)
+            scen_args = collect(
+                _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
 
+            batches = Iterators.partition(scen_args, batch_size)
             if show_progress
-                @showprogress desc = run_msg dt = 4 map(func, scen_args)
+                @showprogress desc = run_msg dt = 4 for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             else
-                map(func, scen_args)
+                for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             end
         end
     end
@@ -289,6 +295,159 @@ function _scenario_args(dom, scenarios_matrix::YAXArray, rcp::String, n::Int)
     return zip(
         rep_doms, target_rows, eachrow(scenarios_matrix[target_rows, :])
     )
+end
+
+"""
+    _collect_scenario_results(domain, scenario, functional_groups)
+
+Run one scenario and return all computed metric arrays without writing to disk.
+Called by `run_scenario` (single write) and by the batched pmap path in `run_scenarios`.
+"""
+function _collect_scenario_results(
+    domain::Domain,
+    scenario::Union{AbstractVector,DataFrameRow},
+    functional_groups::Vector{Vector{FunctionalGroup}}
+)::NamedTuple
+    result_set = run_model(domain, scenario, functional_groups)
+    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
+
+    rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # 6 location-based metrics — order must match LOC_METRIC_NAMES
+    loc_out = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES))
+    vals = relative_cover(rs_raw);                      vals[vals .< threshold] .= 0.0; loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 3] .= vals
+    vals = relative_juveniles(rs_raw);                  vals[vals .< threshold] .= 0.0; loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk);  vals[vals .< threshold] .= 0.0; loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data);               vals[vals .< threshold] .= 0.0; loc_out[:, :, 6] .= vals
+
+    # Taxa cover (groups axis, not locations)
+    taxa_vals = relative_taxa_cover(rs_raw, lk)
+    taxa_vals[taxa_vals .< threshold] .= 0.0
+
+    # Fog and shade combined into a single (tf, n_locs, 2) buffer
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0f0
+    shade_vals[shade_vals .< threshold] .= 0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+
+    # Remaining log arrays — apply threshold where possible
+    site_ranks_vals = result_set.site_ranks
+    try; site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0); catch err; err isa MethodError ? nothing : rethrow(err); end
+
+    mc_vals = result_set.mc_log
+    mc_vals[mc_vals .< threshold] .= Float32(0.0)
+
+    seed_vals = result_set.seed_log
+    seed_vals[seed_vals .< threshold] .= Float32(0.0)
+
+    # coral_dhw_log / coral_cover_log are false when their env var is disabled
+    dhw_vals = result_set.coral_dhw_log
+    cover_vals = result_set.coral_cover_log
+
+    return (
+        loc_out=loc_out,
+        taxa_cover=taxa_vals,
+        shading=shading_buf,
+        site_ranks=site_ranks_vals,
+        mc_log=mc_vals,
+        seed_log=seed_vals,
+        coral_dhw_log=dhw_vals,
+        coral_cover_log=cover_vals
+    )
+end
+
+"""
+    _write_batch!(data_store, start_idx, results)
+
+Write a contiguous batch of collected scenario results to the Zarr data store.
+All arrays in the batch are stacked into a single in-memory buffer and written in one
+Zarr call per array, so the entire batch lands in a single chunk file per array.
+"""
+function _write_batch!(
+    data_store::NamedTuple, start_idx::Int, results::AbstractVector
+)::Nothing
+    n = length(results)
+    idx_range = start_idx:(start_idx + n - 1)
+
+    # loc_outcomes: (tf, n_locs, n_metrics, n)
+    tf, n_locs, n_metrics = size(results[1].loc_out)
+    loc_batch = Array{Float32}(undef, tf, n_locs, n_metrics, n)
+    for (i, r) in enumerate(results)
+        loc_batch[:, :, :, i] .= r.loc_out
+    end
+    data_store.loc_outcomes[:, :, :, idx_range] .= loc_batch
+
+    # relative_taxa_cover: (tf, n_groups, n)
+    _, n_groups = size(results[1].taxa_cover)
+    taxa_batch = Array{Float32}(undef, tf, n_groups, n)
+    for (i, r) in enumerate(results)
+        taxa_batch[:, :, i] .= r.taxa_cover
+    end
+    data_store.relative_taxa_cover[:, :, idx_range] .= taxa_batch
+
+    # shading_log: (tf, n_locs, 2, n)
+    shading_batch = Array{Float32}(undef, tf, n_locs, 2, n)
+    for (i, r) in enumerate(results)
+        shading_batch[:, :, :, i] .= r.shading
+    end
+    data_store.shading_log[:, :, :, idx_range] .= shading_batch
+
+    # site_ranks: (tf, n_locs, n_interventions, n)
+    if !isnothing(data_store.site_ranks)
+        _, _, n_ivs = size(results[1].site_ranks)
+        ranks_batch = Array{Float32}(undef, tf, n_locs, n_ivs, n)
+        for (i, r) in enumerate(results)
+            ranks_batch[:, :, :, i] .= r.site_ranks
+        end
+        data_store.site_ranks[:, :, :, idx_range] .= ranks_batch
+    end
+
+    # mc_log and seed_log: (tf, n_groups, n_locs, n)
+    _, n_g, n_l = size(results[1].mc_log)
+    mc_batch   = Array{Float32}(undef, tf, n_g, n_l, n)
+    seed_batch = Array{Float32}(undef, tf, n_g, n_l, n)
+    for (i, r) in enumerate(results)
+        mc_batch[:, :, :, i]   .= r.mc_log
+        seed_batch[:, :, :, i] .= r.seed_log
+    end
+    data_store.mc_log[:, :, :, idx_range]   .= mc_batch
+    data_store.seed_log[:, :, :, idx_range] .= seed_batch
+
+    # coral_dhw_log (conditional on ADRIA_LOG_DHW_TOLS)
+    if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
+        dhw_r = results[1].coral_dhw_log
+        if dhw_r !== false && !isnothing(dhw_r)
+            _, n_sp, n_ld = size(dhw_r)
+            dhw_batch = Array{Float32}(undef, tf, n_sp, n_ld, n)
+            for (i, r) in enumerate(results)
+                dhw_batch[:, :, :, i] .= r.coral_dhw_log
+            end
+            data_store.coral_dhw_log[:, :, :, idx_range] .= dhw_batch
+        end
+    end
+
+    # coral_cover_log (conditional on ADRIA_LOG_COVER)
+    if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
+        cc_r = results[1].coral_cover_log
+        if cc_r !== false && !isnothing(cc_r)
+            _, n_sp_c, n_lc = size(cc_r)
+            cc_batch = Array{Float32}(undef, tf, n_sp_c, n_lc, n)
+            for (i, r) in enumerate(results)
+                cc_batch[:, :, :, i] .= r.coral_cover_log
+            end
+            data_store.coral_cover_log[:, :, :, idx_range] .= cc_batch
+        end
+    end
+
+    return nothing
 end
 
 """
@@ -332,94 +491,8 @@ function run_scenario(
         domain = switch_RCPs!(domain, rcp)
     end
 
-    result_set = run_model(domain, scenario, functional_groups)
-
-    # Capture results to disk
-    # Set values below threshold to 0 to save space
-    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
-
-    # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
-    rs_raw::Array{Float64} = result_set.raw
-    lk = loc_k_area(domain)
-    coral_spec::DataFrame = to_coral_spec(scenario)
-
-    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
-    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
-    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
-    loc_out = Array{Float32}(
-        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
-    )
-
-    vals = relative_cover(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 1] .= vals
-    vals = relative_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 2] .= vals
-    vals = absolute_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 3] .= vals
-    vals = relative_juveniles(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 4] .= vals
-    vals = juvenile_indicator(rs_raw, coral_spec, lk)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 5] .= vals
-    rtc_vals = relative_loc_taxa_cover(rs_raw)
-    vals = coral_evenness(rtc_vals.data)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 6] .= vals
-
-    data_store.loc_outcomes[:, :, :, idx] .= loc_out
-
-    # Taxa cover uses a groups axis rather than locations — kept as its own store
-    vals = relative_taxa_cover(rs_raw, lk)
-    vals[vals .< threshold] .= 0.0
-    data_store.relative_taxa_cover[:, :, idx] .= vals
-
-    # Write fog and shade together as a single 4-D shading_log chunk
-    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
-    fog_vals = Matrix{Float32}(result_set.fog_log)
-    shade_vals = Matrix{Float32}(result_set.shade_log)
-    fog_vals[fog_vals .< threshold] .= 0.0f0
-    shade_vals[shade_vals .< threshold] .= 0.0f0
-    shading_buf[:, :, 1] .= fog_vals
-    shading_buf[:, :, 2] .= shade_vals
-    data_store.shading_log[:, :, :, idx] .= shading_buf
-
-    # Store remaining logs
-    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
-    for k in log_stores
-        vals = getfield(result_set, k)
-
-        if vals === false || isnothing(vals)
-            continue
-        end
-
-        try
-            vals[vals .< threshold] .= Float32(0.0)
-        catch err
-            err isa MethodError ? nothing : rethrow(err)
-        end
-
-        if k == :seed_log || k == :mc_log
-            getfield(data_store, k)[:, :, :, idx] .= vals
-        elseif k == :site_ranks
-            if !isnothing(data_store.site_ranks)
-                # Squash site ranks down to average rankings over environmental repeats
-                data_store.site_ranks[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_dhw_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_cover_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        end
-    end
-
+    result = _collect_scenario_results(domain, scenario, functional_groups)
+    _write_batch!(data_store, idx, [result])
     return nothing
 end
 function run_scenario(

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -340,55 +340,61 @@ function run_scenario(
 
     # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
     rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
+    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
+    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
+    loc_out = Array{Float32}(
+        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
+    )
+
     vals = relative_cover(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_cover[:, :, idx] .= vals
-
-    vals = absolute_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.absolute_shelter_volume[:, :, idx] .= vals
-    vals = relative_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_shelter_volume[:, :, idx] .= vals
-
-    coral_spec::DataFrame = to_coral_spec(scenario)
+    loc_out[:, :, 3] .= vals
     vals = relative_juveniles(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_juveniles[:, :, idx] .= vals
-
-    vals = juvenile_indicator(rs_raw, coral_spec, loc_k_area(domain))
+    loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk)
     vals[vals .< threshold] .= 0.0
-    data_store.juvenile_indicator[:, :, idx] .= vals
+    loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 6] .= vals
 
-    vals = relative_taxa_cover(rs_raw, loc_k_area(domain))
+    data_store.loc_outcomes[:, :, :, idx] .= loc_out
+
+    # Taxa cover uses a groups axis rather than locations — kept as its own store
+    vals = relative_taxa_cover(rs_raw, lk)
     vals[vals .< threshold] .= 0.0
     data_store.relative_taxa_cover[:, :, idx] .= vals
 
-    vals = relative_loc_taxa_cover(rs_raw)
+    # Write fog and shade together as a single 4-D shading_log chunk
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0.0f0
+    shade_vals[shade_vals .< threshold] .= 0.0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+    data_store.shading_log[:, :, :, idx] .= shading_buf
 
-    vals = coral_evenness(vals.data)
-    vals[vals .< threshold] .= 0.0
-    data_store.coral_evenness[:, :, idx] .= vals
-
-    # Store logs
-    c_dim = Base.ndims(result_set.raw) + 1
-    log_stores = (
-        :site_ranks,
-        :mc_log,
-        :seed_log,
-        :fog_log,
-        :shade_log,
-        :coral_dhw_log,
-        :coral_cover_log
-    )
+    # Store remaining logs
+    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
     for k in log_stores
-        if k == :seed_log || k == :site_ranks
-            concat_dim = c_dim
-        else
-            concat_dim = c_dim - 1
-        end
-
         vals = getfield(result_set, k)
+
+        if vals === false || isnothing(vals)
+            continue
+        end
 
         try
             vals[vals .< threshold] .= Float32(0.0)
@@ -411,8 +417,6 @@ function run_scenario(
             if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
                 getfield(data_store, k)[:, :, :, idx] .= vals
             end
-        else
-            getfield(data_store, k)[:, :, idx] .= vals
         end
     end
 


### PR DESCRIPTION
This pull request significantly refactors the way scenario results are stored and processed, focusing on improving I/O performance and scalability for parallel runs, alongside important documentation updates.

**Zarr Data Store Consolidation**
Consolidates related outcome metrics and intervention logs into more efficient Zarr array structures:
- Combines the six location-based outcome metrics (e.g., `relative_cover`, `relative_shelter_volume`) into a single `loc_outcomes` store, introducing a new `metrics` axis. This reduces the number of individual Zarr arrays and simplifies data access.
- Merges `fog_log` and `shade_log` into a single `shading_log` store, adding an `intervention` axis to differentiate between the two.
- Introduces an `_load_shading_log` function to ensure backward compatibility when loading results from older stores that used separate `fog` and `shade` logs.
- Updates internal data structures and functions to seamlessly work with these new combined stores.

**Batched Zarr Writes for Parallel Runs**
Improves performance for parallel scenario executions by implementing batched writes to the Zarr data store:
- Separates scenario computation from disk I/O, allowing worker processes to only compute results (`_collect_scenario_results`) and return them to the main process.
- Introduces `_write_batch!`, a new function on the main process responsible for efficiently writing a batch of collected results to Zarr. This reduces I/O overhead by writing contiguous blocks of data to single chunks.
- Adds support for an `ADRIA_BATCH_SIZE` environment variable to control the size of these write batches.

**Documentation Improvements**
Clarifies instructions for setting the `JULIA_DEPOT_PATH` environment variable:
- Provides detailed guidance for Linux (`.bashrc`), Windows (control panel), and VS Code (`settings.json`).
- Adds a new example for setting the variable temporarily in Windows Powershell.
- Includes an additional reference link to Julia's Pkg documentation for platform-specific configuration.

**Minor Adjustments**
- Fixes an error in `load_results` by safely checking for `haskey` before accessing outcome properties.
- Simplifies the `ADRIA.viz.map` function by removing the `title` parameter and associated colorbar display logic.