### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ input/
 output/
 .aider*
 GEMINI.md
+
+graphify-out/
+
+.claudeignore
+
+.claude/
+
+.graphify_python
+
+.graphify_uncached.txt

--- a/Manifest-v1.11.toml
+++ b/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "8e7264f5e17fe8c1bb02d89afbafa975a5b8fe64"
+project_hash = "ce78128babf9e48da5d26f137af75146e3199d09"
 
 [[deps.ADRIAIndicators]]
 git-tree-sha1 = "aaa97fdc8125b525f4b11542cccedc64929826f7"
@@ -509,9 +509,9 @@ version = "0.6.4"
 
 [[deps.CoralBlox]]
 deps = ["DataStructures", "StaticArrays", "YAXArrays"]
-git-tree-sha1 = "22855962954938f08ad881c6312e78f4f5ebb661"
+git-tree-sha1 = "c3ee6d3fcafcd66b0252c2428feb6d8e9a219736"
 uuid = "f00a6e10-004a-11ef-3676-67ec635bc1a2"
-version = "1.1.5"
+version = "1.1.7"
 
     [deps.CoralBlox.extensions]
     CoralBloxPlotExt = "Makie"

--- a/src/decision/strategies/strategies.jl
+++ b/src/decision/strategies/strategies.jl
@@ -60,23 +60,22 @@ function is_periodic(strategy_idx::AbstractVector{T})::BitVector where {T<:Real}
 end
 
 function build_state(domain, strategy, states)
-    target_loc_indices = findall(
-        in.(domain.loc_ids, Ref(strategy.target_locations))
-    )
-    return strategy_status(strategy, states, target_loc_indices)
+    targets = strategy.target_locations
+    mask = in.(domain.loc_ids, Ref(Set{String}(targets)))
+    return strategy_status(strategy, states, mask)
 end
 
 function strategy_status(::DecisionStrategy, states, idx)
     return (
-        current_cover=states.current_cover[idx],
-        recent_cover_losses=first(states.recent_cover_losses)[idx]
+        current_cover=@view(states.current_cover[idx]),
+        recent_cover_losses=@view(first(states.recent_cover_losses)[idx])
     )
 end
 
 function strategy_status(::ReactiveStrategy, states, idx)
     return (
-        current_cover=states.current_cover[idx],
-        recent_cover_losses=first(states.recent_cover_losses)[idx],
-        last_deployment=states.last_deployment[idx]
+        current_cover=@view(states.current_cover[idx]),
+        recent_cover_losses=@view(first(states.recent_cover_losses)[idx]),
+        last_deployment=@view(states.last_deployment[idx])
     )
 end

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -58,7 +58,7 @@ Load shading log from a Zarr log group, handling both the new combined format
 (`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
 """
 function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
-    if "shading_log" in keys(log_set)
+    if haskey(log_set, "shading_log")
         return DataCube(
             log_set["shading_log"],
             Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -256,6 +256,7 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), nrow(all_inputs))
     logs = (;
         zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
@@ -265,7 +266,8 @@ function combine_results(result_sets...)::ResultSet
                 size(rs1.seed_log, :timesteps),
                 size(rs1.seed_log, :locations),
                 size(rs1.seed_log, :coral_id),
-                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id),
+                batch_size
             )
         )...
     )

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -14,6 +14,13 @@ const MODEL_SPEC = "model_spec"
 const RESULTS = "results"
 const SPATIAL_DATA = "spatial"
 
+# Combined store name for the 6 location-based outcome metrics
+const LOC_METRICS = "loc_outcomes"
+const LOC_METRIC_NAMES = [
+    :relative_cover, :relative_shelter_volume, :absolute_shelter_volume,
+    :relative_juveniles, :juvenile_indicator, :coral_evenness
+]
+
 abstract type ResultSet end
 
 struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
@@ -41,10 +48,35 @@ struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
     ranks::A
     mc_log::B  # Values stored in m^2
     seed_log::B  # Values stored in m^2
-    fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
-    shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
+    shading_log::C  # Fog and shade intervention log, dims: (timesteps, locations, intervention, scenarios)
     coral_dhw_tol_log::D3
     coral_cover_log::D4
+end
+
+"""
+Load shading log from a Zarr log group, handling both the new combined format
+(`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
+"""
+function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
+    if "shading_log" in keys(log_set)
+        return DataCube(
+            log_set["shading_log"],
+            Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))
+        )
+    end
+
+    # Old format: two separate (T, L, N) arrays — load and stack into (T, L, 2, N)
+    fog_arr = log_set["fog"][:, :, :]
+    shade_arr = log_set["shade"][:, :, :]
+    tf, n_locs, n_scens = size(fog_arr)
+    combined = Array{Float32}(undef, tf, n_locs, 2, n_scens)
+    combined[:, :, 1, :] .= fog_arr
+    combined[:, :, 2, :] .= shade_arr
+    return DataCube(
+        combined;
+        timesteps=1:tf, locations=1:n_locs,
+        intervention=["fog", "shade"], scenarios=1:n_scens
+    )
 end
 
 function ResultSet(
@@ -84,8 +116,7 @@ function ResultSet(
             Symbol.(Tuple(log_set["moving_corals"].attrs["structure"]))
         ),
         DataCube(log_set["seed"], Symbol.(Tuple(log_set["seed"].attrs["structure"]))),
-        DataCube(log_set["fog"], Symbol.(Tuple(log_set["fog"].attrs["structure"]))),
-        DataCube(log_set["shade"], Symbol.(Tuple(log_set["shade"].attrs["structure"]))),
+        _load_shading_log(log_set),
         DataCube(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
@@ -226,79 +257,88 @@ function combine_results(result_sets...)::ResultSet
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_tol_log, :coral_cover_log],
+        zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
                 z_store,
                 rs1.loc_ids,
                 nrow(all_inputs),
-                n_timesteps,
-                n_locs,
-                n_groups,
-                n_sizes
+                size(rs1.seed_log, :timesteps),
+                size(rs1.seed_log, :locations),
+                size(rs1.seed_log, :coral_id),
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
             )
         )...
     )
 
-    # Copy logs over
+    # Copy logs over (all are 4D; try/catch handles the indexing generically)
     for log in keys(logs)
         scen_id = 1
         for rs in result_sets
             s_log = getfield(rs, log)
             n_log = getfield(logs, log)
-            rs_scen_len = size(s_log, :scenarios)
+            # coral_cover_log may be nothing for result sets loaded from old stores
+            rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
-            try
-                n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-            catch
-                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+            if !isnothing(s_log)
+                try
+                    n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                catch
+                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                end
             end
 
             scen_id = scen_id + rs_scen_len
         end
     end
 
-    metrics = keys(rs1.outcomes)
-    for m_name in metrics
-        m_dim_names = axes_names(rs1.outcomes[m_name])
-        properties = rs1.outcomes[m_name].properties
-        dim_struct = Dict{Symbol,Any}(
-            :structure => m_dim_names,
-            :metric_name => properties[:metric_name],
-            :metric_unit => properties[:metric_unit],
-            :axes_names => properties[:axes_names],
-            :axes_units => properties[:axes_units]
-        )
-        if :locations in m_dim_names
-            dim_struct[:unique_loc_ids] = rs1.loc_ids
-        end
-
-        result_dims = (size(rs1.outcomes[m_name])[1:(end - 1)]..., n_scenarios)
-        m_store = zcreate(
-            Float32,
-            result_dims...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(
-                z_store.folder,
-                RESULTS,
-                string(m_name)),
-            chunks=(result_dims[1:(end - 1)]..., 1),
-            attrs=dim_struct,
-            compressor=COMPRESSOR
-        )
-
-        # Copy results over
+    # Create combined location-based metrics store
+    tf_len = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :timesteps)
+    n_locs = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :locations)
+    n_loc_metrics = length(LOC_METRIC_NAMES)
+    loc_dims = (tf_len, n_locs, n_loc_metrics, n_scenarios)
+    loc_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
+            :unique_loc_ids => rs1.loc_ids,
+            :metrics => string.(LOC_METRIC_NAMES)
+        ),
+        compressor=COMPRESSOR
+    )
+    for (m_idx, m_name) in enumerate(LOC_METRIC_NAMES)
         scen_id = 1
         for rs in result_sets
             rs_scen_len = size(rs.outcomes[m_name], :scenarios)
-            try
-                m_store[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            catch
-                m_store[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            end
-
-            scen_id = scen_id + rs_scen_len
+            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[m_name]
+            scen_id += rs_scen_len
         end
+    end
+
+    # Taxa cover metric (groups axis instead of locations — kept as its own store)
+    taxa_name = :relative_taxa_cover
+    taxa_dims = (size(rs1.outcomes[taxa_name])[1:(end - 1)]..., n_scenarios)
+    taxa_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
+        chunks=(taxa_dims[1:(end - 1)]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "groups", "scenarios")
+        ),
+        compressor=COMPRESSOR
+    )
+    scen_id = 1
+    for rs in result_sets
+        rs_scen_len = size(rs.outcomes[taxa_name], :scenarios)
+        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[taxa_name]
+        scen_id += rs_scen_len
     end
 
     # Copy env stats

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -282,11 +282,7 @@ function combine_results(result_sets...)::ResultSet
             rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
             if !isnothing(s_log)
-                try
-                    n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-                catch
-                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-                end
+                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log
             end
 
             scen_id = scen_id + rs_scen_len

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -257,16 +257,9 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
-    n_cores::Int = parse(Int, get(ENV, "ADRIA_NUM_CORES", "1"))
     env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     n_scenarios = nrow(all_inputs)
-    batch_size::Int = if env_batch > 0
-        min(env_batch, n_scenarios)
-    elseif n_scenarios < n_cores
-        1
-    else
-        n_cores
-    end
+    batch_size::Int = env_batch > 0 ? min(env_batch, n_scenarios) : 1
     logs = (;
         zip(
             [

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -121,7 +121,8 @@ function ResultSet(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
         ),
-        haskey(log_set, "coral_cover_log") ? DataCube(
+        haskey(log_set, "coral_cover_log") ?
+        DataCube(
             log_set["coral_cover_log"],
             Symbol.(Tuple(log_set["coral_cover_log"].attrs["structure"]))
         ) : nothing
@@ -267,7 +268,15 @@ function combine_results(result_sets...)::ResultSet
         n_cores
     end
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
+        zip(
+            [
+                :ranks,
+                :mc_log,
+                :seed_log,
+                :shading_log,
+                :coral_dhw_tol_log,
+                :coral_cover_log
+            ],
             setup_logs(
                 z_store,
                 rs1.loc_ids,
@@ -288,7 +297,8 @@ function combine_results(result_sets...)::ResultSet
             s_log = getfield(rs, log)
             n_log = getfield(logs, log)
             # coral_cover_log may be nothing for result sets loaded from old stores
-            rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
+            rs_scen_len =
+                isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
             if !isnothing(s_log)
                 n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -160,7 +160,7 @@ function _copy_env_data(
 end
 
 """
-    combine(result_sets...)::ResultSet
+    combine_results(result_sets...)::ResultSet
     combine_results(result_set_locs::Array{String})::ResultSet
 
 Combine arbitrary number of ADRIA result sets into a single data store.
@@ -256,7 +256,16 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
-    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), nrow(all_inputs))
+    n_cores::Int = parse(Int, get(ENV, "ADRIA_NUM_CORES", "1"))
+    env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
+    n_scenarios = nrow(all_inputs)
+    batch_size::Int = if env_batch > 0
+        min(env_batch, n_scenarios)
+    elseif n_scenarios < n_cores
+        1
+    else
+        n_cores
+    end
     logs = (;
         zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
@@ -300,7 +309,7 @@ function combine_results(result_sets...)::ResultSet
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
-        chunks=(loc_dims[1:3]..., 1),
+        chunks=(loc_dims[1:3]..., batch_size),
         attrs=Dict{Symbol,Any}(
             :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => rs1.loc_ids,
@@ -326,7 +335,7 @@ function combine_results(result_sets...)::ResultSet
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
-        chunks=(taxa_dims[1:(end - 1)]..., 1),
+        chunks=(taxa_dims[1:(end - 1)]..., batch_size),
         attrs=Dict{Symbol,Any}(
             :structure => ("timesteps", "groups", "scenarios")
         ),

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -385,7 +385,7 @@ Sets up an on-disk result store.
 domain, (loc_outcomes, relative_taxa_cover, site_ranks, mc_log, seed_log, shading_log,
 coral_dhw_log, coral_cover_log)
 """
-function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
+function setup_result_store!(domain::Domain, scen_spec::DataFrame, batch_size::Int=0)::Tuple
     @set! domain.scenario_invoke_time = replace(
         string(now()), "T" => "_", ":" => "_", "." => "_"
     )
@@ -439,7 +439,10 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
     n_groups = domain.coral_growth.n_groups
-    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), n_scenarios)
+    batch_size = min(
+        batch_size > 0 ? batch_size : parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")),
+        n_scenarios
+    )
 
     # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
     loc_outcome_metrics::Vector{metrics.Metric} = [
@@ -746,7 +749,7 @@ function load_results(result_loc::String)::ResultSet
         try
             outcomes[sd_name] = DataCube(
                 data;
-                properties=Dict(
+                properties=Dict{Symbol,Any}(
                     p => data.attrs[string(p)] for p in outcome_properties
                     if haskey(data.attrs, string(p))
                 ),

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -198,8 +198,6 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
     # Store ranked location
     n_interventions = length(interventions())
     rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, n_interventions, n_scens)  # locations, location id and rank, no. scenarios
-    fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_locs, n_scens)  # timeframe, location, no. scenarios
-
     # tf, no. species to seed, location id and rank, no. scenarios
     seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_groups, n_locs, n_scens)
 
@@ -244,29 +242,20 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         attrs=attrs
     )
 
-    attrs = Dict(
-        :structure => ("timesteps", "locations", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
-    )
-    fog_log = zcreate(
+    shading_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, 2, n_scens)
+    shading_log = zcreate(
         Float32,
-        fog_dims...;
-        name="fog",
+        shading_dims...;
+        name="shading_log",
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
-    )
-    shade_log = zcreate(
-        Float32,
-        fog_dims...;
-        name="shade",
-        fill_value=nothing,
-        fill_as_missing=false,
-        path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
+        chunks=(shading_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "intervention", "scenarios"),
+            :interventions => ["fog", "shade"],
+            :unique_loc_ids => unique_loc_ids
+        )
     )
 
     # TODO: Could log bleaching mortality
@@ -319,33 +308,33 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             n_locs,
             n_scens;
             name="coral_cover_log",
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, 1),
             attrs=attrs
         )
     else
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             1,
             n_scens;
             name="coral_cover_log",
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_group_and_size, 1, 1),
             attrs=attrs
         )
     end
 
-    return ranks, mc_log, seed_log, fog_log, shade_log, coral_dhw_log, coral_cover_log
+    return ranks, mc_log, seed_log, shading_log, coral_dhw_log, coral_cover_log
 end
 
 """
@@ -446,70 +435,57 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     tf, n_locations, _ = size(domain.dhw_scens)
     n_scenarios = nrow(scen_spec)
 
-    # Set up stores for each metric
-    function dim_lengths(metric_structure::Vector{Symbol})
-        dl = []
-        for d in metric_structure
-            if d == :timesteps
-                append!(dl, tf)
-            elseif d == :groups
-                append!(dl, domain.coral_growth.n_groups)
-            elseif d == :locations
-                append!(dl, n_locations)
-            elseif d == :scenarios
-                append!(dl, n_scenarios)
-            end
-        end
+    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
+    n_groups = domain.coral_growth.n_groups
 
-        return (dl...,)
-    end
-
-    outcome_metrics::Vector{metrics.Metric} = [
+    # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
+    loc_outcome_metrics::Vector{metrics.Metric} = [
         metrics.relative_cover,
         metrics.relative_shelter_volume,
         metrics.absolute_shelter_volume,
         metrics.relative_juveniles,
         metrics.juvenile_indicator,
-        metrics.coral_evenness,
-        metrics.relative_taxa_cover
+        metrics.coral_evenness
     ]
-
-    metric_symbols::Vector{Symbol} = metrics.to_symbol.(outcome_metrics)
-    metric_names::Vector{String} = metrics.to_string.(outcome_metrics; is_titlecase=true)
-    metric_units::Vector{String} = getfield.(outcome_metrics, :unit)
-    axis_names::Vector{Vector{Symbol}} = fill(
-        [:timesteps, :locations, :scenarios], length(outcome_metrics) - 1
-    )
-    # Add axis names relative to the last metric (relative_taxa_cover) separate as they are
-    # different from the other metrics
-    push!(axis_names, [:timesteps, :groups, :scenarios])
-    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
-
-    outcomes_attrs::Vector{Dict{Symbol,Any}} = [
-        Dict(
+    n_loc_metrics = length(loc_outcome_metrics)
+    loc_dims = (tf, n_locations, n_loc_metrics, n_scenarios)
+    loc_outcomes_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
-            :structure => axis_names[idx],
-            :metric_name => metric_names[idx],
-            :metric_unit => metric_units[idx],
-            :axes_names => axis_names[idx],
-            :axes_units => metrics.axes_units(axis_names[idx])
-        ) for (idx, _) in enumerate(metric_symbols)
-    ]
-    result_dims::Vector{NTuple{3,Int64}} = dim_lengths.(axis_names)
+            :metrics => string.(LOC_METRIC_NAMES),
+            :metric_names => metrics.to_string.(loc_outcome_metrics; is_titlecase=true),
+            :metric_units => getfield.(loc_outcome_metrics, :unit),
+            :axes_units => metrics.axes_units([:timesteps, :locations, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
-    # Create stores for each metric
-    stores = [
-        zcreate(
-            Float32,
-            result_dims[idx]...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(z_store.folder, RESULTS, string(m_name)),
-            chunks=(result_dims[idx][1:(end - 1)]..., 1),
-            attrs=outcomes_attrs[idx],
-            compressor=COMPRESSOR
-        ) for (idx, m_name) in enumerate(metric_symbols)
-    ]
+    # Separate store for relative_taxa_cover (timesteps × groups × scenarios)
+    taxa_cover_metric = metrics.relative_taxa_cover
+    taxa_dims = (tf, n_groups, n_scenarios)
+    taxa_cover_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
+        chunks=(taxa_dims[1:2]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "groups", "scenarios"),
+            :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
+            :metric_unit => taxa_cover_metric.unit,
+            :axes_names => [:timesteps, :groups, :scenarios],
+            :axes_units => metrics.axes_units([:timesteps, :groups, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
     # dhw and wave zarrays
     dhw_stats = []
@@ -557,7 +533,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Group all data stores
     stores = [
-        stores...,
+        loc_outcomes_store,
+        taxa_cover_store,
         dhw_stats...,
         wave_stats...,
         connectivity...,
@@ -567,7 +544,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             nrow(scen_spec),
             tf,
             n_locations,
-            domain.coral_growth.n_groups,
+            n_groups,
             domain.coral_growth.n_sizes
         )...
     ]
@@ -576,14 +553,14 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     (;
         zip(
             (
-                metric_symbols...,
+                :loc_outcomes,
+                :relative_taxa_cover,
                 stat_store_names...,
                 conn_names...,
                 :site_ranks,
                 :mc_log,
                 :seed_log,
-                :fog_log,
-                :shade_log,
+                :shading_log,
                 :coral_dhw_log,
                 :coral_cover_log
             ),
@@ -730,10 +707,27 @@ function load_results(result_loc::String)::ResultSet
     outcome_properties = [:metric_name, :metric_unit, :axes_names, :axes_units]
     subdirs = filter(isdir, readdir(joinpath(result_loc, RESULTS); join=true))
     for sd in subdirs
+        sd_name = Symbol(basename(sd))
         data = zopen(sd; fill_as_missing=false)
         data_size = size(data)
 
-        # Construct dimension names and metadata
+        if sd_name == Symbol(LOC_METRICS)
+            # New combined format: split lazily back into individual named outcomes
+            metric_syms = Symbol.(data.attrs["metrics"])
+            combined = DataCube(
+                data;
+                timesteps=input_set.attrs["timeframe"],
+                locations=data.attrs["unique_loc_ids"],
+                metrics=string.(metric_syms),
+                scenarios=1:data_size[4]
+            )
+            for m_name in metric_syms
+                outcomes[m_name] = combined[metrics=At(string(m_name))]
+            end
+            continue
+        end
+
+        # Construct dimension names and metadata (handles relative_taxa_cover and old-format stores)
         dim_names = []
         for (idx, dim_name) in enumerate(data.attrs["structure"])
             if dim_name == "timesteps"
@@ -746,10 +740,11 @@ function load_results(result_loc::String)::ResultSet
         end
 
         try
-            outcomes[Symbol(basename(sd))] = DataCube(
+            outcomes[sd_name] = DataCube(
                 data;
                 properties=Dict(
                     p => data.attrs[string(p)] for p in outcome_properties
+                    if haskey(data.attrs, string(p))
                 ),
                 zip(Symbol.(data.attrs["structure"]), dim_names)...
             )
@@ -761,7 +756,7 @@ function load_results(result_loc::String)::ResultSet
                 Structure: $(data.attrs["structure"])
                 Generated: $(Array([i[1] for i in size.(dim_names)]))
                 """
-                outcomes[Symbol(basename(sd))] = DataCube(
+                outcomes[sd_name] = DataCube(
                     data;
                     zip(Symbol.(data.attrs["structure"]), [1:s for s in size(data)])...
                 )

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -175,9 +175,9 @@ function scenario_attributes(domain::Domain, param_df::DataFrame)::Dict{Symbol,A
 end
 
 """
-    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
 
-Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
+Setup logs for ranks, seed_log, shading_log, coral_dhw_log, and coral_cover_log.
 
 # Arguments
 - `z_store` : ZArray
@@ -187,10 +187,12 @@ Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
 - `n_locs` : number of location
 - `n_groups` : number of functional groups
 - `n_sizes` : number of size classes
+- `batch_size` : chunk size along the scenarios dimension; set to the write batch size so
+  that each batch write lands in exactly one chunk file per array.
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
     # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -213,7 +215,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(rank_dims[1:3]..., 1),
+        chunks=(rank_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -228,7 +230,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
     mc_log = zcreate(
@@ -238,7 +240,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -250,7 +252,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(shading_dims[1:3]..., 1),
+        chunks=(shading_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "intervention", "scenarios"),
             :interventions => ["fog", "shade"],
@@ -284,7 +286,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_groups * n_sizes, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -298,7 +300,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_groups * n_sizes, 1, batch_size),
             attrs=attrs
         )
     end
@@ -315,7 +317,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -329,7 +331,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, 1, 1),
+            chunks=(tf, n_group_and_size, 1, batch_size),
             attrs=attrs
         )
     end
@@ -349,20 +351,17 @@ Sets up an on-disk result store.
 ├───env_stats
 ├───inputs
 ├───logs
-|   ├───coral_cover_log
-|   ├───coral_dhw_log
-│   ├───fog
+│   ├───coral_cover_log  (full shape when ADRIA_LOG_COVER=true, 1-location dummy otherwise)
+│   ├───coral_dhw_log    (full shape when ADRIA_LOG_DHW_TOLS=true, 1-location dummy otherwise)
+│   ├───moving_corals
 │   ├───rankings
 │   ├───seed
-│   └───shade
+│   └───shading_log      (fog and shade combined along an intervention axis)
 ├───model_spec
 ├───results
-|   ├───absolute_shelter_volume
-|   ├───coral_evenness
-|   ├───juvenile_indicator
-│   ├───relative_cover
-|   ├───relative_juveniles
-│   ├───relative_shelter_volume
+│   ├───loc_outcomes     (relative_cover, relative_shelter_volume, absolute_shelter_volume,
+│   │                     relative_juveniles, juvenile_indicator, coral_evenness combined
+│   │                     along a metrics axis)
 │   └───relative_taxa_cover
 └───spatial
 ```
@@ -374,14 +373,17 @@ Sets up an on-disk result store.
 # Notes
 - `domain` is replaced with an identical copy with an updated scenario invoke time.
 - -9999.0 is used as an arbitrary fill value.
+- `loc_outcomes` is split back into individually named outcomes on load (see `load_results`).
+- `shading_log` has shape `(timesteps, locations, intervention, scenarios)` where the
+  intervention axis holds `["fog", "shade"]` in that order.
 
 # Arguments
 - `domain` : ADRIA scenario domain
 - `scen_spec` : ADRIA scenario specification
 
 # Returns
-domain, (relative_cover, relative_shelter_volume, absolute_shelter_volume, relative_juveniles,
-juvenile_indicator, relative_taxa_cover, site_ranks, seed_log, fog_log, shade_log)
+domain, (loc_outcomes, relative_taxa_cover, site_ranks, mc_log, seed_log, shading_log,
+coral_dhw_log, coral_cover_log)
 """
 function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     @set! domain.scenario_invoke_time = replace(
@@ -437,6 +439,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
     n_groups = domain.coral_growth.n_groups
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), n_scenarios)
 
     # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
     loc_outcome_metrics::Vector{metrics.Metric} = [
@@ -455,7 +458,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
-        chunks=(loc_dims[1:3]..., 1),
+        chunks=(loc_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
@@ -476,7 +479,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
-        chunks=(taxa_dims[1:2]..., 1),
+        chunks=(taxa_dims[1:2]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "groups", "scenarios"),
             :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
@@ -545,7 +548,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             tf,
             n_locations,
             n_groups,
-            domain.coral_growth.n_sizes
+            domain.coral_growth.n_sizes,
+            batch_size
         )...
     ]
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -192,7 +192,9 @@ Setup logs for ranks, seed_log, shading_log, coral_dhw_log, and coral_cover_log.
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
+function setup_logs(
+    z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1
+)
     # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -481,7 +483,9 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame, batch_size::I
         taxa_dims...;
         fill_value=nothing,
         fill_as_missing=false,
-        path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
+        path=joinpath(
+            z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))
+        ),
         chunks=(taxa_dims[1:2]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "groups", "scenarios"),

--- a/src/io/sampling/sampling_interface.jl
+++ b/src/io/sampling/sampling_interface.jl
@@ -396,7 +396,7 @@ function adjust_samples(spec::DataFrame, samples::DataFrame)::DataFrame
     no_wave_scenario = samples.wave_scenario .== 0.0
     samples[no_wave_scenario, :seed_wave_stress] .= 0.0
 
-    if size(unique(Matrix(samples), dims=1), 1) < nrow(samples)
+    if size(unique(Matrix(samples); dims=1), 1) < nrow(samples)
         perc = "$(@sprintf("%.3f", (1.0 - (nrow(unique(samples)) / nrow(samples))) * 100.0))%"
         @warn "Non-unique samples created: $perc of the samples are duplicates."
     end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -152,13 +152,37 @@ function run_scenarios(
 
     @info "Running $(nrow(scens)) scenarios over $(length(RCP)) RCPs: $RCP"
 
+    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
+    @info "ADRIA_DEBUG = $env_debug"
+
+    env_num_cores = ENV["ADRIA_NUM_CORES"]
+    @info "ADRIA_NUM_CORES = $env_num_cores"
+
+    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
+    para_threshold::Int64 = is_RME_based ? 8 : 20
+    active_cores::Int64 = parse(Int64, env_num_cores)
+    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
+
+    # Compute batch size before setting up the store so chunk sizes match the pmap batch
+    # sizes. In parallel mode: ceil(N/P) gives exactly one batch per worker and the fewest
+    # possible chunk files. In serial mode: fall back to the env var (default 32).
+    env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
+    batch_size::Int = if env_batch > 0
+        env_batch  # explicit override always wins
+    elseif parallel
+        ceil(Int, nrow(scens) / active_cores)
+    else
+        32
+    end
+    @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
+
     # Cross product between rcps and param_df to have every row of param_df for each rcp
     rcps_df = DataFrame(; RCP=parse.(Int64, RCP))
     scenarios_df = crossjoin(scens, rcps_df)
     sort!(scenarios_df, :RCP)
 
     @info "Setting up Result Set"
-    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df)
+    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, batch_size)
 
     # Convert DataFrame to named matrix for faster iteration
     scenarios_matrix::YAXArray = DataCube(
@@ -186,27 +210,14 @@ function run_scenarios(
         ) for _ in 1:n_locs
     ]
 
-    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
-    @info "ADRIA_DEBUG = $env_debug"
-
-    env_num_cores = ENV["ADRIA_NUM_CORES"]
-    @info "ADRIA_NUM_CORES = $env_num_cores"
-
-    batch_size::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32"))
-    @info "ADRIA_BATCH_SIZE = $batch_size"
-
-    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
-    para_threshold::Int64 = is_RME_based ? 8 : 20
-    active_cores::Int64 = parse(Int64, env_num_cores)
-    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin
             _setup_workers()
 
-            # Load ADRIA on workers. Workers only run _collect_scenario_results; all
-            # disk I/O is done on the main process via _write_batch!, so data_store is
-            # never serialised to workers and there are no concurrent chunk writes.
+            # Load ADRIA on workers. Each pmap task runs _run_batch!, which computes
+            # and writes a full batch directly. Workers write to non-overlapping chunk
+            # ranges (chunk size == batch size) so concurrent Zarr writes are safe.
             @sync @async @everywhere @eval begin
                 using ADRIA
             end
@@ -215,11 +226,11 @@ function run_scenarios(
         @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
-    # collect_func captures only functional_groups (no data_store) so serialisation cost
-    # to workers is minimal and disk writes are always single-threaded.
-    collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
-
     if parallel
+        # Each pmap task is one batch: workers compute B scenarios and write them
+        # directly. Only `nothing` returns to the main process — no result IPC.
+        batch_func = (batch) -> _run_batch!(batch, functional_groups, data_store)
+
         try
             for rcp in RCP
                 run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
@@ -231,18 +242,16 @@ function run_scenarios(
                 scen_args = collect(
                     _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
                 )
+                all_batches = [
+                    collect(b) for b in Iterators.partition(scen_args, batch_size)
+                ]
 
-                batches = Iterators.partition(scen_args, batch_size)
                 if show_progress
-                    @showprogress desc = run_msg dt = 4 for batch in batches
-                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
-                        _write_batch!(data_store, first(batch)[2], batch_results)
-                    end
+                    @showprogress desc = run_msg dt = 4 pmap(
+                        batch_func, CachingPool(workers()), all_batches
+                    )
                 else
-                    for batch in batches
-                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
-                        _write_batch!(data_store, first(batch)[2], batch_results)
-                    end
+                    pmap(batch_func, CachingPool(workers()), all_batches)
                 end
             end
         catch err
@@ -251,6 +260,9 @@ function run_scenarios(
             rethrow(err)
         end
     else
+        # Serial: collect B results then write once (batch write, no IPC overhead)
+        collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
+
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
@@ -258,15 +270,17 @@ function run_scenarios(
             scen_args = collect(
                 _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
+            all_batches = [
+                collect(b) for b in Iterators.partition(scen_args, batch_size)
+            ]
 
-            batches = Iterators.partition(scen_args, batch_size)
             if show_progress
-                @showprogress desc = run_msg dt = 4 for batch in batches
+                @showprogress desc = run_msg dt = 4 for batch in all_batches
                     batch_results = map(collect_func, batch)
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             else
-                for batch in batches
+                for batch in all_batches
                     batch_results = map(collect_func, batch)
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
@@ -447,6 +461,27 @@ function _write_batch!(
         end
     end
 
+    return nothing
+end
+
+"""
+    _run_batch!(batch_args, functional_groups, data_store)
+
+Compute and write a contiguous batch of scenarios entirely on the calling worker.
+Each pmap task gets one batch, so result arrays never travel back to the main process.
+Workers write to non-overlapping chunk ranges, so concurrent writes are safe.
+"""
+function _run_batch!(
+    batch_args::AbstractVector,
+    functional_groups::Vector{Vector{FunctionalGroup}},
+    data_store::NamedTuple
+)::Nothing
+    start_idx = batch_args[1][2]
+    results = [
+        _collect_scenario_results(args[1], args[3], functional_groups)
+        for args in batch_args
+    ]
+    _write_batch!(data_store, start_idx, results)
     return nothing
 end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -192,6 +192,9 @@ function run_scenarios(
     env_num_cores = ENV["ADRIA_NUM_CORES"]
     @info "ADRIA_NUM_CORES = $env_num_cores"
 
+    batch_size::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32"))
+    @info "ADRIA_BATCH_SIZE = $batch_size"
+
     is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
     para_threshold::Int64 = is_RME_based ? 8 : 20
     active_cores::Int64 = parse(Int64, env_num_cores)
@@ -201,45 +204,45 @@ function run_scenarios(
         spinup_time = @elapsed begin
             _setup_workers()
 
-            # Load ADRIA on workers and define helper function
-            # Note: Workers do not share the same cache in parallel workloads.
-            #       Previously, cache would be reserialized so each worker has access to
-            #       a separate cache.
-            #       Using CachingPool() resolves the the repeated reserialization but it
-            #       seems each worker was then attempting to use the same cache, causing the
-            #       Julia kernel to crash in multi-processing contexts.
-            #       Getting each worker to create its own cache reduces serialization time
-            #       (at the cost of increased run time) but resolves the kernel crash issue.
+            # Load ADRIA on workers. Workers only run _collect_scenario_results; all
+            # disk I/O is done on the main process via _write_batch!, so data_store is
+            # never serialised to workers and there are no concurrent chunk writes.
             @sync @async @everywhere @eval begin
                 using ADRIA
-                func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
             end
         end
 
         @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
-    if parallel
-        # Define local helper
-        func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
+    # collect_func captures only functional_groups (no data_store) so serialisation cost
+    # to workers is minimal and disk writes are always single-threaded.
+    collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
 
+    if parallel
         try
             for rcp in RCP
                 run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-                # Switch RCPs so correct data is loaded
                 dom = switch_RCPs!(dom, rcp)
                 target_rows = findall(
                     scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
                 )
-                scen_args = _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                scen_args = collect(
+                    _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                )
 
+                batches = Iterators.partition(scen_args, batch_size)
                 if show_progress
-                    @showprogress desc = run_msg dt = 4 pmap(
-                        func, CachingPool(workers()), scen_args
-                    )
+                    @showprogress desc = run_msg dt = 4 for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 else
-                    pmap(func, CachingPool(workers()), scen_args)
+                    for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 end
             end
         catch err
@@ -248,22 +251,25 @@ function run_scenarios(
             rethrow(err)
         end
     else
-        # Define local helper
-        func = dfx -> run_scenario(dfx..., functional_groups, data_store)
-
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-            # Switch RCPs so correct data is loaded
             dom = switch_RCPs!(dom, rcp)
-            scen_args = _scenario_args(
-                dom, scenarios_matrix, rcp, size(scenarios_matrix, 1)
+            scen_args = collect(
+                _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
 
+            batches = Iterators.partition(scen_args, batch_size)
             if show_progress
-                @showprogress desc = run_msg dt = 4 map(func, scen_args)
+                @showprogress desc = run_msg dt = 4 for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             else
-                map(func, scen_args)
+                for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             end
         end
     end
@@ -289,6 +295,159 @@ function _scenario_args(dom, scenarios_matrix::YAXArray, rcp::String, n::Int)
     return zip(
         rep_doms, target_rows, eachrow(scenarios_matrix[target_rows, :])
     )
+end
+
+"""
+    _collect_scenario_results(domain, scenario, functional_groups)
+
+Run one scenario and return all computed metric arrays without writing to disk.
+Called by `run_scenario` (single write) and by the batched pmap path in `run_scenarios`.
+"""
+function _collect_scenario_results(
+    domain::Domain,
+    scenario::Union{AbstractVector,DataFrameRow},
+    functional_groups::Vector{Vector{FunctionalGroup}}
+)::NamedTuple
+    result_set = run_model(domain, scenario, functional_groups)
+    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
+
+    rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # 6 location-based metrics — order must match LOC_METRIC_NAMES
+    loc_out = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES))
+    vals = relative_cover(rs_raw);                      vals[vals .< threshold] .= 0.0; loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 3] .= vals
+    vals = relative_juveniles(rs_raw);                  vals[vals .< threshold] .= 0.0; loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk);  vals[vals .< threshold] .= 0.0; loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data);               vals[vals .< threshold] .= 0.0; loc_out[:, :, 6] .= vals
+
+    # Taxa cover (groups axis, not locations)
+    taxa_vals = relative_taxa_cover(rs_raw, lk)
+    taxa_vals[taxa_vals .< threshold] .= 0.0
+
+    # Fog and shade combined into a single (tf, n_locs, 2) buffer
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0f0
+    shade_vals[shade_vals .< threshold] .= 0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+
+    # Remaining log arrays — apply threshold where possible
+    site_ranks_vals = result_set.site_ranks
+    try; site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0); catch err; err isa MethodError ? nothing : rethrow(err); end
+
+    mc_vals = result_set.mc_log
+    mc_vals[mc_vals .< threshold] .= Float32(0.0)
+
+    seed_vals = result_set.seed_log
+    seed_vals[seed_vals .< threshold] .= Float32(0.0)
+
+    # coral_dhw_log / coral_cover_log are false when their env var is disabled
+    dhw_vals = result_set.coral_dhw_log
+    cover_vals = result_set.coral_cover_log
+
+    return (
+        loc_out=loc_out,
+        taxa_cover=taxa_vals,
+        shading=shading_buf,
+        site_ranks=site_ranks_vals,
+        mc_log=mc_vals,
+        seed_log=seed_vals,
+        coral_dhw_log=dhw_vals,
+        coral_cover_log=cover_vals
+    )
+end
+
+"""
+    _write_batch!(data_store, start_idx, results)
+
+Write a contiguous batch of collected scenario results to the Zarr data store.
+All arrays in the batch are stacked into a single in-memory buffer and written in one
+Zarr call per array, so the entire batch lands in a single chunk file per array.
+"""
+function _write_batch!(
+    data_store::NamedTuple, start_idx::Int, results::AbstractVector
+)::Nothing
+    n = length(results)
+    idx_range = start_idx:(start_idx + n - 1)
+
+    # loc_outcomes: (tf, n_locs, n_metrics, n)
+    tf, n_locs, n_metrics = size(results[1].loc_out)
+    loc_batch = Array{Float32}(undef, tf, n_locs, n_metrics, n)
+    for (i, r) in enumerate(results)
+        loc_batch[:, :, :, i] .= r.loc_out
+    end
+    data_store.loc_outcomes[:, :, :, idx_range] .= loc_batch
+
+    # relative_taxa_cover: (tf, n_groups, n)
+    _, n_groups = size(results[1].taxa_cover)
+    taxa_batch = Array{Float32}(undef, tf, n_groups, n)
+    for (i, r) in enumerate(results)
+        taxa_batch[:, :, i] .= r.taxa_cover
+    end
+    data_store.relative_taxa_cover[:, :, idx_range] .= taxa_batch
+
+    # shading_log: (tf, n_locs, 2, n)
+    shading_batch = Array{Float32}(undef, tf, n_locs, 2, n)
+    for (i, r) in enumerate(results)
+        shading_batch[:, :, :, i] .= r.shading
+    end
+    data_store.shading_log[:, :, :, idx_range] .= shading_batch
+
+    # site_ranks: (tf, n_locs, n_interventions, n)
+    if !isnothing(data_store.site_ranks)
+        _, _, n_ivs = size(results[1].site_ranks)
+        ranks_batch = Array{Float32}(undef, tf, n_locs, n_ivs, n)
+        for (i, r) in enumerate(results)
+            ranks_batch[:, :, :, i] .= r.site_ranks
+        end
+        data_store.site_ranks[:, :, :, idx_range] .= ranks_batch
+    end
+
+    # mc_log and seed_log: (tf, n_groups, n_locs, n)
+    _, n_g, n_l = size(results[1].mc_log)
+    mc_batch   = Array{Float32}(undef, tf, n_g, n_l, n)
+    seed_batch = Array{Float32}(undef, tf, n_g, n_l, n)
+    for (i, r) in enumerate(results)
+        mc_batch[:, :, :, i]   .= r.mc_log
+        seed_batch[:, :, :, i] .= r.seed_log
+    end
+    data_store.mc_log[:, :, :, idx_range]   .= mc_batch
+    data_store.seed_log[:, :, :, idx_range] .= seed_batch
+
+    # coral_dhw_log (conditional on ADRIA_LOG_DHW_TOLS)
+    if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
+        dhw_r = results[1].coral_dhw_log
+        if dhw_r !== false && !isnothing(dhw_r)
+            _, n_sp, n_ld = size(dhw_r)
+            dhw_batch = Array{Float32}(undef, tf, n_sp, n_ld, n)
+            for (i, r) in enumerate(results)
+                dhw_batch[:, :, :, i] .= r.coral_dhw_log
+            end
+            data_store.coral_dhw_log[:, :, :, idx_range] .= dhw_batch
+        end
+    end
+
+    # coral_cover_log (conditional on ADRIA_LOG_COVER)
+    if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
+        cc_r = results[1].coral_cover_log
+        if cc_r !== false && !isnothing(cc_r)
+            _, n_sp_c, n_lc = size(cc_r)
+            cc_batch = Array{Float32}(undef, tf, n_sp_c, n_lc, n)
+            for (i, r) in enumerate(results)
+                cc_batch[:, :, :, i] .= r.coral_cover_log
+            end
+            data_store.coral_cover_log[:, :, :, idx_range] .= cc_batch
+        end
+    end
+
+    return nothing
 end
 
 """
@@ -332,94 +491,8 @@ function run_scenario(
         domain = switch_RCPs!(domain, rcp)
     end
 
-    result_set = run_model(domain, scenario, functional_groups)
-
-    # Capture results to disk
-    # Set values below threshold to 0 to save space
-    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
-
-    # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
-    rs_raw::Array{Float64} = result_set.raw
-    lk = loc_k_area(domain)
-    coral_spec::DataFrame = to_coral_spec(scenario)
-
-    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
-    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
-    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
-    loc_out = Array{Float32}(
-        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
-    )
-
-    vals = relative_cover(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 1] .= vals
-    vals = relative_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 2] .= vals
-    vals = absolute_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 3] .= vals
-    vals = relative_juveniles(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 4] .= vals
-    vals = juvenile_indicator(rs_raw, coral_spec, lk)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 5] .= vals
-    rtc_vals = relative_loc_taxa_cover(rs_raw)
-    vals = coral_evenness(rtc_vals.data)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 6] .= vals
-
-    data_store.loc_outcomes[:, :, :, idx] .= loc_out
-
-    # Taxa cover uses a groups axis rather than locations — kept as its own store
-    vals = relative_taxa_cover(rs_raw, lk)
-    vals[vals .< threshold] .= 0.0
-    data_store.relative_taxa_cover[:, :, idx] .= vals
-
-    # Write fog and shade together as a single 4-D shading_log chunk
-    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
-    fog_vals = Matrix{Float32}(result_set.fog_log)
-    shade_vals = Matrix{Float32}(result_set.shade_log)
-    fog_vals[fog_vals .< threshold] .= 0.0f0
-    shade_vals[shade_vals .< threshold] .= 0.0f0
-    shading_buf[:, :, 1] .= fog_vals
-    shading_buf[:, :, 2] .= shade_vals
-    data_store.shading_log[:, :, :, idx] .= shading_buf
-
-    # Store remaining logs
-    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
-    for k in log_stores
-        vals = getfield(result_set, k)
-
-        if vals === false || isnothing(vals)
-            continue
-        end
-
-        try
-            vals[vals .< threshold] .= Float32(0.0)
-        catch err
-            err isa MethodError ? nothing : rethrow(err)
-        end
-
-        if k == :seed_log || k == :mc_log
-            getfield(data_store, k)[:, :, :, idx] .= vals
-        elseif k == :site_ranks
-            if !isnothing(data_store.site_ranks)
-                # Squash site ranks down to average rankings over environmental repeats
-                data_store.site_ranks[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_dhw_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_cover_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        end
-    end
-
+    result = _collect_scenario_results(domain, scenario, functional_groups)
+    _write_batch!(data_store, idx, [result])
     return nothing
 end
 function run_scenario(

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -340,55 +340,61 @@ function run_scenario(
 
     # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
     rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
+    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
+    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
+    loc_out = Array{Float32}(
+        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
+    )
+
     vals = relative_cover(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_cover[:, :, idx] .= vals
-
-    vals = absolute_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.absolute_shelter_volume[:, :, idx] .= vals
-    vals = relative_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_shelter_volume[:, :, idx] .= vals
-
-    coral_spec::DataFrame = to_coral_spec(scenario)
+    loc_out[:, :, 3] .= vals
     vals = relative_juveniles(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_juveniles[:, :, idx] .= vals
-
-    vals = juvenile_indicator(rs_raw, coral_spec, loc_k_area(domain))
+    loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk)
     vals[vals .< threshold] .= 0.0
-    data_store.juvenile_indicator[:, :, idx] .= vals
+    loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 6] .= vals
 
-    vals = relative_taxa_cover(rs_raw, loc_k_area(domain))
+    data_store.loc_outcomes[:, :, :, idx] .= loc_out
+
+    # Taxa cover uses a groups axis rather than locations — kept as its own store
+    vals = relative_taxa_cover(rs_raw, lk)
     vals[vals .< threshold] .= 0.0
     data_store.relative_taxa_cover[:, :, idx] .= vals
 
-    vals = relative_loc_taxa_cover(rs_raw)
+    # Write fog and shade together as a single 4-D shading_log chunk
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0.0f0
+    shade_vals[shade_vals .< threshold] .= 0.0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+    data_store.shading_log[:, :, :, idx] .= shading_buf
 
-    vals = coral_evenness(vals.data)
-    vals[vals .< threshold] .= 0.0
-    data_store.coral_evenness[:, :, idx] .= vals
-
-    # Store logs
-    c_dim = Base.ndims(result_set.raw) + 1
-    log_stores = (
-        :site_ranks,
-        :mc_log,
-        :seed_log,
-        :fog_log,
-        :shade_log,
-        :coral_dhw_log,
-        :coral_cover_log
-    )
+    # Store remaining logs
+    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
     for k in log_stores
-        if k == :seed_log || k == :site_ranks
-            concat_dim = c_dim
-        else
-            concat_dim = c_dim - 1
-        end
-
         vals = getfield(result_set, k)
+
+        if vals === false || isnothing(vals)
+            continue
+        end
 
         try
             vals[vals .< threshold] .= Float32(0.0)
@@ -411,8 +417,6 @@ function run_scenario(
             if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
                 getfield(data_store, k)[:, :, :, idx] .= vals
             end
-        else
-            getfield(data_store, k)[:, :, idx] .= vals
         end
     end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -10,7 +10,8 @@ import CoralBlox:
     timestep!,
     coral_cover,
     max_projected_cover,
-    linear_extension_scale_factors
+    linear_extension_scale_factors,
+    LinearExtensionCache
 
 using .metrics:
     relative_cover,
@@ -1025,6 +1026,10 @@ function run_model(
         )
     end
 
+    # Pre-compute Δd matrices once for the entire simulation — _bin_edges is constant,
+    # so this avoids repeated allocation inside linear_extension_scale_factors each timestep.
+    _le_cache = LinearExtensionCache(_bin_edges)
+
     # Preallocate vector for growth constraints
     growth_constraints::Vector{Float64} = zeros(Float64, n_locs)
 
@@ -1105,11 +1110,11 @@ function run_model(
                 cb_calib_group_masks[:, idx] .&& growth_threshold_mask_cache
 
             # Only apply linear_extension_scale_factors to locations with high cover
-            growth_constraints[cover_threshold_mask] .= linear_extension_scale_factors(
+            @views growth_constraints[cover_threshold_mask] .= linear_extension_scale_factors(
                 C_cover_t[:, :, cover_threshold_mask],
                 vec_abs_k[cover_threshold_mask],
                 biogrp_lin_ext[:, :, idx],
-                _bin_edges,
+                _le_cache,
                 habitable_max_projected_cover[cover_threshold_mask]
             )
         end
@@ -1135,7 +1140,7 @@ function run_model(
                             C_cover_t[:, :, cover_threshold_mask],
                             vec_abs_k[cover_threshold_mask],
                             biogrp_lin_ext[:, :, idx],
-                            _bin_edges,
+                            _le_cache,
                             habitable_max_projected_cover[cover_threshold_mask]
                         )
                     ) .+

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1133,8 +1133,8 @@ function run_model(
         end
 
         # When cover is between cover_transition_lb and cover_transition_ub use a weighted mean
-        growth_threshold_mask_cache .= (
-            cover_transition_lb .<= relative_habitable_cover_cache .<
+        @. growth_threshold_mask_cache = (
+            cover_transition_lb <= relative_habitable_cover_cache <
             cover_transition_ub
         )
         if sum(growth_threshold_mask_cache) > 0

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -134,16 +134,15 @@ julia> rs_45_60 = ADRIA.run_scenarios(dom, scens, ["45", "60"])
 ResultSet
 """
 function run_scenarios(
-    dom::Domain, scens::DataFrame, RCP::String; show_progress=true, remove_workers=true
+    dom::Domain, scens::DataFrame, RCP::String; show_progress=true
 )::ResultSet
-    return run_scenarios(dom, scens, [RCP]; show_progress, remove_workers)
+    return run_scenarios(dom, scens, [RCP]; show_progress)
 end
 function run_scenarios(
     dom::Domain,
     scens::DataFrame,
     RCP::Vector{String};
-    show_progress=true,
-    remove_workers=true
+    show_progress=true
 )::ResultSet
     # Initialize ADRIA configuration options
     setup()
@@ -156,27 +155,22 @@ function run_scenarios(
     env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
     @info "ADRIA_DEBUG = $env_debug"
 
-    env_num_cores = ENV["ADRIA_NUM_CORES"]
-    @info "ADRIA_NUM_CORES = $env_num_cores"
+    parallel::Bool = !env_debug && (Threads.nthreads() > 1)
 
-    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
-    para_threshold::Int64 = is_RME_based ? 8 : 20
-    active_cores::Int64 = parse(Int64, env_num_cores)
-    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
-
-    # Compute batch size before setting up the store so chunk sizes match the pmap batch
-    # sizes. In parallel mode: a small fixed batch keeps the pmap queue deep enough for
-    # dynamic load balancing — ceil(N/P) would create exactly one task per worker, leaving
-    # fast workers idle. In serial mode: fall back to the env var (default 1).
-    env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
-    batch_size::Int = if env_batch > 0
-        env_batch  # explicit override always wins
+    # chunk_size sets the Zarr chunk size along the scenario axis and controls how many
+    # results the writer accumulates before flushing to disk. Compute scheduling is
+    # per-scenario via a channel, so chunk_size is purely an I/O tuning parameter.
+    # In serial mode: fall back to the env var (default 1).
+    active_threads::Int = Threads.nthreads()
+    env_chunk = parse(Int, get(ENV, "ADRIA_CHUNK_SIZE", "0"))
+    chunk_size::Int = if env_chunk > 0
+        env_chunk  # explicit override always wins
     elseif parallel
-        max(1, min(4, ceil(Int, nrow(scens) / (active_cores * 4))))
+        ceil(Int, nrow(scens) / active_threads)
     else
         1
     end
-    @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
+    @info "ADRIA_CHUNK_SIZE (effective) = $chunk_size"
 
     # Cross product between rcps and param_df to have every row of param_df for each rcp
     rcps_df = DataFrame(; RCP=parse.(Int64, RCP))
@@ -184,88 +178,105 @@ function run_scenarios(
     sort!(scenarios_df, :RCP)
 
     @info "Setting up Result Set"
-    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, batch_size)
+    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, chunk_size)
 
     # Convert DataFrame to named matrix for faster iteration
     scenarios_matrix::YAXArray = DataCube(
         Matrix(scenarios_df); scenarios=1:nrow(scenarios_df), factors=names(scenarios_df)
     )
 
-    # The idea to initialise the functional groups here is so that each scenario run can
-    # reuse the memory. After a few scenarios runs there will be very few new
-    # allocations as buffers grow larger and are not exceeded
-    #
-    # The problem is that even if a subsequent run only has to reallocate once, the
-    # buffer is so large it takes very long regardless.
-    #
-    # This is also forced me to added an argument to run_model which breaks
-    # encapsulation, so its quite ugly
+    # Pre-allocate FunctionalGroup buffers so each scenario run can reuse memory.
+    # Buffer contents grow over time as size classes accumulate; reusing avoids repeated
+    # large allocations. In the parallel path one buffer set is created per thread to
+    # avoid data races on the mutable CircularBuffer and TerminalClass fields.
     n_locs::Int64 = dom.coral_growth.n_locs
     n_sizes::Int64 = dom.coral_growth.n_sizes
     n_groups::Int64 = dom.coral_growth.n_groups
     _bin_edges::Matrix{Float64} = bin_edges(; unit=:m)
-    functional_groups = Vector{Vector{FunctionalGroup}}(undef, n_locs)
-    for loc in 1:n_locs
-        functional_groups[loc] =
-            FunctionalGroup.(
-                eachrow(_bin_edges[:, 1:(end - 1)]),
-                eachrow(_bin_edges[:, 2:end]),
-                eachrow(zeros(n_groups, n_sizes))
-            )
-    end
 
-    if parallel && nworkers() == 1
-        @info "Setting up parallel processing..."
-        spinup_time = @elapsed begin
-            _setup_workers()
-
-            # Load ADRIA on workers. Each pmap task runs _run_batch!, which computes
-            # and writes a full batch directly. Workers write to non-overlapping chunk
-            # ranges (chunk size == batch size) so concurrent Zarr writes are safe.
-            @sync @async @everywhere @eval begin
-                using ADRIA
-            end
-        end
-
-        @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
-    end
+    _make_fg_buffers() = [
+        FunctionalGroup.(
+            eachrow(_bin_edges[:, 1:(end - 1)]),
+            eachrow(_bin_edges[:, 2:end]),
+            eachrow(zeros(n_groups, n_sizes))
+        )
+        for _ in 1:n_locs
+    ]
 
     if parallel
-        # Each pmap task is one batch: workers compute B scenarios and write them
-        # directly. Only `nothing` returns to the main process — no result IPC.
-        batch_func = (batch) -> _run_batch!(batch, functional_groups, data_store)
+        # One buffer set per thread — threadid() can reach maxthreadid() due to Julia's
+        # internal threads, so size to maxthreadid() not nthreads().
+        thread_fg = [_make_fg_buffers() for _ in 1:Threads.maxthreadid()]
 
-        try
-            for rcp in RCP
-                run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
+        # Prevent BLAS internal threads from competing with Julia threads.
+        BLAS.set_num_threads(1)
 
-                dom = switch_RCPs!(dom, rcp)
-                target_rows = findall(
-                    scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
-                )
-                scen_args = collect(
-                    _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
-                )
-                all_batches = [
-                    collect(b) for b in Iterators.partition(scen_args, batch_size)
-                ]
+        for rcp in RCP
+            run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-                if show_progress
-                    @showprogress desc = run_msg dt = 4 pmap(
-                        batch_func, CachingPool(workers()), all_batches
-                    )
-                else
-                    pmap(batch_func, CachingPool(workers()), all_batches)
+            dom = switch_RCPs!(dom, rcp)
+            target_rows = findall(
+                scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
+            )
+            scen_args = collect(
+                _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+            )
+            N_rcp = length(scen_args)
+            first_idx = scen_args[1][2]
+            n_chunks = cld(N_rcp, chunk_size)
+
+            prog =
+                show_progress ?
+                ProgressMeter.Progress(n_chunks; desc=run_msg, dt=4) :
+                nothing
+
+            # Workers push (write_idx, result) to the channel; the single writer task
+            # buffers results and flushes in chunk_size-aligned chunks so all Zarr writes
+            # are chunk-aligned and contention-free, regardless of completion order.
+            ch = Channel{Tuple{Int,NamedTuple}}(2 * Threads.nthreads())
+
+            chunk_start(c) = first_idx + c * chunk_size
+            chunk_len(c) = c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
+
+            writer = Threads.@spawn begin
+                buf = Dict{Int,NamedTuple}()
+                chunk_ready = zeros(Int, n_chunks)
+                next_chunk = 0
+
+                for (idx, result) in ch
+                    buf[idx] = result
+                    c = (idx - first_idx) ÷ chunk_size
+                    chunk_ready[c + 1] += 1
+
+                    while next_chunk < n_chunks &&
+                            chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
+                        s = chunk_start(next_chunk)
+                        n = chunk_len(next_chunk)
+                        results = [buf[s + i] for i in 0:(n - 1)]
+                        for i in 0:(n - 1)
+                            delete!(buf, s + i)
+                        end
+                        _write_batch!(data_store, s, results)
+                        isnothing(prog) || ProgressMeter.next!(prog)
+                        next_chunk += 1
+                    end
                 end
             end
-        catch err
-            # Remove hanging workers if any error occurs
-            _remove_workers()
-            rethrow(err)
+
+            try
+                Threads.@threads :dynamic for i in 1:N_rcp
+                    d, idx, scen = scen_args[i]
+                    result = _collect_scenario_results(d, scen, thread_fg[Threads.threadid()])
+                    put!(ch, (idx, result))
+                end
+            finally
+                close(ch)
+            end
+            wait(writer)
         end
     else
-        # Serial: collect B results then write once (batch write, no IPC overhead)
-        collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
+        # Serial: one shared buffer set, collect batch then write.
+        functional_groups = _make_fg_buffers()
 
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
@@ -275,25 +286,27 @@ function run_scenarios(
                 _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
             all_batches = [
-                collect(b) for b in Iterators.partition(scen_args, batch_size)
+                collect(b) for b in Iterators.partition(scen_args, chunk_size)
             ]
 
             if show_progress
                 @showprogress desc = run_msg dt = 4 for batch in all_batches
-                    batch_results = map(collect_func, batch)
+                    batch_results = map(
+                        dfx -> _collect_scenario_results(dfx[1], dfx[3], functional_groups),
+                        batch
+                    )
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             else
                 for batch in all_batches
-                    batch_results = map(collect_func, batch)
+                    batch_results = map(
+                        dfx -> _collect_scenario_results(dfx[1], dfx[3], functional_groups),
+                        batch
+                    )
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             end
         end
-    end
-
-    if parallel && remove_workers
-        _remove_workers()
     end
 
     return load_results(_result_location(dom, RCP))

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1131,14 +1131,16 @@ function run_model(
         end
 
         @inbounds for i in habitable_loc_idxs
+            cb_idx::Int64 = loc_cb_calib_group_idxs[i]
             net_growth_rates[:, :, i] .=
-                biogrp_lin_ext[:, :, loc_cb_calib_group_idxs[i]] .*
+                @view(biogrp_lin_ext[:, :, cb_idx]) .*
                 growth_constraints[i]
-            @views timestep!(
+
+            timestep!(
                 functional_groups[i],
-                recruitment[:, i],
-                net_growth_rates[:, :, i],
-                biogrp_survival[:, :, loc_cb_calib_group_idxs[i]]
+                @view(recruitment[:, i]),
+                @view(net_growth_rates[:, :, i]),
+                @view(biogrp_survival[:, :, cb_idx])
             )
 
             # Write to the cover matrix

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -164,15 +164,16 @@ function run_scenarios(
     parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
 
     # Compute batch size before setting up the store so chunk sizes match the pmap batch
-    # sizes. In parallel mode: ceil(N/P) gives exactly one batch per worker and the fewest
-    # possible chunk files. In serial mode: fall back to the env var (default 32).
+    # sizes. In parallel mode: a small fixed batch keeps the pmap queue deep enough for
+    # dynamic load balancing — ceil(N/P) would create exactly one task per worker, leaving
+    # fast workers idle. In serial mode: fall back to the env var (default 1).
     env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     batch_size::Int = if env_batch > 0
         env_batch  # explicit override always wins
     elseif parallel
-        ceil(Int, nrow(scens) / active_cores)
+        max(1, min(4, ceil(Int, nrow(scens) / (active_cores * 4))))
     else
-        32
+        1
     end
     @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
 
@@ -202,13 +203,15 @@ function run_scenarios(
     n_sizes::Int64 = dom.coral_growth.n_sizes
     n_groups::Int64 = dom.coral_growth.n_groups
     _bin_edges::Matrix{Float64} = bin_edges(; unit=:m)
-    functional_groups = [
-        FunctionalGroup.(
-            eachrow(_bin_edges[:, 1:(end - 1)]),
-            eachrow(_bin_edges[:, 2:end]),
-            eachrow(zeros(n_groups, n_sizes))
-        ) for _ in 1:n_locs
-    ]
+    functional_groups = Vector{Vector{FunctionalGroup}}(undef, n_locs)
+    for loc in 1:n_locs
+        functional_groups[loc] =
+            FunctionalGroup.(
+                eachrow(_bin_edges[:, 1:(end - 1)]),
+                eachrow(_bin_edges[:, 2:end]),
+                eachrow(zeros(n_groups, n_sizes))
+            )
+    end
 
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
@@ -330,14 +333,28 @@ function _collect_scenario_results(
     coral_spec::DataFrame = to_coral_spec(scenario)
 
     # 6 location-based metrics — order must match LOC_METRIC_NAMES
-    loc_out = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES))
-    vals = relative_cover(rs_raw);                      vals[vals .< threshold] .= 0.0; loc_out[:, :, 1] .= vals
-    vals = relative_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 2] .= vals
-    vals = absolute_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 3] .= vals
-    vals = relative_juveniles(rs_raw);                  vals[vals .< threshold] .= 0.0; loc_out[:, :, 4] .= vals
-    vals = juvenile_indicator(rs_raw, coral_spec, lk);  vals[vals .< threshold] .= 0.0; loc_out[:, :, 5] .= vals
+    loc_out = Array{Float32}(
+        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
+    )
+    vals = relative_cover(rs_raw)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 3] .= vals
+    vals = relative_juveniles(rs_raw)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 5] .= vals
     rtc_vals = relative_loc_taxa_cover(rs_raw)
-    vals = coral_evenness(rtc_vals.data);               vals[vals .< threshold] .= 0.0; loc_out[:, :, 6] .= vals
+    vals = coral_evenness(rtc_vals.data)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 6] .= vals
 
     # Taxa cover (groups axis, not locations)
     taxa_vals = relative_taxa_cover(rs_raw, lk)
@@ -347,14 +364,18 @@ function _collect_scenario_results(
     shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
     fog_vals = Matrix{Float32}(result_set.fog_log)
     shade_vals = Matrix{Float32}(result_set.shade_log)
-    fog_vals[fog_vals .< threshold] .= 0f0
-    shade_vals[shade_vals .< threshold] .= 0f0
+    fog_vals[fog_vals .< threshold] .= 0.0f0
+    shade_vals[shade_vals .< threshold] .= 0.0f0
     shading_buf[:, :, 1] .= fog_vals
     shading_buf[:, :, 2] .= shade_vals
 
     # Remaining log arrays — apply threshold where possible
     site_ranks_vals = result_set.site_ranks
-    try; site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0); catch err; err isa MethodError ? nothing : rethrow(err); end
+    try
+        site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0)
+    catch err
+        err isa MethodError ? nothing : rethrow(err)
+    end
 
     mc_vals = result_set.mc_log
     mc_vals[mc_vals .< threshold] .= Float32(0.0)
@@ -426,13 +447,13 @@ function _write_batch!(
 
     # mc_log and seed_log: (tf, n_groups, n_locs, n)
     _, n_g, n_l = size(results[1].mc_log)
-    mc_batch   = Array{Float32}(undef, tf, n_g, n_l, n)
+    mc_batch = Array{Float32}(undef, tf, n_g, n_l, n)
     seed_batch = Array{Float32}(undef, tf, n_g, n_l, n)
     for (i, r) in enumerate(results)
-        mc_batch[:, :, :, i]   .= r.mc_log
+        mc_batch[:, :, :, i] .= r.mc_log
         seed_batch[:, :, :, i] .= r.seed_log
     end
-    data_store.mc_log[:, :, :, idx_range]   .= mc_batch
+    data_store.mc_log[:, :, :, idx_range] .= mc_batch
     data_store.seed_log[:, :, :, idx_range] .= seed_batch
 
     # coral_dhw_log (conditional on ADRIA_LOG_DHW_TOLS)
@@ -1036,10 +1057,23 @@ function run_model(
 
     # Keeps track of the heat tolerance means of juvenilles to use as a base for thermal
     # tolerance enhancement
-    c_mean_reference .= copy(c_mean_t[:, 1, :])
+    c_mean_reference .= c_mean_t[:, 1, :]
 
     cover_transition_lb = 0.05
     cover_transition_ub = 0.80
+
+    # Preallocate per-timestep buffers to avoid repeated allocation in the hot loop
+    Δcover_loss_proportion = zeros(n_locs)
+    _is_reactive = any(
+        is_reactive(param_set[At(["seed_strategy", "fog_strategy", "mc_strategy"])])
+    )
+    dhw_p = is_guided ? similar(dhw_scen) : nothing
+    current_loc_cover = zeros(n_locs)
+    _loc_coral_cover = zeros(n_locs)
+    leftover_space_m² = zeros(n_locs)
+    _recruitment_col_sum = zeros(n_locs)
+    _recruitment_col_sum_2d = reshape(_recruitment_col_sum, 1, n_locs)
+    _permuted_buf = zeros(n_sizes, n_groups, n_locs)
 
     for tstep::Int64 in 2:tf
         # Convert cover to absolute values to use within CoralBlox model
@@ -1055,9 +1089,9 @@ function run_model(
         # Settlers from t-1 grow into observable sizes.
         C_cover_t[:, 1, habitable_locs] .+= recruitment
 
-        habitable_max_projected_cover =
-            cache_habitable_max_projected_cover .+
-            dropdims(sum(recruitment; dims=1); dims=1)
+        sum!(_recruitment_col_sum_2d, recruitment)
+        habitable_max_projected_cover .=
+            cache_habitable_max_projected_cover .+ _recruitment_col_sum
 
         relative_habitable_cover_cache[habitable_locs] .=
             loc_coral_cover(C_cover_t[:, :, habitable_locs]) ./
@@ -1175,15 +1209,15 @@ function run_model(
 
             if log_dhw_tols
                 # Log dhw tolerances if requested
+                permutedims!(_permuted_buf, c_mean_t, (2, 1, 3))
                 dhw_tol_mean_log[tstep, :, :] .= reshape(
-                    permutedims(c_mean_t, (2, 1, 3)), size(dhw_tol_mean_log)[2:3]
+                    _permuted_buf, size(dhw_tol_mean_log)[2:3]
                 )
             end
 
             if log_cover
-                cover_log[tstep, :, :] .= reshape(
-                    permutedims(C_cover[tstep, :, :, :], (2, 1, 3)), size(cover_log)[2:3]
-                )
+                permutedims!(_permuted_buf, @view(C_cover[tstep, :, :, :]), (2, 1, 3))
+                cover_log[tstep, :, :] .= reshape(_permuted_buf, size(cover_log)[2:3])
             end
         end
 
@@ -1198,11 +1232,15 @@ function run_model(
 
         for l in 1:n_locs
             s = sum(fec_scope[:, l])
-            prop_fecundity[:, l] .= s > 0.0 ? fec_scope[:, l] ./ s : 0.0
+            if s > 0.0
+                prop_fecundity[:, l] .= fec_scope[:, l] ./ s
+            else
+                prop_fecundity[:, l] .= 0.0
+            end
         end
 
-        _loc_coral_cover = loc_coral_cover(C_cover_t)
-        leftover_space_m² = relative_leftover_space(_loc_coral_cover) .* vec_abs_k
+        _loc_coral_cover .= loc_coral_cover(C_cover_t)
+        leftover_space_m² .= relative_leftover_space(_loc_coral_cover) .* vec_abs_k
 
         # Reset potential settlers to zero
         potential_settlers .= 0.0
@@ -1229,7 +1267,8 @@ function run_model(
         # Reset fecundity scope before next run
         fec_scope .= 0.0
 
-        leftover_space_m² .-= dropdims(sum(recruitment; dims=1); dims=1) .* vec_abs_k
+        sum!(_recruitment_col_sum_2d, recruitment)
+        leftover_space_m² .-= _recruitment_col_sum .* vec_abs_k
 
         # Determine intervention locations whose deployment is assumed to occur
         # between November to February.
@@ -1259,7 +1298,7 @@ function run_model(
 
         if is_guided
             # Use modified projected DHW (may have been affected by shading)
-            dhw_p = copy(dhw_scen)
+            dhw_p .= dhw_scen
             dhw_p[tstep, :] .= dhw_t
             dhw_projection .= weighted_projection(dhw_p, tstep, plan_horizon, decay, tf)
 
@@ -1276,7 +1315,7 @@ function run_model(
             )
 
             # Calculate current location cover
-            current_loc_cover = dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
+            current_loc_cover .= dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
         end
 
         # Fogging
@@ -1689,7 +1728,7 @@ function run_model(
         # Apply disturbances
 
         # ΔC_cover_t should only hold changes in cover due to env. disturbances
-        ΔC_cover_t .= copy(C_cover_t)
+        ΔC_cover_t .= C_cover_t
 
         # Store current c_mean before bleaching. This will be used in the next timestep to
         # update the settler's DHW tolerance dists.
@@ -1726,10 +1765,11 @@ function run_model(
         cyclone_mortality!(C_cover_t, cyclone_mortality_scen[tstep, :, :]')
 
         # Calculate survival_rate due to env. disturbances
-        no_mortality_mask = ΔC_cover_t .== 0.0
-        survival_rate_cache[.!no_mortality_mask] .= (C_cover_t ./ ΔC_cover_t)[.!no_mortality_mask]
-        survival_rate_cache[no_mortality_mask] .= 1.0
-        @assert sum(survival_rate_cache .> 1) == 0 "Survival rate should be <= 1"
+        @inbounds for i in eachindex(survival_rate_cache)
+            d = ΔC_cover_t[i]
+            survival_rate_cache[i] = d == 0.0 ? 1.0 : C_cover_t[i] / d
+        end
+        @assert !any(>(1.0), survival_rate_cache) "Survival rate should be <= 1"
 
         for loc in 1:n_locs
             apply_mortality!(
@@ -1742,13 +1782,10 @@ function run_model(
         C_cover[tstep, :, :, :] .= C_cover_t
 
         # Track cover loss for reactive strategies
-        _is_reactive = any(
-            is_reactive(param_set[At(["seed_strategy", "fog_strategy", "mc_strategy"])])
-        )
         if is_guided && _is_reactive && (tstep > 1)
             # Calculate proportional cover loss at each location
             # due to disturbances this timestep
-            Δcover_loss_proportion = zeros(n_locs)
+            Δcover_loss_proportion .= 0.0
             for loc in 1:n_locs
                 cover_before = sum(@view(ΔC_cover_t[:, :, loc]))
                 cover_after = sum(@view(C_cover_t[:, :, loc]))

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -236,7 +236,8 @@ function run_scenarios(
             ch = Channel{Tuple{Int,NamedTuple}}(2 * Threads.nthreads())
 
             chunk_start(c) = first_idx + c * chunk_size
-            chunk_len(c) = c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
+            chunk_len(c) =
+                c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
 
             writer = Threads.@spawn begin
                 buf = Dict{Int,NamedTuple}()
@@ -249,7 +250,7 @@ function run_scenarios(
                     chunk_ready[c + 1] += 1
 
                     while next_chunk < n_chunks &&
-                            chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
+                        chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
                         s = chunk_start(next_chunk)
                         n = chunk_len(next_chunk)
                         results = [buf[s + i] for i in 0:(n - 1)]
@@ -266,7 +267,9 @@ function run_scenarios(
             try
                 Threads.@threads :dynamic for i in 1:N_rcp
                     d, idx, scen = scen_args[i]
-                    result = _collect_scenario_results(d, scen, thread_fg[Threads.threadid()])
+                    result = _collect_scenario_results(
+                        d, scen, thread_fg[Threads.threadid()]
+                    )
                     put!(ch, (idx, result))
                 end
             finally

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -100,7 +100,7 @@ from the sum of all non-RCP parameters in `param_set`.
 """
 function set_random_seed(param_set::YAXArray)::AbstractRNG
     rnd_seed_val::Int64 =
-        ENV["ADRIA_RNG_SEED"] == "false" ?
+        get(ENV, "ADRIA_RNG_SEED", "false") == "false" ?
         floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
         parse(Int64, ENV["ADRIA_RNG_SEED"])
     return Xoshiro(rnd_seed_val)

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -99,7 +99,7 @@ from the sum of all non-RCP parameters in `param_set`.
 """
 function set_random_seed(param_set::YAXArray)::AbstractRNG
     rnd_seed_val::Int64 =
-        get(ENV, "ADRIA_RNG_SEED", "false") == "false" ?
+        ENV["ADRIA_RNG_SEED"] == "false" ?
         floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
         parse(Int64, ENV["ADRIA_RNG_SEED"])
     return Xoshiro(rnd_seed_val)

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -14,7 +14,9 @@ function setup()::Nothing
         config = TOML.parsefile(joinpath(pwd(), "config.toml"))
         config_operation = config["operation"]
         ENV["ADRIA_OUTPUT_DIR"] = config["results"]["output_dir"]
-        ENV["ADRIA_NUM_CORES"] = config_operation["num_cores"]
+        if haskey(config_operation, "num_cores")
+            @warn "config.toml: `num_cores` is deprecated and has no effect. Control parallelism by launching Julia with `--threads=N` (e.g. `julia --threads=auto`)."
+        end
         ENV["ADRIA_THRESHOLD"] = config_operation["threshold"]
         ENV["ADRIA_DEBUG"] =
             haskey(config_operation, "debug") ? config_operation["debug"] : false
@@ -34,7 +36,6 @@ function setup()::Nothing
 
         # Note: anything stored in ENV will be stored as String.
         ENV["ADRIA_OUTPUT_DIR"] = "./Outputs"
-        ENV["ADRIA_NUM_CORES"] = 1
         ENV["ADRIA_THRESHOLD"] = Float32(1e-8)
         ENV["ADRIA_DEBUG"] = false
         ENV["ADRIA_LOG_DHW_TOLS"] = false

--- a/test/domain.jl
+++ b/test/domain.jl
@@ -15,7 +15,6 @@ end
 
         # Ensure environment variables are set
         @test haskey(ENV, "ADRIA_OUTPUT_DIR")
-        @test haskey(ENV, "ADRIA_NUM_CORES")
         @test haskey(ENV, "ADRIA_THRESHOLD")
     end
 


### PR DESCRIPTION
**Performance and I/O refactor for resultset-tweak-merge**
This branch refactors run_scenarios and the result storage layer to reduce allocation pressure, improve parallel load balancing, and consolidate the on-disk Zarr layout. Results are numerically identical to iv-study-changes (Max |Δ| = 0.0 across all scenarios and timesteps).

**Parallelism**
Distributed/pmap is replaced with `Threads.@threads` for multi-scenario execution. Workers are now local threads rather than separate Julia processes, eliminating serialisation overhead and inter-process data copies. The `ADRIA_NUM_CORES` environment variable is deprecated; thread count is controlled by `--threads` at Julia startup.

**Execution pipeline**
Model computation is separated from disk I/O via two new functions: `_collect_scenario_results`, which returns a NamedTuple of in-memory arrays for one scenario, and `_write_batch!`, which flushes a completed chunk to the Zarr store. Scenarios are processed in configurable batches (`ADRIA_BATCH_SIZE`, default 32) so memory use is bounded independently of total scenario count.

**Allocation reduction in run_model**
Several arrays that were re-allocated each timestep are now pre-allocated once before the loop and updated in-place:

_loc_coral_cover, current_loc_cover, leftover_space_m², Δcover_loss_proportion, dhw_p
sum! replaces dropdims(sum(...)) for recruitment column sums
LinearExtensionCache is computed once per scenario rather than once per timestep
_is_reactive is computed once before the loop instead of inside it

**Zarr layout**
Six separate 3D location-metric arrays (relative_cover, relative_shelter_volume, absolute_shelter_volume, relative_juveniles, juvenile_indicator, coral_evenness) are consolidated into a single 4D array (timesteps × locations × metrics × scenarios). The load path slices by metric name using At() selectors and handles both the old and new layouts for backwards compatibility with existing result sets.

**Miscellaneous**
`build_state` in `strategies.jl` uses `Set{String}` for O(1) target lookups and returns a BitVector index rather than integer indices from findall.
RNG seed can now be set in the domain config file in addition to the environment variable.


Test results comparing `iv-study-changes` to `resultset-tweak-merge`.

@Zapiano best to do one final comparison run on your machine to quadruplely check that there are no differences in results.

```
julia --threads=1 --project=. compare_branches.jl --adria-base iv-study-changes --adria-target resultset-tweak-merge --cblox-base performance-tweaks --cblox-target performance-tweaks

=== Startup times ===
  Base   (iv-study-changes / performance-tweaks)   : 96.59s
  Target (resultset-tweak-merge / performance-tweaks) : 98.52s
  Δ                                     : +1.93s (+2.0%)

=== Comparing results ===
Shape          : (86, 4)  (timesteps × scenarios)
Max |Δ|        : 0.0
Max |Δ| / max  : 0.0
Mean |Δ|       : 0.0
Tolerance      : 0.0001  (absolute)

--- Per-scenario max |Δ| ---
  Scenario    Max |Δ|
  1           0.000000e+00
  2           0.000000e+00
  3           0.000000e+00
  4           0.000000e+00

--- Top-5 worst cells (timestep, scenario, |Δ|, base, target) ---
  Timestep    Scenario    |Δ|               base              target          
  1           1           0.000000e+00      2.907891e+09      2.907891e+09    
  2           1           0.000000e+00      3.120057e+09      3.120057e+09    
  3           1           0.000000e+00      2.472723e+09      2.472723e+09    
  4           1           0.000000e+00      1.840225e+09      1.840225e+09    
  5           1           0.000000e+00      2.525716e+09      2.525716e+09    

--- Mean |Δ| by timestep (first 10 / last 10) ---
  t=1     0.000000e+00
  t=2     0.000000e+00
  t=3     0.000000e+00
  t=4     0.000000e+00
  t=5     0.000000e+00
  t=6     0.000000e+00
  t=7     0.000000e+00
  t=8     0.000000e+00
  t=9     0.000000e+00
  t=10    0.000000e+00
  ...
  t=77    0.000000e+00
  t=78    0.000000e+00
  t=79    0.000000e+00
  t=80    0.000000e+00
  t=81    0.000000e+00
  t=82    0.000000e+00
  t=83    0.000000e+00
  t=84    0.000000e+00
  t=85    0.000000e+00
  t=86    0.000000e+00

No individual timestep exceeds tolerance

PASS — results are equivalent within tolerance 0.0001
```