### PR TITLE
find_scenarios documentation

### DIFF
--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -423,6 +423,13 @@ This can be interpreted as a form of scenario discovery where a target group of 
 Here the timeseries represent sites rather than scenarios. 
 Using `summarize`, timeseries for scenarios could be obtained by aggregating over sites.
 
+For this test dataset, findings in terms of scenario discovery suggest:
+
+1) **Ensuring conditions for success**: Low temporal variability in shelter volume involves sites that stay low. Temporal variability would likely not be interpreted as a success metric given that high temporal variability also reflects large declines in shelter volume.
+2) **Avoiding failure**: Both groups show declines across all sites using the median across scenarios. The analysis could be repeated to investigate how behaviour differs across scenarios, particularly in which interventions improve outcomes.
+3) **Planning for failure modes**: The non-target group of sites starts with higher shelter volume. While the median across scenarios declines, further investigation could test whether certain interventions cope better than others with changing conditions.
+4) **Further deliberation**: Discussion would likely further explore performance metrics other than temporal variability, and factors other than sites.
+
 ### Multiple Time Series Clustering
 
 It is possible to perform time series clustering for different metric outcomes and find

--- a/docs/src/usage/analysis.md
+++ b/docs/src/usage/analysis.md
@@ -381,20 +381,22 @@ save("tsc.png", tsc_fig)
 ### Target clusters
 
 One can also target scenarios that belong to specific clusters (like clusters with higher
-median value for some outcome):
+median value for some outcome).
+
+Here we use clustering to identify groups of time series for sites with low temporal variability in shelter volume across scenarios.
 
 ```julia
-# Extract metric from scenarios
+# Time series for each site summarizing median shelter volume (in cubic metres) across all scenarios
 asv = ADRIA.metrics.absolute_shelter_volume(rs)
-
-# Time series summarizing scenarios for each site
 asv_site_series = ADRIA.metrics.loc_trajectory(median, asv)
 
-# Cluster scenarios
+# Cluster sites with similar shelter volume time series
 n_clusters = 6
-asv_clusters = ADRIA.analysis.cluster_scenarios(asv_site_series, n_clusters)
+asv_clusters = ADRIA.analysis.cluster_series(asv_site_series, n_clusters)
 
-# Target scenarios that belong to the two lowest value clusters
+# find_scenarios computes median timeseries for each cluster 
+#   and by default calculates temporal variability of that median timeseries
+# We target sites that belong to the two clusters with lowest temporal variability in shelter volume
 lowest = x -> x .∈ [sort(x; rev=true)[1:2]]
 asv_target = ADRIA.analysis.find_scenarios(asv_site_series, asv_clusters, lowest)
 
@@ -410,6 +412,16 @@ save("tsc_asv.png", tsc_asc_fig)
 ```
 
 ![Plots of targeted lowest clusters](../assets/imgs/analysis/tsc_asv.png)
+
+As expected, we see the sites in the target group have lower temporal variability. The non-target group has larger temporal variability.
+The sites could then be investigated further.
+
+As the sites were selected using the median timeseries of two clusters, there is still a large range of shelter volume across sites at the start of the time series.
+Focusing on the lowest cluster or splitting into more clusters could produce a more homogeneous group of scenarios.
+
+This can be interpreted as a form of scenario discovery where a target group of timeseries is summarised visually.
+Here the timeseries represent sites rather than scenarios. 
+Using `summarize`, timeseries for scenarios could be obtained by aggregating over sites.
 
 ### Multiple Time Series Clustering
 

--- a/src/metrics/spatial.jl
+++ b/src/metrics/spatial.jl
@@ -29,7 +29,7 @@ end
 """
     loc_trajectory(metric, data::YAXArray{D,T,N,A})::YAXArray where {D,T,N,A}
 
-Alias for summarize(data, [:scenarios], metric). Collate trajectory for each location.
+Alias for summarize(data, [:scenarios], metric). Collate trajectory for each location, applying `metric` across values for all scenarios.
 
 # Examples
 ```julia


### PR DESCRIPTION
As part of work on scenario discovery, I've reviewed and added interpretation to the find_scenarios functionality / Target Clusters section.

Corrections:

- Because it uses loc_trajectory, the example actually aggregates out the scenarios and the resulting time series represent different sites, not scenarios. As cluster_scenarios is an alias for cluster_series, I have used the latter. 

Clarifications: 
- loc_trajectory API docs are clear that it is a wrapper around summarize, but I've added some text to emphasise this.
- find_scenarios performs aggregation by both median and temporal variability internally before applying the filter function.

Additions:
- Added interpretation, both of the time series and in terms of scenario discovery

Out of scope:

- Renaming find_scenarios to find_series, which might be a more accurate name given the functionality
- Changing the example to use `summarize` instead of `loc_trajectory` to aggregate over sites rather than scenarios
- There is confusingly a separate function called target_clusters even though this section called Target Clusters uses the find_scenarios function. I haven't changed this as Target Clusters is actually probably the better name.