### PR TITLE
Outcome mapping documentation

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -536,17 +536,35 @@ save("rsa.png", rsa_fig)
 
 ### Outcome mapping
 
-A monte-carlo filtering approach similar to Regional Sensitivity Analysis.
+As the name implies, outcome mapping aims to identify the relationship between model outputs and the region of factor space that led to those outputs.
+Similarly to Regional Sensitivity Analysis, it does this by filtering scenarios that match a specific outcome.
 
-As the name implies, outcome mapping aids in identifying the relationship between model
-outputs and the region of factor space that led to those outputs.
+This implementation then calculates the mean value of an outcome as a function of a factor.
+This is a form of scenario discovery that summarises scenarios matching an outcome in terms of values of a factor and the average value of one outcome.
+
+This example aims to identify DHW and wave scenarios and interventions which lead to top outcomes for coral cover. Note that it uses a test dataset rather than real data.
 
 ```julia
+# As outcome, we are looking at total coral cover, averaged over time
+s_tac = ADRIA.metrics.scenario_total_cover(rs)
 mean_s_tac = dropdims(mean(s_tac, dims=1), dims=1)
+
+# Factors of interest to investigate
+foi = [
+    :dhw_scenario, # DHW scenarios 1-50 in the test dataset
+    :wave_scenario, # Wave scenarios 1-50 in the test dataset
+    # Interventions
+    :N_seed_TA, # Number of seeded Tabular Acropora deployed per intervention event
+    :N_seed_CA, # Number of seeded Corymbose Acropora deployed per intervention event
+    :fogging, # Fogging effectiveness on a scale of 0-1
+    :SRM # Reduction in DHW obtained by shading
+]
 
 tf = Figure(size=(1600, 1200))  # size of figure
 
-# Indicate factor values that are in the top 50 percentile
+# Indicate factor values that are in the top half of the range
+#   mean_s_tac is normalised to [0,1], so 0.5 is half-way between the minimum and maximum values
+# Split each factor into 20 bins
 tac_top_50 = ADRIA.sensitivity.outcome_map(rs, mean_s_tac, x -> any(x .>= 0.5), foi; S=20)
 ADRIA.viz.outcome_map!(
     tf[1, 1],
@@ -556,7 +574,7 @@ ADRIA.viz.outcome_map!(
     axis_opts=Dict(:title => "Regions which lead to Top 50th Percentile Outcomes", :ylabel => "TAC [m²]")
 )
 
-# Indicate factor values that are in the top 30 percentile
+# Indicate factor values that are in the top 30% of the range
 tac_top_30 = ADRIA.sensitivity.outcome_map(rs, mean_s_tac, x -> any(x .>= 0.7), foi; S=20)
 ADRIA.viz.outcome_map!(
     tf[2, 1],
@@ -569,6 +587,40 @@ save("outcome_map.png", tf)
 ```
 
 ![Outcome mapping](../assets/imgs/analysis/outcome_map.png)
+
+The figure shows the mean values of total coral cover (TAC) obtained as a function of each factor value, across scenarios in which outcomes in the top 50% or 30% of the range are obtained. The ribbon shows the estimated 95% confidence interval around the mean.
+
+There is less uncertainty in the mean for the top 30% because there were fewer scenarios in this group. The top 30% scenarios are a subset of the scenarios in the top 50%.
+
+While this example uses a test data package rather than real data, we can still interpret the results:
+
+- DHW scenario:
+  - These are categorical values representing 50 different scenarios. There is no specific order to the scenarios - they are just interpreted individually.
+  - Note that as `S=20`, only 20 bins are shown - multiple scenarios have been aggregated.
+  - All 50 scenarios are represented in the top 50% of the range - it is possible to get results in the top half of the range in all scenarios. Coral cover is higher in scenarios ~20-25, ~35 and ~40, and lower in scenarios ~15 and ~45. To interpret this, we would need to look at the definition of those scenarios.
+  - In the top 30% of the range, only some scenarios are represented. For the DHW scenarios that are missing, none of the combinations of factors sampled are able to achieve results in the top 30% of the range.
+- Wave scenario: categorical variable representing each scenario in the test data package
+  - Note: Wave scenarios are no longer active as of ADRIA v0.7.0
+- Seeded Tabular Acropora and Seeded Corymbose Acropora
+  - Coral cover in the scenarios varies substantially as number of seeded corals increase. There is substantial uncertainty in the mean, but even so there is no clear pattern. Outcomes are likely more heavily influenced by other factors in the scenario set.
+  - Top 30% scenarios are obtained even with fewer seeded corals, though in fewer scenarios - there is very little uncertainty in the mean.
+- Fogging:
+  - Similar to seeding, there is no clear pattern to coral cover as fogging effectiveness increases.
+  - Only scenarios with at least 0.1 fogging effectiveness are in the top 30% of the range.
+- SRM: 
+  - As expected, coral cover increases with shade (decreases with DHW) in both groups of scenarios.
+  - In the top 30% of the range, the scenario with the lowest level of shade still has about 4.5 DHW reduction.
+  - In the top 50% of the range, the scenario with the lowest level of shade still has about 2.5 DHW reduction.
+  - There are very few scenarios in the top 50% with shade giving reductions of less than 3 DHW - there is very little uncertainty in the mean.
+
+For this test dataset, according to this analysis:
+
+1) **Ensuring conditions for success**: Shade (SRM) is dominating the analysis. To be in the top 30% of the range, shade with at least ~4.5 DHW reduction is necessary.  Fogging with an effectiveness of at least 0.1 is also needed. 
+2) **Avoiding failure**: In some DHW scenarios, none of the sampled interventions are able to achieve performance in the top 30% of the range. Whether this is a problem depends on what those scenarios represent.
+3) **Planning for failure modes**: There are DHW scenarios for which high levels of SRM are not in the top 30% of the range - despite its cost, SRM has not delivered. This might warrant investigation as to why SRM was not sufficient in those scenarios.
+4) **Further deliberation**: High levels of SRM may be controversial both in terms of feasibility and cost. There is likely to be further debate about whether these scenarios should be considered, and whether top 30% of the range is an appropriate criteria for success.
+
+Additional sampling may be be needed to confirm findings where no matching scenarios were found.
 
 ### Data Envelopment Analysis
 

--- a/ext/AvizExt/viz/sensitivity.jl
+++ b/ext/AvizExt/viz/sensitivity.jl
@@ -398,17 +398,24 @@ end
     ADRIA.viz.outcome_map!(g::Union{GridLayout,GridPosition}, rs::ResultSet, outcomes::YAXArray, factors::Vector{String}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
     ADRIA.viz.outcome_map!(ax::Axis, outcomes::YAXArray, ms_factor::DataFrame, f_vals::Vector{Float64}; opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}(), axis_opts::Dict{Symbol,<:Any}=Dict{Symbol,Any}())
 
-Plot outcomes mapped to factor regions for up to 30 factors.
+Plot results of `outcome_map` for up to 30 factors.
+
+For each `factor` in `factors`, plot `outcomes` with a ribbon for the `upper` and `lower` bounds and a line for the `mean`.
 
 # Arguments
 - `rs` : ResultSet
-- `outcomes` : ADRIA Outcome Mapping results
-- `factors` : The factors of interest to display
+- `outcomes` : ADRIA Outcome Mapping results for one or more factors
+- `factors` / `factor` : The factor(s) of interest to display
 - `opts` : Additional figure customization options
 - `fig_opts` : Additional options to pass to adjust Figure creation
   See: https://docs.makie.org/v0.19/api/index.html#Figure
 - `axis_opts` : Additional options to pass to adjust Axis attributes
   See: https://docs.makie.org/v0.19/api/index.html#Axis
+- `g` : A `GridLayout` and `GridPosition`
+- `ax` : An Axis
+  See: https://docs.makie.org/v0.19/api/index.html#Axis
+- `ms_factor` : Model specification for one factor
+- `f_vals` : Factor values for one factor, as present in the result set 
 
 # Returns
 Makie figure

--- a/src/analysis/sensitivity.jl
+++ b/src/analysis/sensitivity.jl
@@ -733,16 +733,23 @@ end
     outcome_map(rs::ResultSet, y::AbstractVector{T}, rule::Union{Function,BitVector,Vector{Int64}}, target_factor::Symbol; S::Int64=20, n_boot::Int64=100, conf::Float64=0.95)::YAXArray where {T<:Real}
     outcome_map(rs::ResultSet, y::AbstractVector{T}, rule::Union{Function,BitVector,Vector{Int64}}; S::Int64=20, n_boot::Int64=100, conf::Float64=0.95)::Dataset where {T<:Real}
 
-Map normalized outcomes (defined by `rule`) to factor values discretized into `S` bins.
+Maps the mean outcome obtained in scenarios matching a rule, as a function of factor values discretized into `S` bins.
+
+These methods take a scenario specification (`X`), result set (`rs`), or array of results (`p`), along with a set of outcomes `y`. 
+The outcomes are normalised to [0,1] and a `rule` is applied to determine whether the scenario is kept. 
+For the scenarios retained, the values for `target_factor` are extracted, and discretized into `S` bins.
+For each bin, the mean is calculated, along with a `conf` confidence interval (default 95%) using `n_boot` bootstraps samples of the retained scenarios.
+This process is repeated for each of the specified `target_factors` individually.
 
 Produces a matrix indicating the range of (normalized) outcomes across factor space for
 each dimension (the model inputs). This is similar to a Regional Sensitivity Analysis,
 except that the model outputs are examined directly as opposed to a measure of sensitivity.
 
 Note:
-- `y` is normalized on a per-column basis prior to the analysis
+- `y` is normalized to [0,1] on a per-column basis prior to the analysis
 - Empty areas of factor space (those that do not have any desired outcomes)
   will be assigned `NaN`
+- Categorical variables are also binned. Using fewer bins than there are categories will result in categories being combined.
 
 # Arguments
 - `X` : scenario specification
@@ -750,14 +757,19 @@ Note:
 - `rule` : a callable defining a "desirable" scenario outcome
 - `target_factors` : list of factors of interest to perform analyses on
 - `S` : number of slices of factor space. Higher values equate to finer granularity
-- `n_boot` : number of bootstraps (default: 100)
+- `n_boot` : number of bootstraps (default: 100) to use for calculation of confidence interval of the mean
+  See: https://github.com/juliangehring/Bootstrap.jl
 - `conf` : confidence interval (default: 0.95)
+- `p`: Array of results
+- `X_q` : Factor quantiles for which to calculate bounds. When generated internally, this is of length `S`.
+- `X_f` : Factor values for each scenario
+- `behave`: `BitVector` defining whether each scenario is "behavioural", i.e. satisfies the rule
 
 # Returns
 3-dimensional YAXArray, of shape \$S\$ ⋅ \$D\$ ⋅ 3, where:
 - \$S\$ is the slices,
 - \$D\$ is the number of dimensions, with
-- boostrapped mean (dim 1) and the lower/upper 95% confidence interval (dims 2 and 3).
+- bootstrapped mean (dim 1) and the lower/upper `conf` confidence interval (95% by default) (dims 2 and 3).
 
 # Examples
 ```julia
@@ -770,7 +782,7 @@ foi = [:SRM, :fogging, :a_adapt]
 # Find scenarios where all metrics are above their median
 rule = y -> all(y .> 0.5)
 
-# Map input values where to their outcomes
+# Map input values where rule is met to their outcomes
 ADRIA.sensitivity.outcome_map(X, y, rule, foi; S=20, n_boot=100, conf=0.95)
 ```
 """


### PR DESCRIPTION
As part of work on scenario discovery, I've reviewed and added interpretation to the outcome mapping functionality.

Corrections:

- The method does not actually calculate factor regions. Through the use of bootstrapping, it actually calculates the confidence interval of the mean.
https://github.com/open-AIMS/ADRIA.jl/blob/341a867a7c99e41b4c6058d44f7c7584fd9575e6/src/analysis/sensitivity.jl#L805
- The example does not use percentiles. Min-max normalisation is used but the result is just the same variable rescaled to [0,1]. These do not represent percentiles of the underlying data points.

Clarifications

- Added API description of missing arguments
- Added `s_tac` and `foi` definition based on the original test
https://github.com/open-AIMS/ADRIA.jl/blob/d0ecf31c835896f81f94a9f20091da44d2434ef3/test/analysis.jl#L298

Added
- Emphasised selection of outcome and factors of interest as a key step in the scenario discovery process
- Interpretation in terms of scenario discovery

Out of scope

- Rerunning the example. Mismatched figure labels are therefore not fixed.
- Real world example - I have emphasised that this is based on the test data.