### PR TITLE
Refactor parallel runner to Julia threads, fix FG buffer data race, and coral growth model corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,13 @@ input/
 output/
 .aider*
 GEMINI.md
+
+graphify-out/
+
+.claudeignore
+
+.claude/
+
+.graphify_python
+
+.graphify_uncached.txt

--- a/Manifest-v1.11.toml
+++ b/Manifest-v1.11.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.9"
 manifest_format = "2.0"
-project_hash = "8e7264f5e17fe8c1bb02d89afbafa975a5b8fe64"
+project_hash = "ce78128babf9e48da5d26f137af75146e3199d09"
 
 [[deps.ADRIAIndicators]]
 git-tree-sha1 = "aaa97fdc8125b525f4b11542cccedc64929826f7"
@@ -509,9 +509,9 @@ version = "0.6.4"
 
 [[deps.CoralBlox]]
 deps = ["DataStructures", "StaticArrays", "YAXArrays"]
-git-tree-sha1 = "22855962954938f08ad881c6312e78f4f5ebb661"
+git-tree-sha1 = "c3ee6d3fcafcd66b0252c2428feb6d8e9a219736"
 uuid = "f00a6e10-004a-11ef-3676-67ec635bc1a2"
-version = "1.1.5"
+version = "1.1.7"
 
     [deps.CoralBlox.extensions]
     CoralBloxPlotExt = "Makie"

--- a/Manifest-v1.11.toml
+++ b/Manifest-v1.11.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "8e7264f5e17fe8c1bb02d89afbafa975a5b8fe64"
 
 [[deps.ADRIAIndicators]]
-git-tree-sha1 = "18c4d5c27bb21232116f7d10e4b3fb4634c0b8b9"
+git-tree-sha1 = "aaa97fdc8125b525f4b11542cccedc64929826f7"
 uuid = "05ad51df-066f-4748-8c47-f6b67db83211"
-version = "0.2.0"
+version = "0.2.1"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "8b2b045b22740e4be20654175cc38291d48539db"

--- a/Project.toml
+++ b/Project.toml
@@ -77,7 +77,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 AvizExt = ["Makie", "GeoMakie", "GraphMakie"]
 
 [compat]
-ADRIAIndicators = "0.2"
+ADRIAIndicators = "0.2.1"
 Aqua = "0.8, 0.9"
 ArchGDAL = "0.9, 0.10"
 BlackBoxOptim = "0.6"

--- a/docs/src/usage/getting_started.md
+++ b/docs/src/usage/getting_started.md
@@ -33,9 +33,10 @@ This is optional, and the assumed default values are shown below:
 
 ```toml
 [operation]
-num_cores = 2     # No. of cores to use. Values <= 0 will use all available cores.
-threshold = 1e-8  # Result values below this will be set to 0.0 (to save disk space)
-debug = false     # Disable multi-processing to allow error messages to be shown
+num_cores = 2         # No. of cores to use. Values <= 0 will use all available cores.
+threshold = 1e-8      # Result values below this will be set to 0.0 (to save disk space)
+debug = false         # Disable multi-processing to allow error messages to be shown
+log_dhw_tols = false  # Log per-location coral DHW tolerance trajectories (increases disk usage)
 
 [results]
 output_dir = "./Outputs"  # Change this to point to where you want to store results

--- a/docs/src/usage/getting_started.md
+++ b/docs/src/usage/getting_started.md
@@ -34,12 +34,14 @@ This is optional, and the assumed default values are shown below:
 ```toml
 [operation]
 num_cores = 2         # No. of cores to use. Values <= 0 will use all available cores.
-threshold = 1e-8      # Result values below this will be set to 0.0 (to save disk space)
-debug = false         # Disable multi-processing to allow error messages to be shown
-log_dhw_tols = false  # Log per-location coral DHW tolerance trajectories (increases disk usage)
+threshold = 1e-8      # Result values below this will be set to 0.0 (to save disk space).
+debug = false         # Disable multi-processing to allow error messages to be shown.
+log_dhw_tols = false  # Log per-location coral DHW tolerance trajectories (increases disk usage).
+log_cover = false     # Log raw results (coral cover) for all timesteps, locations, functional groups, size classes and scenarios.
+rng_seed = false      # Set to an integer to be used as RNG seed for all runs.
 
 [results]
-output_dir = "./Outputs"  # Change this to point to where you want to store results
+output_dir = "./Outputs"  # Change this to point to where you want to store results.
 ```
 
 This `config.toml` file is specific to your computer and project. It **should not be**

--- a/ext/AvizExt/theme.jl
+++ b/ext/AvizExt/theme.jl
@@ -7,6 +7,8 @@ const COLORS::Dict{Symbol,Union{Symbol,String}} = Dict(
     :RCP45 => :darkblue,
     :RCP60 => :seagreen,
     :RCP85 => :orangered,
+    :scenarios => :steelblue,
+    :interventions => :steelblue,
     :counterfactual => :red,
     :unguided => :lawngreen,
     :guided => :dodgerblue,
@@ -21,7 +23,7 @@ function colors(
     scen_groups::Dict{Symbol,BitVector}
 )::Dict{Symbol,COLOR_TYPE}
     group_names = keys(scen_groups)
-    if count(group_names .∉ [keys(COLORS)]) > 0
+    if count(group_names .∉ Ref(keys(COLORS))) > 0
         colormap = cgrad(:brg, length(group_names); categorical=true).colors
 
         return Dict{Symbol,COLOR_TYPE}(

--- a/ext/AvizExt/viz/scenarios.jl
+++ b/ext/AvizExt/viz/scenarios.jl
@@ -76,6 +76,27 @@ function ADRIA.viz.scenarios!(
     )
 end
 function ADRIA.viz.scenarios(
+    outcomes::YAXArray,
+    scen_groups::Dict{Symbol,BitVector};
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(:size => (800, 300)),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Figure
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+
+    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
+    xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
+    ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
+
+    ADRIA.viz.scenarios!(
+        g, ax, outcomes, scen_groups;
+        opts=opts, axis_opts=axis_opts, series_opts=series_opts
+    )
+    return f
+end
+function ADRIA.viz.scenarios(
     rs::RMEResultSet,
     outcomes::YAXArray;
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(:by_RCP => false),
@@ -328,9 +349,10 @@ function _confints(
     # Compute confints
     confints::Array{Float64} = zeros(n_timesteps, n_groups, 3)
     agg_dim = symdiff(axes_names(outcomes), [:timesteps])[1]
+    outcomes_arr = Array(outcomes)
     for (idx, group) in enumerate(group_names)
         confints[:, idx, :] = series_confint(
-            outcomes.data[:, scen_groups[group]]; agg_dim=agg_dim
+            outcomes_arr[:, scen_groups[group]]; agg_dim=agg_dim
         )
     end
 
@@ -351,7 +373,7 @@ function scenarios_confint!(
     end
 
     series_colors = [_colors[group] for group in ordered_groups]
-    series!(ax, x_vals, confints[:, :, 2]'; solid_color=series_colors)
+    series!(ax, x_vals, Matrix(confints[:, :, 2]'); solid_color=series_colors)
 
     return nothing
 end
@@ -362,14 +384,20 @@ function scenarios_confint!(
     group_names::Vector{Symbol}
 )::Nothing
     _colors::Dict{Symbol,COLOR_TYPE} = colors(scen_groups)
-    confints = _confints(outcomes, scen_groups, group_names)
-    return scenarios_confint!(
-        ax,
-        confints,
-        group_names,
-        _colors;
-        x_vals=collect(1:size(confints, 1))
-    )
+    x_vals = collect(1:size(outcomes, 1))
+    outcomes_arr = Array(outcomes)
+
+    single_groups = filter(g -> sum(scen_groups[g]) == 1, group_names)
+    for group in single_groups
+        idx = findfirst(scen_groups[group])
+        lines!(ax, x_vals, outcomes_arr[:, idx]; color=_colors[group])
+    end
+
+    multi_groups = filter(g -> sum(scen_groups[g]) > 1, group_names)
+    isempty(multi_groups) && return nothing
+
+    confints = _confints(outcomes, scen_groups, multi_groups)
+    return scenarios_confint!(ax, confints, multi_groups, _colors; x_vals=x_vals)
 end
 
 function scenarios_series!(
@@ -383,10 +411,11 @@ function scenarios_series!(
     _colors::Dict{Symbol,COLOR_TYPE} = colors(scen_groups)
     _alphas::Dict{Symbol,Float64} = alphas(scen_groups)
 
+    outcomes_arr = Array(outcomes)
     for group in group_names
         color = (_colors[group], _alphas[group])
-        scens = outcomes[:, scen_groups[group]]'
-        series!(ax, x_vals, scens.data; solid_color=color, series_opts...)
+        scens = Matrix(outcomes_arr[:, scen_groups[group]]')
+        series!(ax, x_vals, scens; solid_color=color, series_opts...)
     end
 
     return nothing
@@ -428,10 +457,87 @@ function _render_legend(
     _colors = colors(scen_groups)
     line_els::Vector{LineElement} = [LineElement(; color=_colors[n]) for n in legend_labels]
 
-    title = pop!(legend_opts, :title, "Intervention scenarios")
+    title = pop!(legend_opts, :title, "Scenarios")
     Legend(g, line_els, labels(legend_labels), title; framevisible=false, legend_opts...)
 
     return nothing
+end
+
+"""
+    ADRIA.viz.scenarios(outcomes::YAXArray; opts=Dict(), fig_opts=Dict(), axis_opts=Dict(), series_opts=Dict())::Figure
+    ADRIA.viz.scenarios!(g::Union{GridLayout,GridPosition}, outcomes::YAXArray; opts=Dict(), axis_opts=Dict(), series_opts=Dict())
+
+Plot scenario outcomes over time directly from a `YAXArray`, without requiring a result set
+or scenario `DataFrame`. All scenarios are treated as a single group.
+
+# Examples
+```julia
+# outcomes is a (timesteps × scenarios) YAXArray, e.g. from an external source
+ADRIA.viz.scenarios(outcomes)
+
+# Plot individual lines instead of the confidence interval band
+ADRIA.viz.scenarios(outcomes; opts=Dict(:summarize => false))
+```
+
+# Arguments
+- `outcomes` : Results of scenario metric, with dimensions `(timesteps, scenarios)`
+- `opts` : Aviz options
+    - `summarize` : plot confidence interval band. Defaults to true.
+    - `legend` : show legend. Defaults to false.
+    - `histogram` : show marginal histogram. Defaults to false.
+- `fig_opts` : Additional options to pass to `Figure`
+- `axis_opts` : Additional options to pass to `Axis`
+  See: https://docs.makie.org/v0.19/api/index.html#Axis
+- `series_opts` : Additional options to pass to `series!`
+  See: https://docs.makie.org/v0.19/api/index.html#series!
+
+# Returns
+Figure or GridPosition
+"""
+function ADRIA.viz.scenarios(
+    outcomes::YAXArray;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(:size => (800, 300)),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Figure
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+    ADRIA.viz.scenarios!(
+        g, outcomes; opts=opts, axis_opts=axis_opts, series_opts=series_opts
+    )
+    return f
+end
+function ADRIA.viz.scenarios!(
+    g::Union{GridLayout,GridPosition},
+    outcomes::YAXArray;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    series_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Union{GridLayout,GridPosition}
+    xtick_vals = get(axis_opts, :xticks, _time_labels(timesteps(outcomes)))
+    xtick_rot = get(axis_opts, :xticklabelrotation, 2 / π)
+
+    if !haskey(axis_opts, :title)
+        axis_opts[:title] = outcome_title(outcomes)
+    end
+
+    ax = Axis(g[1, 1]; xticks=xtick_vals, xticklabelrotation=xtick_rot, axis_opts...)
+
+    n_scenarios = size(outcomes, 2)
+    scen_groups = Dict{Symbol,BitVector}(:scenarios => trues(n_scenarios))
+    opts[:legend] = get(opts, :legend, false)
+    opts[:histogram] = get(opts, :histogram, false)
+
+    return ADRIA.viz.scenarios!(
+        g,
+        ax,
+        outcomes,
+        scen_groups;
+        opts=opts,
+        axis_opts=axis_opts,
+        series_opts=series_opts
+    )
 end
 
 """
@@ -459,8 +565,9 @@ function _sort_keys(
         by_RCP && return sort(collect(keys(scenario_types)))
         !isempty(default_names) && return default_names
 
-        default_keys = [:counterfactual, :unguided, :guided]
-        return default_keys[default_keys .∈ [scen_types]]
+        default_keys = [:counterfactual, :interventions, :unguided, :guided]
+        filtered = default_keys[default_keys .∈ [scen_types]]
+        return isempty(filtered) ? scen_types : filtered
     elseif by == :variance
         msg = "When sorting by variance, optional parameter `outcomes` must be provided"
         isempty(outcomes) && throw(ArgumentError(msg))

--- a/ext/AvizExt/viz/spatial.jl
+++ b/ext/AvizExt/viz/spatial.jl
@@ -353,8 +353,8 @@ Plot an arbitrary GeoDataFrame, optionally specifying a color for each feature.
 - `geom_col` : Column in GeoDataFrame that holds feature data
 - `color` : Colors to use for each feature
 """
-function ADRIA.viz.map(gdf::DataFrame; geom_col=:geometry, color=nothing)
-    f = Figure(; size=(600, 900), figure_padding=0.1)
+function ADRIA.viz.map(gdf::DataFrame; geom_col=:geometry, color=nothing, title="")
+    f = Figure(; size=(600, 900), figure_padding=0.2)
     ga = GeoAxis(
         f[1, 1];
         dest="+proj=latlong +datum=WGS84",
@@ -370,6 +370,22 @@ function ADRIA.viz.map(gdf::DataFrame; geom_col=:geometry, color=nothing)
     )
 
     ADRIA.viz.map!(ga, gdf; geom_col=geom_col, color=color)
+
+    if !isempty(title)
+        ga.title = title
+    end
+
+    if !isnothing(color)
+        finite_vals = filter(isfinite, color)  # clear out any infs
+        Colorbar(
+            f[1, 2];
+            colormap=:viridis,
+            colorrange=(minimum(finite_vals), maximum(finite_vals)),
+            vertical=true,
+            height=Relative(0.8),
+            tellwidth=true
+        )
+    end
 
     display(f)
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -554,3 +554,29 @@ function set_mc_target_locations!(
     domain.mc_target_locations = location_ids
     return nothing
 end
+
+"""
+    set_depth_med!(
+        domain::Domain,
+        new_depth_med::Float64
+    )::Nothing
+
+Set `depth_med` of all reefs to `new_depth_med`.
+
+# Arguments
+- `domain`: Domain to modify
+- `new_depth_med`: Depth to set as default across all reefs
+
+# Example
+```julia
+dom = ADRIA.load_domain("path/to/domain")
+ADRIA.set_depth_med!(dom, 7.0)
+```
+"""
+function set_depth_med!(
+    domain::Domain,
+    new_depth_med::Float64
+)::Nothing
+    domain.loc_data.depth_med .= new_depth_med
+    return nothing
+end

--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -167,7 +167,7 @@ function load_domain(
     end
 
     force_single_reef && (dhw_scens = dhw_scens[:, [1], :])
-    loc_ids::Vector{String} = collect(dhw_scens.locs)
+    loc_ids::Vector{String} = collect(dhw_scens.locations)
 
     # Standardize IDs to use for site/reef and cluster
     _standardize_cluster_ids!(spatial_data)

--- a/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -400,7 +400,7 @@ function load_DHW(
 )::YAXArray
     dhw_path = _data_folder_path(data_path, "dhw")
     rcp_files = _get_relevant_files(dhw_path, rcp)
-    rcp_files = filter(x -> occursin("SSP", x), rcp_files)
+    rcp_files = filter(x -> occursin("$(rcp)_", x), rcp_files)
     if isempty(rcp_files)
         ArgumentError("No DHW data files found in: $(dhw_path)")
     end
@@ -452,8 +452,8 @@ function load_DHW(
     return DataCube(
         data_cube[:, :, keep_ds];
         timesteps=_timeframe[1]:_timeframe[2],
-        locs=loc_ids,
-        scenarios=rcp_files[keep_ds]
+        locations=loc_ids,
+        scenarios=map(x -> split.(basename.(x), ".")[1], rcp_files[keep_ds])
     )
 end
 

--- a/src/decision/strategies/strategies.jl
+++ b/src/decision/strategies/strategies.jl
@@ -60,23 +60,22 @@ function is_periodic(strategy_idx::AbstractVector{T})::BitVector where {T<:Real}
 end
 
 function build_state(domain, strategy, states)
-    target_loc_indices = findall(
-        in.(domain.loc_ids, Ref(strategy.target_locations))
-    )
-    return strategy_status(strategy, states, target_loc_indices)
+    targets = strategy.target_locations
+    mask = in.(domain.loc_ids, Ref(Set{String}(targets)))
+    return strategy_status(strategy, states, mask)
 end
 
 function strategy_status(::DecisionStrategy, states, idx)
     return (
-        current_cover=states.current_cover[idx],
-        recent_cover_losses=first(states.recent_cover_losses)[idx]
+        current_cover=@view(states.current_cover[idx]),
+        recent_cover_losses=@view(first(states.recent_cover_losses)[idx])
     )
 end
 
 function strategy_status(::ReactiveStrategy, states, idx)
     return (
-        current_cover=states.current_cover[idx],
-        recent_cover_losses=first(states.recent_cover_losses)[idx],
-        last_deployment=states.last_deployment[idx]
+        current_cover=@view(states.current_cover[idx]),
+        recent_cover_losses=@view(first(states.recent_cover_losses)[idx]),
+        last_deployment=@view(states.last_deployment[idx])
     )
 end

--- a/src/ecosystem/connectivity.jl
+++ b/src/ecosystem/connectivity.jl
@@ -210,7 +210,14 @@ function connectivity_strength(
     # If a weighted metric is desired, use `custom_indegree_centrality`.
     C1 = in_method(g)
 
-    C2 = out_method(g)
+    # eigenvector_centrality uses an iterative QR algorithm that may not converge for
+    # degenerate/near-zero matrices (e.g. when coral cover collapses). Fall back to
+    # indegree centrality in that case.
+    C2 = try
+        out_method(g)
+    catch
+        custom_indegree_centrality(g)
+    end
 
     return (in_conn=C1, out_conn=C2, network=g)
 end

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -3,6 +3,7 @@ import ModelParameters: Model
 
 # Upper bound offset to use when re-creating critical DHW distributions
 const HEAT_UB = 8.0
+const HEAT_LB = 1.0     # minimum susceptibility threshold
 
 """
     functional_group_names()::Vector{Symbol}

--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -2,7 +2,7 @@ using DataFrames
 import ModelParameters: Model
 
 # Upper bound offset to use when re-creating critical DHW distributions
-const HEAT_UB = 10.0
+const HEAT_UB = 8.0
 
 """
     functional_group_names()::Vector{Symbol}

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -286,7 +286,8 @@ function bleaching_mortality!(
     depth_coeff::Vector{Float64},
     stdev::AbstractMatrix{Float64},
     dist_t::AbstractArray{Float64,3},
-    bleach_dhw::SubArray{Float64}
+    bleach_dhw::SubArray{Float64},
+    tol_ceil::AbstractArray{Float64,3}
 )::Nothing
     n_groups, n_sizes, n_locs = size(cover)
 
@@ -318,11 +319,12 @@ function bleaching_mortality!(
                 end
 
                 μ::Float64 = dist_t[grp, sc, loc]
+                μ_ceil::Float64 = tol_ceil[grp, sc, loc]  # initial mean + HEAT_UB (fixed)
                 affected_pop::Float64 = truncated_normal_cdf(
                     # Use the previous bleaching DHW as the distribution lower bound,
                     # with 4.0 DHW-weeks as the minimum susceptibility threshold.
                     dhw[loc], μ, stdev[grp, sc], max(4.0, bleach_dhw[1, grp, sc, loc]),
-                    μ + HEAT_UB
+                    μ_ceil
                 )
 
                 mort_pop::Float64 = 0.0
@@ -344,12 +346,14 @@ function bleaching_mortality!(
                 # the truncation effectively identical to truncating at 0.
                 bleach_dhw[2, grp, sc, loc] = dhw[loc]
                 if mort_pop > 0.0
-                    # Re-create distribution truncated at current bleaching DHW: survivors
+                    # 1. Re-create distribution truncated at current bleaching DHW: survivors
                     # must have had tolerance above dhw[loc], so this is the correct lower
-                    # bound. Use same stdev as target size class to maintain genetic variance
+                    # bound.
+                    #
+                    # 2. Use same stdev as target size class to maintain genetic variance
                     # pers comm K.B-N (2023-08-09 16:24 AEST)
                     dist_t[grp, sc, loc] = truncated_normal_mean(
-                        μ, stdev[grp, sc], 4.0, μ + HEAT_UB
+                        μ, stdev[grp, sc], 4.0, μ_ceil
                     )
 
                     # Update population
@@ -485,10 +489,24 @@ function adjust_DHW_distribution!(
 
     return nothing
 end
+"""
+    adjust_DHW_distribution!(cover_t_1, dist_t, growth_rate, tol_ceil)
+
+Adjust critical DHW distributions across all groups and locations as corals mature
+into higher size classes. Applies a hard ceiling so tolerance cannot exceed
+`tol_ceil` (initial population mean + HEAT_UB) regardless of size-class redistribution.
+
+# Arguments
+- `cover_t_1`  : Coral cover at the previous timestep (groups × sizes × locations).
+- `dist_t`     : Tolerance distribution means for the current timestep; updated in place.
+- `growth_rate`: Growth rates per (group, size, location).
+- `tol_ceil`   : Per-(group, size, location) tolerance ceiling (initial mean + HEAT_UB).
+"""
 function adjust_DHW_distribution!(
     cover_t_1::SubArray{T,3},
     dist_t::AbstractArray{T,3},
-    growth_rate::AbstractArray{T,3}
+    growth_rate::AbstractArray{T,3},
+    tol_ceil::AbstractArray{T,3}
 )::Nothing where {T<:Float64}
     groups, _, locs = axes(cover_t_1)
 
@@ -506,6 +524,7 @@ function adjust_DHW_distribution!(
         end
     end
 
+    dist_t .= min.(dist_t, tol_ceil)
     return nothing
 end
 
@@ -532,7 +551,10 @@ absolute units.
 - `tp` : Connectivity matrix.
 - `settlers` : Recruitment cover matrix for each functional group (rows) and locations (cols).
 - `fecundity_per_m²` : Fecundity in number of corals per area (in m²) each functional group.
-- `h²` : Heritability parameter.
+- `h²`      : Heritability parameter.
+- `tol_ceil`: Per-(group, size, location) tolerance ceiling (initial mean + HEAT_UB).
+  Applied as a hard cap to `c_mean_t` after settler tolerances are written, preventing
+  connectivity-driven drift from compounding across timesteps beyond the initial ceiling.
 """
 function settler_DHW_tolerance!(
     c_mean_t_1::AbstractArray{F,3},
@@ -542,7 +564,8 @@ function settler_DHW_tolerance!(
     tp::SparseMatrixCSC{F},
     settlers::AbstractMatrix{F},
     fecundity_per_m²::AbstractMatrix{F},
-    h²::F
+    h²::F,
+    tol_ceil::AbstractArray{F,3}
 )::Nothing where {F<:Float64}
     groups, _, locs = axes(c_mean_t_1)
     n_groups = length(groups)
@@ -622,6 +645,7 @@ function settler_DHW_tolerance!(
         end
     end
 
+    c_mean_t .= min.(c_mean_t, tol_ceil)
     return nothing
 end
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -290,7 +290,13 @@ function bleaching_mortality!(
 )::Nothing
     n_groups, n_sizes, n_locs = size(cover)
 
-    non_juveniles = 1:n_sizes
+    # New evidence that all size classes bleach
+    # Álvarez-Noriega et al., 2025.
+    # Challenging Paradigms Around the Role of Colony Size, Taxa, and Environment on
+    # Bleaching Susceptibility.
+    # Global Change Biology 31, e70090.
+    # https://doi.org/10.1111/gcb.70090
+    all_sizes = 1:n_sizes
 
     # Potential bleaching locations (skip locations with no heat stress)
     active_locs = findall(dhw .> 4.0)
@@ -305,7 +311,7 @@ function bleaching_mortality!(
                 continue
             end
 
-            for sc in non_juveniles
+            for sc in all_sizes
                 # Skip location if there is no population
                 if cover[grp, sc, loc] == 0.0
                     continue

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -549,13 +549,11 @@ function settler_DHW_tolerance!(
     # Cache for settlers c_mean for each functional group
     c_mean_per_group::Vector{Float64} = zeros(Float64, n_groups)
 
-    source_loc_idx = 1:sum(dropdims(sum(settlers; dims=1); dims=1) .> 0)
-    for loc in source_loc_idx
+    pos_settlers_loc_idx = findall(dropdims(sum(settlers; dims=1); dims=1) .> 0)
+    for loc in pos_settlers_loc_idx
         for grp in groups
             cover_sum = sum(C_cover_t[grp, fecund_size_mask, loc])
-            if cover_sum == 0
-                continue
-            end
+            (cover_sum == 0) ? continue : 0
             w = StatsBase.weights(C_cover_t[grp, fecund_size_mask, loc] ./ cover_sum)
             c_mean_per_group .=
                 breeders.(

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -286,7 +286,7 @@ function bleaching_mortality!(
     depth_coeff::Vector{Float64},
     stdev::AbstractMatrix{Float64},
     dist_t::AbstractArray{Float64,3},
-    prop_mort::SubArray{Float64}
+    bleach_dhw::SubArray{Float64}
 )::Nothing
     n_groups, n_sizes, n_locs = size(cover)
 
@@ -313,9 +313,9 @@ function bleaching_mortality!(
 
                 μ::Float64 = dist_t[grp, sc, loc]
                 affected_pop::Float64 = truncated_normal_cdf(
-                    # Use the previous mortality threshold or 4.0 as the minimum,
-                    # whichever is greater
-                    dhw[loc], μ, stdev[grp, sc], max(4.0, prop_mort[1, grp, sc, loc]),
+                    # Use the previous bleaching DHW as the distribution lower bound,
+                    # with 4.0 DHW-weeks as the minimum susceptibility threshold.
+                    dhw[loc], μ, stdev[grp, sc], max(4.0, bleach_dhw[1, grp, sc, loc]),
                     μ + HEAT_UB
                 )
 
@@ -331,13 +331,19 @@ function bleaching_mortality!(
                     end
                 end
 
-                prop_mort[2, grp, sc, loc] = mort_pop
+                # Store current DHW (DHW-weeks) as the bleaching threshold for this location.
+                # Previously stored mort_pop (a dimensionless fraction 0-1), which caused a
+                # dimensional mismatch: the value was used as a lower bound on the DHW
+                # tolerance distribution (units: DHW-weeks) in the next timestep, making
+                # the truncation effectively identical to truncating at 0.
+                bleach_dhw[2, grp, sc, loc] = dhw[loc]
                 if mort_pop > 0.0
-                    # Re-create distribution
-                    # Use same stdev as target size class to maintain genetic variance
+                    # Re-create distribution truncated at current bleaching DHW: survivors
+                    # must have had tolerance above dhw[loc], so this is the correct lower
+                    # bound. Use same stdev as target size class to maintain genetic variance
                     # pers comm K.B-N (2023-08-09 16:24 AEST)
                     dist_t[grp, sc, loc] = truncated_normal_mean(
-                        μ, stdev[grp, sc], mort_pop, μ + HEAT_UB
+                        μ, stdev[grp, sc], 4.0, μ + HEAT_UB
                     )
 
                     # Update population

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -759,10 +759,13 @@ Calculates coral recruitment for each species/group and location.
 # Returns
 λ, total coral recruitment for each coral taxa and location based on a Poisson distribution.
 """
-function recruitment_rate(larval_pool::AbstractArray{T,2}, A::AbstractArray{T};
-    α::Union{T,Vector{T}}=2.5, β::Union{T,Vector{T}}=5000.0)::Matrix{T} where {T<:Float64}
+function recruitment_rate(
+    larval_pool::AbstractArray{T,2}, A::AbstractArray{T};
+    α::Union{T,Vector{T}}=2.5, β::Union{T,Vector{T}}=5000.0, rng=Random.GLOBAL_RNG
+)::Matrix{T} where {T<:Float64}
     sd = settler_density.(α, β, larval_pool) .* A'
-    @views sd[sd .> 0.0] .= rand.(Poisson.(sd[sd .> 0.0]))
+
+    @views sd[sd .> 0.0] .= rand.(rng, Poisson.(sd[sd .> 0.0]))
 
     return sd
 end
@@ -794,7 +797,8 @@ function settler_cover(
     α::V,
     β::V,
     basal_area_per_settler::V,
-    potential_settlers::T
+    potential_settlers::T;
+    rng::AbstractRNG=Random.GLOBAL_RNG
 )::T where {T<:AbstractMatrix{Float64},V<:Vector{Float64}}
 
     # Send larvae out into the world (reuse potential_settlers to reduce allocations)
@@ -811,7 +815,7 @@ function settler_cover(
     # Larvae have landed, work out how many are recruited
     # Determine area covered by recruited larvae (settler cover) per m^2
     # recruits per m^2 per site multiplied by area per settler
-    return recruitment_rate(potential_settlers, leftover_space; α=α, β=β) .*
+    return recruitment_rate(potential_settlers, leftover_space; α=α, β=β, rng=rng) .*
            basal_area_per_settler
 end
 

--- a/src/ecosystem/corals/growth.jl
+++ b/src/ecosystem/corals/growth.jl
@@ -289,7 +289,7 @@ function bleaching_mortality!(
     bleach_dhw::SubArray{Float64},
     tol_ceil::AbstractArray{Float64,3}
 )::Nothing
-    n_groups, n_sizes, n_locs = size(cover)
+    n_groups, n_sizes, _ = size(cover)
 
     # New evidence that all size classes bleach
     # Álvarez-Noriega et al., 2025.
@@ -300,7 +300,8 @@ function bleaching_mortality!(
     all_sizes = 1:n_sizes
 
     # Potential bleaching locations (skip locations with no heat stress)
-    active_locs = findall(dhw .> 4.0)
+    # Use HEAT_LB (heat tolerance distribution lower bound) as the bleaching threshold
+    active_locs = findall(dhw .> HEAT_LB)
 
     # Adjust distributions for each functional group over all locations, ignoring juveniles
     # we assume the high background mortality of juveniles includes DHW mortality
@@ -322,8 +323,8 @@ function bleaching_mortality!(
                 μ_ceil::Float64 = tol_ceil[grp, sc, loc]  # initial mean + HEAT_UB (fixed)
                 affected_pop::Float64 = truncated_normal_cdf(
                     # Use the previous bleaching DHW as the distribution lower bound,
-                    # with 4.0 DHW-weeks as the minimum susceptibility threshold.
-                    dhw[loc], μ, stdev[grp, sc], max(4.0, bleach_dhw[1, grp, sc, loc]),
+                    # with 4.0 DHW-weeks as the minimum susceptibility threshold
+                    dhw[loc], μ, stdev[grp, sc], max(HEAT_LB, bleach_dhw[1, grp, sc, loc]),
                     μ_ceil
                 )
 
@@ -353,7 +354,7 @@ function bleaching_mortality!(
                     # 2. Use same stdev as target size class to maintain genetic variance
                     # pers comm K.B-N (2023-08-09 16:24 AEST)
                     dist_t[grp, sc, loc] = truncated_normal_mean(
-                        μ, stdev[grp, sc], 4.0, μ_ceil
+                        μ, stdev[grp, sc], HEAT_LB, μ_ceil
                     )
 
                     # Update population

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -121,6 +121,9 @@ tolerance enhancement.
 - `seed_locs` : Seeding locations
 - `seed_sc` : Size classes to seed
 - `a_adapt` : Level of assisted adaptation (as DHW tolerance increase)
+- `tol_ceil` : Per-(group, size, location) ceiling on tolerance (initial mean + HEAT_UB).
+  Applied as a hard cap to `c_dist_t` after mixing, so tolerance cannot drift above the
+  initial population ceiling regardless of cumulative seeding.
 """
 function update_tolerance_distribution!(
     scaled_seed::YAXArray,
@@ -130,7 +133,8 @@ function update_tolerance_distribution!(
     stdev::AbstractArray{T},
     seed_locs::Vector{Int64},
     seed_sc::AbstractMatrix{Bool},
-    a_adapt::AbstractVector{T}
+    a_adapt::AbstractVector{T},
+    tol_ceil::AbstractArray{T,3}
 )::Nothing where {T<:Float64}
 
     # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
@@ -154,9 +158,12 @@ function update_tolerance_distribution!(
         # Truncated normal distributions for deployed corals.
         # Lower bound fixed at 4.0 DHW-weeks (minimum susceptibility threshold),
         # consistent with bleaching_mortality! which uses the same floor.
+        # Upper bound anchored to initial mean + HEAT_UB (fixed ceiling) shifted by
+        # the a_adapt enhancement, so the cap does not drift with population tolerance.
         tn::Vector{Float64} =
             truncated_normal_mean.(
-                a_adapt_relative, stdev[seed_sc], 4.0, a_adapt_relative .+ HEAT_UB
+                a_adapt_relative, stdev[seed_sc], 4.0,
+                view(tol_ceil, :, :, loc)[seed_sc] .+ a_adapt
             )
 
         # If seeding an empty location, no need to do any further calculations
@@ -172,5 +179,6 @@ function update_tolerance_distribution!(
         c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
     end
 
+    c_dist_t .= min.(c_dist_t, tol_ceil)
     return nothing
 end

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -156,14 +156,13 @@ function update_tolerance_distribution!(
         c_dist_ti = @view(c_dist_t[seed_sc, loc])
 
         # Truncated normal distributions for deployed corals.
-        # Lower bound fixed at 4.0 DHW-weeks (minimum susceptibility threshold),
-        # consistent with bleaching_mortality! which uses the same floor.
-        # Upper bound anchored to initial mean + HEAT_UB (fixed ceiling) shifted by
-        # the a_adapt enhancement, so the cap does not drift with population tolerance.
+        # Lower bound fixed (HEAT_LB), consistent with bleaching_mortality! which uses the
+        # same floor. Upper bound anchored to initial mean + HEAT_UB (fixed ceiling) shifted
+        # by the a_adapt enhancement, so the cap does not drift with population tolerance.
         tn::Vector{Float64} =
             truncated_normal_mean.(
-                a_adapt_relative, stdev[seed_sc], 4.0,
-                view(tol_ceil, :, :, loc)[seed_sc] .+ a_adapt
+                a_adapt_relative, stdev[seed_sc], HEAT_LB,
+                view(tol_ceil, :, :, loc)[seed_sc]
             )
 
         # If seeding an empty location, no need to do any further calculations

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -134,11 +134,12 @@ function update_tolerance_distribution!(
 )::Nothing where {T<:Float64}
 
     # Calculate distribution weights using proportion of area (used as priors for MixtureModel)
+    # w_taxa[j, i] = fraction of total (cover + seeds) that consists of newly seeded corals
+    # for taxon j at location i. Used as the weight for the seeded distribution (tn).
     # Note: It is entirely possible for a location to be ranked in the top N, but
     #       with no deployments (for a given species). A location with 0 cover
-    #       and no deployments will therefore be NaN due to zero division.
-    #       These are replaced with 1.0 so that the distribution for unseeded
-    #       corals are used.
+    #       and 0 deployments will therefore be NaN due to zero division.
+    #       These are replaced with 0.0 so that the existing distribution is used unchanged.
     w_taxa::Matrix{Float64} = scaled_seed ./ (cover[seed_sc, seed_locs] .+ scaled_seed)
     # NaN occurs when both cover and scaled_seed are 0 (undeployed taxa at bare locations).
     replace!(w_taxa, NaN => 0.0)
@@ -150,11 +151,12 @@ function update_tolerance_distribution!(
         # Previous distributions
         c_dist_ti = @view(c_dist_t[seed_sc, loc])
 
-        # Truncated normal distributions for deployed corals
-        # Assume same stdev and bounds as original
+        # Truncated normal distributions for deployed corals.
+        # Lower bound fixed at 4.0 DHW-weeks (minimum susceptibility threshold),
+        # consistent with bleaching_mortality! which uses the same floor.
         tn::Vector{Float64} =
             truncated_normal_mean.(
-                a_adapt_relative, stdev[seed_sc], 0.0, a_adapt_relative .+ HEAT_UB
+                a_adapt_relative, stdev[seed_sc], 4.0, a_adapt_relative .+ HEAT_UB
             )
 
         # If seeding an empty location, no need to do any further calculations
@@ -163,10 +165,10 @@ function update_tolerance_distribution!(
             continue
         end
 
-        # Create new distributions by mixing previous and current distributions using
-        # proportional cover as the priors/weights
-        # Priors (weights based on cover for each species)
-        tx::Vector{Weights} = Weights.(eachcol(vcat(w_taxa[:, i]', 1.0 .- w_taxa[:, i]')))
+        # Mix existing and seeded distributions weighted by their proportional cover.
+        # w_taxa = seeds fraction → weights tn (seeded enhanced distribution).
+        # 1 - w_taxa = existing fraction → weights c_dist_ti (pre-seeding distribution).
+        tx::Vector{Weights} = Weights.(eachcol(vcat(1.0 .- w_taxa[:, i]', w_taxa[:, i]')))
         c_dist_t[seed_sc, loc] = sum.(eachcol(vcat(c_dist_ti', tn')), tx)
     end
 

--- a/src/interventions/seeding.jl
+++ b/src/interventions/seeding.jl
@@ -140,7 +140,8 @@ function update_tolerance_distribution!(
     #       These are replaced with 1.0 so that the distribution for unseeded
     #       corals are used.
     w_taxa::Matrix{Float64} = scaled_seed ./ (cover[seed_sc, seed_locs] .+ scaled_seed)
-    replace!(w_taxa, NaN => 1.0)
+    # NaN occurs when both cover and scaled_seed are 0 (undeployed taxa at bare locations).
+    replace!(w_taxa, NaN => 0.0)
 
     # Update critical DHW distribution for deployed size classes
     a_adapt_relative = copy(a_adapt)

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -58,7 +58,7 @@ Load shading log from a Zarr log group, handling both the new combined format
 (`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
 """
 function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
-    if "shading_log" in keys(log_set)
+    if haskey(log_set, "shading_log")
         return DataCube(
             log_set["shading_log"],
             Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -16,7 +16,7 @@ const SPATIAL_DATA = "spatial"
 
 abstract type ResultSet end
 
-struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF} <: ResultSet
+struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
     name::String
     RCP::String
     invoke_time::String
@@ -44,6 +44,7 @@ struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,DF} <: ResultSet
     fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
     shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
     coral_dhw_tol_log::D3
+    coral_cover_log::D4
 end
 
 function ResultSet(
@@ -88,7 +89,11 @@ function ResultSet(
         DataCube(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
-        )
+        ),
+        haskey(log_set, "coral_cover_log") ? DataCube(
+            log_set["coral_cover_log"],
+            Symbol.(Tuple(log_set["coral_cover_log"].attrs["structure"]))
+        ) : nothing
     )
 end
 
@@ -221,7 +226,7 @@ function combine_results(result_sets...)::ResultSet
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_tol_log],
+        zip([:ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
                 z_store,
                 rs1.loc_ids,

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -256,6 +256,7 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), nrow(all_inputs))
     logs = (;
         zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
@@ -265,7 +266,8 @@ function combine_results(result_sets...)::ResultSet
                 size(rs1.seed_log, :timesteps),
                 size(rs1.seed_log, :locations),
                 size(rs1.seed_log, :coral_id),
-                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id),
+                batch_size
             )
         )...
     )

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -14,6 +14,13 @@ const MODEL_SPEC = "model_spec"
 const RESULTS = "results"
 const SPATIAL_DATA = "spatial"
 
+# Combined store name for the 6 location-based outcome metrics
+const LOC_METRICS = "loc_outcomes"
+const LOC_METRIC_NAMES = [
+    :relative_cover, :relative_shelter_volume, :absolute_shelter_volume,
+    :relative_juveniles, :juvenile_indicator, :coral_evenness
+]
+
 abstract type ResultSet end
 
 struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
@@ -41,10 +48,35 @@ struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
     ranks::A
     mc_log::B  # Values stored in m^2
     seed_log::B  # Values stored in m^2
-    fog_log::C   # Reduction in bleaching mortality (0.0 - 1.0)
-    shade_log::C # Reduction in bleaching mortality (0.0 - 1.0)
+    shading_log::C  # Fog and shade intervention log, dims: (timesteps, locations, intervention, scenarios)
     coral_dhw_tol_log::D3
     coral_cover_log::D4
+end
+
+"""
+Load shading log from a Zarr log group, handling both the new combined format
+(`shading_log`) and old stores that kept `fog` and `shade` as separate arrays.
+"""
+function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
+    if "shading_log" in keys(log_set)
+        return DataCube(
+            log_set["shading_log"],
+            Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))
+        )
+    end
+
+    # Old format: two separate (T, L, N) arrays — load and stack into (T, L, 2, N)
+    fog_arr = log_set["fog"][:, :, :]
+    shade_arr = log_set["shade"][:, :, :]
+    tf, n_locs, n_scens = size(fog_arr)
+    combined = Array{Float32}(undef, tf, n_locs, 2, n_scens)
+    combined[:, :, 1, :] .= fog_arr
+    combined[:, :, 2, :] .= shade_arr
+    return DataCube(
+        combined;
+        timesteps=1:tf, locations=1:n_locs,
+        intervention=["fog", "shade"], scenarios=1:n_scens
+    )
 end
 
 function ResultSet(
@@ -84,8 +116,7 @@ function ResultSet(
             Symbol.(Tuple(log_set["moving_corals"].attrs["structure"]))
         ),
         DataCube(log_set["seed"], Symbol.(Tuple(log_set["seed"].attrs["structure"]))),
-        DataCube(log_set["fog"], Symbol.(Tuple(log_set["fog"].attrs["structure"]))),
-        DataCube(log_set["shade"], Symbol.(Tuple(log_set["shade"].attrs["structure"]))),
+        _load_shading_log(log_set),
         DataCube(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
@@ -226,79 +257,88 @@ function combine_results(result_sets...)::ResultSet
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_tol_log, :coral_cover_log],
+        zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
                 z_store,
                 rs1.loc_ids,
                 nrow(all_inputs),
-                n_timesteps,
-                n_locs,
-                n_groups,
-                n_sizes
+                size(rs1.seed_log, :timesteps),
+                size(rs1.seed_log, :locations),
+                size(rs1.seed_log, :coral_id),
+                size(rs1.coral_dhw_tol_log, :species) ÷ size(rs1.seed_log, :coral_id)
             )
         )...
     )
 
-    # Copy logs over
+    # Copy logs over (all are 4D; try/catch handles the indexing generically)
     for log in keys(logs)
         scen_id = 1
         for rs in result_sets
             s_log = getfield(rs, log)
             n_log = getfield(logs, log)
-            rs_scen_len = size(s_log, :scenarios)
+            # coral_cover_log may be nothing for result sets loaded from old stores
+            rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
-            try
-                n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-            catch
-                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+            if !isnothing(s_log)
+                try
+                    n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                catch
+                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
+                end
             end
 
             scen_id = scen_id + rs_scen_len
         end
     end
 
-    metrics = keys(rs1.outcomes)
-    for m_name in metrics
-        m_dim_names = axes_names(rs1.outcomes[m_name])
-        properties = rs1.outcomes[m_name].properties
-        dim_struct = Dict{Symbol,Any}(
-            :structure => m_dim_names,
-            :metric_name => properties[:metric_name],
-            :metric_unit => properties[:metric_unit],
-            :axes_names => properties[:axes_names],
-            :axes_units => properties[:axes_units]
-        )
-        if :locations in m_dim_names
-            dim_struct[:unique_loc_ids] = rs1.loc_ids
-        end
-
-        result_dims = (size(rs1.outcomes[m_name])[1:(end - 1)]..., n_scenarios)
-        m_store = zcreate(
-            Float32,
-            result_dims...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(
-                z_store.folder,
-                RESULTS,
-                string(m_name)),
-            chunks=(result_dims[1:(end - 1)]..., 1),
-            attrs=dim_struct,
-            compressor=COMPRESSOR
-        )
-
-        # Copy results over
+    # Create combined location-based metrics store
+    tf_len = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :timesteps)
+    n_locs = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :locations)
+    n_loc_metrics = length(LOC_METRIC_NAMES)
+    loc_dims = (tf_len, n_locs, n_loc_metrics, n_scenarios)
+    loc_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
+            :unique_loc_ids => rs1.loc_ids,
+            :metrics => string.(LOC_METRIC_NAMES)
+        ),
+        compressor=COMPRESSOR
+    )
+    for (m_idx, m_name) in enumerate(LOC_METRIC_NAMES)
         scen_id = 1
         for rs in result_sets
             rs_scen_len = size(rs.outcomes[m_name], :scenarios)
-            try
-                m_store[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            catch
-                m_store[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= rs.outcomes[m_name]
-            end
-
-            scen_id = scen_id + rs_scen_len
+            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[m_name]
+            scen_id += rs_scen_len
         end
+    end
+
+    # Taxa cover metric (groups axis instead of locations — kept as its own store)
+    taxa_name = :relative_taxa_cover
+    taxa_dims = (size(rs1.outcomes[taxa_name])[1:(end - 1)]..., n_scenarios)
+    taxa_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
+        chunks=(taxa_dims[1:(end - 1)]..., 1),
+        attrs=Dict{Symbol,Any}(
+            :structure => ("timesteps", "groups", "scenarios")
+        ),
+        compressor=COMPRESSOR
+    )
+    scen_id = 1
+    for rs in result_sets
+        rs_scen_len = size(rs.outcomes[taxa_name], :scenarios)
+        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[taxa_name]
+        scen_id += rs_scen_len
     end
 
     # Copy env stats

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -282,11 +282,7 @@ function combine_results(result_sets...)::ResultSet
             rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
             if !isnothing(s_log)
-                try
-                    n_log[:, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-                catch
-                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] .= s_log
-                end
+                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log
             end
 
             scen_id = scen_id + rs_scen_len

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -257,16 +257,9 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
-    n_cores::Int = parse(Int, get(ENV, "ADRIA_NUM_CORES", "1"))
     env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     n_scenarios = nrow(all_inputs)
-    batch_size::Int = if env_batch > 0
-        min(env_batch, n_scenarios)
-    elseif n_scenarios < n_cores
-        1
-    else
-        n_cores
-    end
+    batch_size::Int = env_batch > 0 ? min(env_batch, n_scenarios) : 1
     logs = (;
         zip(
             [

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -121,7 +121,8 @@ function ResultSet(
             log_set["coral_dhw_log"],
             Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
         ),
-        haskey(log_set, "coral_cover_log") ? DataCube(
+        haskey(log_set, "coral_cover_log") ?
+        DataCube(
             log_set["coral_cover_log"],
             Symbol.(Tuple(log_set["coral_cover_log"].attrs["structure"]))
         ) : nothing
@@ -267,7 +268,15 @@ function combine_results(result_sets...)::ResultSet
         n_cores
     end
     logs = (;
-        zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
+        zip(
+            [
+                :ranks,
+                :mc_log,
+                :seed_log,
+                :shading_log,
+                :coral_dhw_tol_log,
+                :coral_cover_log
+            ],
             setup_logs(
                 z_store,
                 rs1.loc_ids,
@@ -288,7 +297,8 @@ function combine_results(result_sets...)::ResultSet
             s_log = getfield(rs, log)
             n_log = getfield(logs, log)
             # coral_cover_log may be nothing for result sets loaded from old stores
-            rs_scen_len = isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
+            rs_scen_len =
+                isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
             if !isnothing(s_log)
                 n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -160,7 +160,7 @@ function _copy_env_data(
 end
 
 """
-    combine(result_sets...)::ResultSet
+    combine_results(result_sets...)::ResultSet
     combine_results(result_set_locs::Array{String})::ResultSet
 
 Combine arbitrary number of ADRIA result sets into a single data store.
@@ -256,7 +256,16 @@ function combine_results(result_sets...)::ResultSet
     n_locs = size(rs1.seed_log, :locations)
     n_groups = size(rs1.seed_log, :coral_id)
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
-    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), nrow(all_inputs))
+    n_cores::Int = parse(Int, get(ENV, "ADRIA_NUM_CORES", "1"))
+    env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
+    n_scenarios = nrow(all_inputs)
+    batch_size::Int = if env_batch > 0
+        min(env_batch, n_scenarios)
+    elseif n_scenarios < n_cores
+        1
+    else
+        n_cores
+    end
     logs = (;
         zip([:ranks, :mc_log, :seed_log, :shading_log, :coral_dhw_tol_log, :coral_cover_log],
             setup_logs(
@@ -300,7 +309,7 @@ function combine_results(result_sets...)::ResultSet
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
-        chunks=(loc_dims[1:3]..., 1),
+        chunks=(loc_dims[1:3]..., batch_size),
         attrs=Dict{Symbol,Any}(
             :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => rs1.loc_ids,
@@ -326,7 +335,7 @@ function combine_results(result_sets...)::ResultSet
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
-        chunks=(taxa_dims[1:(end - 1)]..., 1),
+        chunks=(taxa_dims[1:(end - 1)]..., batch_size),
         attrs=Dict{Symbol,Any}(
             :structure => ("timesteps", "groups", "scenarios")
         ),

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -102,9 +102,9 @@ function _rankings_data(rankings_set::ZArray{T})::YAXArray{T} where {T}
     ax_labels::Vector{Union{UnitRange{Int64},Vector{Symbol}}} =
         range.([1], size(rankings_set))
 
-    # Replace intervention
-    intervention_idx = findfirst(x -> x == :intervention, ax_names)
-    ax_labels[intervention_idx] = interventions()
+    # Replace interventions axis with named labels
+    intervention_idx = findfirst(x -> x == :interventions, ax_names)
+    !isnothing(intervention_idx) && (ax_labels[intervention_idx] = interventions())
 
     return DataCube(rankings_set; NamedTuple{ax_names}(ax_labels)...)
 end

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -284,7 +284,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
 
     n_group_and_size = n_groups * n_sizes
     local coral_dhw_log
-    if parse(Bool, ENV["ADRIA_DEBUG"]) == true
+    if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
         coral_dhw_log = zcreate(
             Float32,
             tf,

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -385,7 +385,7 @@ Sets up an on-disk result store.
 domain, (loc_outcomes, relative_taxa_cover, site_ranks, mc_log, seed_log, shading_log,
 coral_dhw_log, coral_cover_log)
 """
-function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
+function setup_result_store!(domain::Domain, scen_spec::DataFrame, batch_size::Int=0)::Tuple
     @set! domain.scenario_invoke_time = replace(
         string(now()), "T" => "_", ":" => "_", "." => "_"
     )
@@ -439,7 +439,10 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
     n_groups = domain.coral_growth.n_groups
-    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), n_scenarios)
+    batch_size = min(
+        batch_size > 0 ? batch_size : parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")),
+        n_scenarios
+    )
 
     # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
     loc_outcome_metrics::Vector{metrics.Metric} = [
@@ -746,7 +749,7 @@ function load_results(result_loc::String)::ResultSet
         try
             outcomes[sd_name] = DataCube(
                 data;
-                properties=Dict(
+                properties=Dict{Symbol,Any}(
                     p => data.attrs[string(p)] for p in outcome_properties
                     if haskey(data.attrs, string(p))
                 ),

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -314,7 +314,38 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         )
     end
 
-    return ranks, mc_log, seed_log, fog_log, shade_log, coral_dhw_log
+    local coral_cover_log
+    if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
+        coral_cover_log = zcreate(
+            Float32,
+            tf,
+            n_groups * n_sizes,
+            n_locs,
+            n_scens;
+            name="coral_cover_log",
+            fill_value=nothing,
+            fill_as_missing=false,
+            path=log_fn,
+            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            attrs=attrs
+        )
+    else
+        coral_cover_log = zcreate(
+            Float32,
+            tf,
+            n_groups * n_sizes,
+            1,
+            n_scens;
+            name="coral_cover_log",
+            fill_value=0.0,
+            fill_as_missing=false,
+            path=log_fn,
+            chunks=(tf, n_groups * n_sizes, 1, 1),
+            attrs=attrs
+        )
+    end
+
+    return ranks, mc_log, seed_log, fog_log, shade_log, coral_dhw_log, coral_cover_log
 end
 
 """
@@ -329,6 +360,7 @@ Sets up an on-disk result store.
 ├───env_stats
 ├───inputs
 ├───logs
+|   ├───coral_cover_log
 |   ├───coral_dhw_log
 │   ├───fog
 │   ├───rankings
@@ -552,7 +584,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
                 :seed_log,
                 :fog_log,
                 :shade_log,
-                :coral_dhw_log
+                :coral_dhw_log,
+                :coral_cover_log
             ),
             stores
         )...

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -198,8 +198,6 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
     # Store ranked location
     n_interventions = length(interventions())
     rank_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, n_interventions, n_scens)  # locations, location id and rank, no. scenarios
-    fog_dims::Tuple{Int64,Int64,Int64} = (tf, n_locs, n_scens)  # timeframe, location, no. scenarios
-
     # tf, no. species to seed, location id and rank, no. scenarios
     seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_groups, n_locs, n_scens)
 
@@ -244,29 +242,20 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         attrs=attrs
     )
 
-    attrs = Dict(
-        :structure => ("timesteps", "locations", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
-    )
-    fog_log = zcreate(
+    shading_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, 2, n_scens)
+    shading_log = zcreate(
         Float32,
-        fog_dims...;
-        name="fog",
+        shading_dims...;
+        name="shading_log",
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
-    )
-    shade_log = zcreate(
-        Float32,
-        fog_dims...;
-        name="shade",
-        fill_value=nothing,
-        fill_as_missing=false,
-        path=log_fn,
-        chunks=(fog_dims[1:2]..., 1),
-        attrs=attrs
+        chunks=(shading_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "intervention", "scenarios"),
+            :interventions => ["fog", "shade"],
+            :unique_loc_ids => unique_loc_ids
+        )
     )
 
     # TODO: Could log bleaching mortality
@@ -319,33 +308,33 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             n_locs,
             n_scens;
             name="coral_cover_log",
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, 1),
             attrs=attrs
         )
     else
         coral_cover_log = zcreate(
             Float32,
             tf,
-            n_groups * n_sizes,
+            n_group_and_size,
             1,
             n_scens;
             name="coral_cover_log",
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_group_and_size, 1, 1),
             attrs=attrs
         )
     end
 
-    return ranks, mc_log, seed_log, fog_log, shade_log, coral_dhw_log, coral_cover_log
+    return ranks, mc_log, seed_log, shading_log, coral_dhw_log, coral_cover_log
 end
 
 """
@@ -446,70 +435,57 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     tf, n_locations, _ = size(domain.dhw_scens)
     n_scenarios = nrow(scen_spec)
 
-    # Set up stores for each metric
-    function dim_lengths(metric_structure::Vector{Symbol})
-        dl = []
-        for d in metric_structure
-            if d == :timesteps
-                append!(dl, tf)
-            elseif d == :groups
-                append!(dl, domain.coral_growth.n_groups)
-            elseif d == :locations
-                append!(dl, n_locations)
-            elseif d == :scenarios
-                append!(dl, n_scenarios)
-            end
-        end
+    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
+    n_groups = domain.coral_growth.n_groups
 
-        return (dl...,)
-    end
-
-    outcome_metrics::Vector{metrics.Metric} = [
+    # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
+    loc_outcome_metrics::Vector{metrics.Metric} = [
         metrics.relative_cover,
         metrics.relative_shelter_volume,
         metrics.absolute_shelter_volume,
         metrics.relative_juveniles,
         metrics.juvenile_indicator,
-        metrics.coral_evenness,
-        metrics.relative_taxa_cover
+        metrics.coral_evenness
     ]
-
-    metric_symbols::Vector{Symbol} = metrics.to_symbol.(outcome_metrics)
-    metric_names::Vector{String} = metrics.to_string.(outcome_metrics; is_titlecase=true)
-    metric_units::Vector{String} = getfield.(outcome_metrics, :unit)
-    axis_names::Vector{Vector{Symbol}} = fill(
-        [:timesteps, :locations, :scenarios], length(outcome_metrics) - 1
-    )
-    # Add axis names relative to the last metric (relative_taxa_cover) separate as they are
-    # different from the other metrics
-    push!(axis_names, [:timesteps, :groups, :scenarios])
-    _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
-
-    outcomes_attrs::Vector{Dict{Symbol,Any}} = [
-        Dict(
+    n_loc_metrics = length(loc_outcome_metrics)
+    loc_dims = (tf, n_locations, n_loc_metrics, n_scenarios)
+    loc_outcomes_store = zcreate(
+        Float32,
+        loc_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
+        chunks=(loc_dims[1:3]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
-            :structure => axis_names[idx],
-            :metric_name => metric_names[idx],
-            :metric_unit => metric_units[idx],
-            :axes_names => axis_names[idx],
-            :axes_units => metrics.axes_units(axis_names[idx])
-        ) for (idx, _) in enumerate(metric_symbols)
-    ]
-    result_dims::Vector{NTuple{3,Int64}} = dim_lengths.(axis_names)
+            :metrics => string.(LOC_METRIC_NAMES),
+            :metric_names => metrics.to_string.(loc_outcome_metrics; is_titlecase=true),
+            :metric_units => getfield.(loc_outcome_metrics, :unit),
+            :axes_units => metrics.axes_units([:timesteps, :locations, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
-    # Create stores for each metric
-    stores = [
-        zcreate(
-            Float32,
-            result_dims[idx]...;
-            fill_value=nothing,
-            fill_as_missing=false,
-            path=joinpath(z_store.folder, RESULTS, string(m_name)),
-            chunks=(result_dims[idx][1:(end - 1)]..., 1),
-            attrs=outcomes_attrs[idx],
-            compressor=COMPRESSOR
-        ) for (idx, m_name) in enumerate(metric_symbols)
-    ]
+    # Separate store for relative_taxa_cover (timesteps × groups × scenarios)
+    taxa_cover_metric = metrics.relative_taxa_cover
+    taxa_dims = (tf, n_groups, n_scenarios)
+    taxa_cover_store = zcreate(
+        Float32,
+        taxa_dims...;
+        fill_value=nothing,
+        fill_as_missing=false,
+        path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
+        chunks=(taxa_dims[1:2]..., 1),
+        attrs=Dict(
+            :structure => ("timesteps", "groups", "scenarios"),
+            :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
+            :metric_unit => taxa_cover_metric.unit,
+            :axes_names => [:timesteps, :groups, :scenarios],
+            :axes_units => metrics.axes_units([:timesteps, :groups, :scenarios])
+        ),
+        compressor=COMPRESSOR
+    )
 
     # dhw and wave zarrays
     dhw_stats = []
@@ -557,7 +533,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     # Group all data stores
     stores = [
-        stores...,
+        loc_outcomes_store,
+        taxa_cover_store,
         dhw_stats...,
         wave_stats...,
         connectivity...,
@@ -567,7 +544,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             nrow(scen_spec),
             tf,
             n_locations,
-            domain.coral_growth.n_groups,
+            n_groups,
             domain.coral_growth.n_sizes
         )...
     ]
@@ -576,14 +553,14 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     (;
         zip(
             (
-                metric_symbols...,
+                :loc_outcomes,
+                :relative_taxa_cover,
                 stat_store_names...,
                 conn_names...,
                 :site_ranks,
                 :mc_log,
                 :seed_log,
-                :fog_log,
-                :shade_log,
+                :shading_log,
                 :coral_dhw_log,
                 :coral_cover_log
             ),
@@ -730,10 +707,27 @@ function load_results(result_loc::String)::ResultSet
     outcome_properties = [:metric_name, :metric_unit, :axes_names, :axes_units]
     subdirs = filter(isdir, readdir(joinpath(result_loc, RESULTS); join=true))
     for sd in subdirs
+        sd_name = Symbol(basename(sd))
         data = zopen(sd; fill_as_missing=false)
         data_size = size(data)
 
-        # Construct dimension names and metadata
+        if sd_name == Symbol(LOC_METRICS)
+            # New combined format: split lazily back into individual named outcomes
+            metric_syms = Symbol.(data.attrs["metrics"])
+            combined = DataCube(
+                data;
+                timesteps=input_set.attrs["timeframe"],
+                locations=data.attrs["unique_loc_ids"],
+                metrics=string.(metric_syms),
+                scenarios=1:data_size[4]
+            )
+            for m_name in metric_syms
+                outcomes[m_name] = combined[metrics=At(string(m_name))]
+            end
+            continue
+        end
+
+        # Construct dimension names and metadata (handles relative_taxa_cover and old-format stores)
         dim_names = []
         for (idx, dim_name) in enumerate(data.attrs["structure"])
             if dim_name == "timesteps"
@@ -746,10 +740,11 @@ function load_results(result_loc::String)::ResultSet
         end
 
         try
-            outcomes[Symbol(basename(sd))] = DataCube(
+            outcomes[sd_name] = DataCube(
                 data;
                 properties=Dict(
                     p => data.attrs[string(p)] for p in outcome_properties
+                    if haskey(data.attrs, string(p))
                 ),
                 zip(Symbol.(data.attrs["structure"]), dim_names)...
             )
@@ -761,7 +756,7 @@ function load_results(result_loc::String)::ResultSet
                 Structure: $(data.attrs["structure"])
                 Generated: $(Array([i[1] for i in size.(dim_names)]))
                 """
-                outcomes[Symbol(basename(sd))] = DataCube(
+                outcomes[sd_name] = DataCube(
                     data;
                     zip(Symbol.(data.attrs["structure"]), [1:s for s in size(data)])...
                 )

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -175,9 +175,9 @@ function scenario_attributes(domain::Domain, param_df::DataFrame)::Dict{Symbol,A
 end
 
 """
-    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+    setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
 
-Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
+Setup logs for ranks, seed_log, shading_log, coral_dhw_log, and coral_cover_log.
 
 # Arguments
 - `z_store` : ZArray
@@ -187,10 +187,12 @@ Setup logs for ranks, seed_log, fog_log, shade_log and coral_dhw_log.
 - `n_locs` : number of location
 - `n_groups` : number of functional groups
 - `n_sizes` : number of size classes
+- `batch_size` : chunk size along the scenarios dimension; set to the write batch size so
+  that each batch write lands in exactly one chunk file per array.
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes)
+function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
     # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -213,7 +215,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(rank_dims[1:3]..., 1),
+        chunks=(rank_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -228,7 +230,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
     mc_log = zcreate(
@@ -238,7 +240,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(seed_dims[1:3]..., 1),
+        chunks=(seed_dims[1:3]..., batch_size),
         attrs=attrs
     )
 
@@ -250,7 +252,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
         fill_value=nothing,
         fill_as_missing=false,
         path=log_fn,
-        chunks=(shading_dims[1:3]..., 1),
+        chunks=(shading_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "intervention", "scenarios"),
             :interventions => ["fog", "shade"],
@@ -284,7 +286,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, n_locs, 1),
+            chunks=(tf, n_groups * n_sizes, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -298,7 +300,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_groups * n_sizes, 1, 1),
+            chunks=(tf, n_groups * n_sizes, 1, batch_size),
             attrs=attrs
         )
     end
@@ -315,7 +317,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=nothing,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, n_locs, 1),
+            chunks=(tf, n_group_and_size, n_locs, batch_size),
             attrs=attrs
         )
     else
@@ -329,7 +331,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
             fill_value=0.0,
             fill_as_missing=false,
             path=log_fn,
-            chunks=(tf, n_group_and_size, 1, 1),
+            chunks=(tf, n_group_and_size, 1, batch_size),
             attrs=attrs
         )
     end
@@ -349,20 +351,17 @@ Sets up an on-disk result store.
 ├───env_stats
 ├───inputs
 ├───logs
-|   ├───coral_cover_log
-|   ├───coral_dhw_log
-│   ├───fog
+│   ├───coral_cover_log  (full shape when ADRIA_LOG_COVER=true, 1-location dummy otherwise)
+│   ├───coral_dhw_log    (full shape when ADRIA_LOG_DHW_TOLS=true, 1-location dummy otherwise)
+│   ├───moving_corals
 │   ├───rankings
 │   ├───seed
-│   └───shade
+│   └───shading_log      (fog and shade combined along an intervention axis)
 ├───model_spec
 ├───results
-|   ├───absolute_shelter_volume
-|   ├───coral_evenness
-|   ├───juvenile_indicator
-│   ├───relative_cover
-|   ├───relative_juveniles
-│   ├───relative_shelter_volume
+│   ├───loc_outcomes     (relative_cover, relative_shelter_volume, absolute_shelter_volume,
+│   │                     relative_juveniles, juvenile_indicator, coral_evenness combined
+│   │                     along a metrics axis)
 │   └───relative_taxa_cover
 └───spatial
 ```
@@ -374,14 +373,17 @@ Sets up an on-disk result store.
 # Notes
 - `domain` is replaced with an identical copy with an updated scenario invoke time.
 - -9999.0 is used as an arbitrary fill value.
+- `loc_outcomes` is split back into individually named outcomes on load (see `load_results`).
+- `shading_log` has shape `(timesteps, locations, intervention, scenarios)` where the
+  intervention axis holds `["fog", "shade"]` in that order.
 
 # Arguments
 - `domain` : ADRIA scenario domain
 - `scen_spec` : ADRIA scenario specification
 
 # Returns
-domain, (relative_cover, relative_shelter_volume, absolute_shelter_volume, relative_juveniles,
-juvenile_indicator, relative_taxa_cover, site_ranks, seed_log, fog_log, shade_log)
+domain, (loc_outcomes, relative_taxa_cover, site_ranks, mc_log, seed_log, shading_log,
+coral_dhw_log, coral_cover_log)
 """
 function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
     @set! domain.scenario_invoke_time = replace(
@@ -437,6 +439,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
 
     _unique_loc_ids::Vector{String} = unique_loc_ids(domain)
     n_groups = domain.coral_growth.n_groups
+    batch_size::Int = min(parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32")), n_scenarios)
 
     # Combined store for the 6 location-based outcome metrics (timesteps × locations × metrics × scenarios)
     loc_outcome_metrics::Vector{metrics.Metric} = [
@@ -455,7 +458,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
-        chunks=(loc_dims[1:3]..., 1),
+        chunks=(loc_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "metrics", "scenarios"),
             :unique_loc_ids => _unique_loc_ids,
@@ -476,7 +479,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
         fill_value=nothing,
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
-        chunks=(taxa_dims[1:2]..., 1),
+        chunks=(taxa_dims[1:2]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "groups", "scenarios"),
             :metric_name => metrics.to_string(taxa_cover_metric; is_titlecase=true),
@@ -545,7 +548,8 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame)::Tuple
             tf,
             n_locations,
             n_groups,
-            domain.coral_growth.n_sizes
+            domain.coral_growth.n_sizes,
+            batch_size
         )...
     ]
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -192,7 +192,9 @@ Setup logs for ranks, seed_log, shading_log, coral_dhw_log, and coral_cover_log.
 
 Note: This setup relies on hardcoded values for number of species represented and seeded.
 """
-function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1)
+function setup_logs(
+    z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_sizes, batch_size=1
+)
     # Set up logs for location ranks, seed/fog log
     zgroup(z_store, LOG_GRP)
     log_fn::String = joinpath(z_store.folder, LOG_GRP)
@@ -481,7 +483,9 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame, batch_size::I
         taxa_dims...;
         fill_value=nothing,
         fill_as_missing=false,
-        path=joinpath(z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))),
+        path=joinpath(
+            z_store.folder, RESULTS, string(metrics.to_symbol(taxa_cover_metric))
+        ),
         chunks=(taxa_dims[1:2]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "groups", "scenarios"),

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -205,7 +205,7 @@ function setup_logs(z_store, unique_loc_ids, n_scens, tf, n_locs, n_groups, n_si
 
     attrs = Dict(
         # Here, "intervention" refers to seeding or shading
-        :structure => ("timesteps", "locations", "intervention", "scenarios"),
+        :structure => ("timesteps", "locations", "interventions", "scenarios"),
         :unique_loc_ids => unique_loc_ids
     )
     ranks = zcreate(

--- a/src/io/rme_result_io.jl
+++ b/src/io/rme_result_io.jl
@@ -98,10 +98,11 @@ function load_results(
     input_path = joinpath(result_dir, "scenarios.csv")
     inputs::DataFrame = _get_inputs(input_path)
 
-    # Counterfactual scenario if outplant area and enrichment area are both 0
-    scenario_groups::Dict{Symbol,BitVector} = _construct_scenario_groups(
-        inputs, length(raw_set.scenarios)
-    )
+    scenario_groups::Dict{Symbol,BitVector} = if haskey(raw_set.cubes, :is_counterfactual)
+        _construct_scenario_groups_from_netcdf(raw_set)
+    else
+        _construct_scenario_groups(inputs, length(raw_set.scenarios))
+    end
 
     env_layer_md::EnvLayer = EnvLayer(
         data_dir,
@@ -159,6 +160,22 @@ function _get_inputs(filepath::String)::DataFrame
         return DataFrame()
     end
     return inputs = CSV.read(filepath, DataFrame; header=true)
+end
+
+"""
+    _construct_scenario_groups_from_netcdf(raw_set::Dataset)::Dict{Symbol,BitVector}
+
+Build scenario groups directly from the `is_counterfactual` variable stored in the NetCDF.
+Used for dynamic RME runs where no `scenarios.csv` is available.
+"""
+function _construct_scenario_groups_from_netcdf(raw_set::Dataset)::Dict{Symbol,BitVector}
+    cf_data = raw_set.is_counterfactual.data[:]
+    counterfactual_scens = BitVector(cf_data .== 1)
+    intervened_scens = .!counterfactual_scens
+    groups = Dict{Symbol,BitVector}()
+    any(counterfactual_scens) && (groups[:counterfactual] = counterfactual_scens)
+    any(intervened_scens) && (groups[:interventions] = intervened_scens)
+    return groups
 end
 
 """

--- a/src/io/sampling/sampling_interface.jl
+++ b/src/io/sampling/sampling_interface.jl
@@ -396,7 +396,7 @@ function adjust_samples(spec::DataFrame, samples::DataFrame)::DataFrame
     no_wave_scenario = samples.wave_scenario .== 0.0
     samples[no_wave_scenario, :seed_wave_stress] .= 0.0
 
-    if size(unique(Matrix(samples), dims=1), 1) < nrow(samples)
+    if size(unique(Matrix(samples); dims=1), 1) < nrow(samples)
         perc = "$(@sprintf("%.3f", (1.0 - (nrow(unique(samples)) / nrow(samples))) * 100.0))%"
         @warn "Non-unique samples created: $perc of the samples are duplicates."
     end

--- a/src/io/sampling/sampling_interface.jl
+++ b/src/io/sampling/sampling_interface.jl
@@ -396,7 +396,7 @@ function adjust_samples(spec::DataFrame, samples::DataFrame)::DataFrame
     no_wave_scenario = samples.wave_scenario .== 0.0
     samples[no_wave_scenario, :seed_wave_stress] .= 0.0
 
-    if nrow(unique(samples)) < nrow(samples)
+    if size(unique(Matrix(samples), dims=1), 1) < nrow(samples)
         perc = "$(@sprintf("%.3f", (1.0 - (nrow(unique(samples)) / nrow(samples))) * 100.0))%"
         @warn "Non-unique samples created: $perc of the samples are duplicates."
     end

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -55,12 +55,20 @@ end
 Makes Metric types callable with arbitrary arguments that are passed to associated function.
 """
 function (f::Metric)(raw, args...; kwargs...)::YAXArray
-    if :scenarios in f.in_dims
-        axes = f.in_dims[1:ndims(raw)]
+    if raw isa YAXArray
+        result = f.func(raw, args...; kwargs...)
+        # YAXArrays operations (sum, dropdims, etc.) reset axis values to 1:n.
+        # Restore the original values from raw for any axis that survived (same name + length).
+        raw_names = axes_names(raw)
+        new_dims = Tuple(map(axes_names(result), result.axes) do nm, rd
+            i = findfirst(==(nm), raw_names)
+            (i !== nothing && length(raw.axes[i]) == length(rd)) ? raw.axes[i] : rd
+        end)
+        return fill_metadata!(YAXArray(new_dims, result.data, result.properties), f)
     else
-        axes = f.in_dims
+        axes = :scenarios in f.in_dims ? f.in_dims[1:ndims(raw)] : f.in_dims
+        return fill_metadata!(f.func(DataCube(raw, axes), args...; kwargs...), f)
     end
-    return fill_metadata!(f.func(DataCube(raw, axes), args...; kwargs...), f)
 end
 function (f::Metric)(rs::ResultSet, args...; kwargs...)::YAXArray
     return fill_metadata!(f.func(rs, args...; kwargs...), f)

--- a/src/metrics/metrics.jl
+++ b/src/metrics/metrics.jl
@@ -60,10 +60,12 @@ function (f::Metric)(raw, args...; kwargs...)::YAXArray
         # YAXArrays operations (sum, dropdims, etc.) reset axis values to 1:n.
         # Restore the original values from raw for any axis that survived (same name + length).
         raw_names = axes_names(raw)
-        new_dims = Tuple(map(axes_names(result), result.axes) do nm, rd
-            i = findfirst(==(nm), raw_names)
-            (i !== nothing && length(raw.axes[i]) == length(rd)) ? raw.axes[i] : rd
-        end)
+        new_dims = Tuple(
+            map(axes_names(result), result.axes) do nm, rd
+                i = findfirst(==(nm), raw_names)
+                (i !== nothing && length(raw.axes[i]) == length(rd)) ? raw.axes[i] : rd
+            end
+        )
         return fill_metadata!(YAXArray(new_dims, result.data, result.properties), f)
     else
         axes = :scenarios in f.in_dims ? f.in_dims[1:ndims(raw)] : f.in_dims

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -501,10 +501,7 @@ function run_model(
     n_groups::Int64 = domain.coral_growth.n_groups
     n_sizes::Int64 = domain.coral_growth.n_sizes
 
-    # Set random seed using intervention values
-    # TODO: More robust way of getting intervention/criteria values
-    rnd_seed_val::Int64 = floor(Int64, sum(param_set[Where(x -> x != "RCP")]))  # select everything except RCP
-    Random.seed!(rnd_seed_val)
+    rng = set_random_seed(param_set)
 
     # Extract environmental data
     dhw_idx::Int64 = Int64(param_set[At("dhw_scenario")])
@@ -1068,7 +1065,8 @@ function run_model(
                 sim_params.max_settler_density,
                 sim_params.max_larval_density,
                 basal_area_per_settler,
-                potential_settlers
+                potential_settlers;
+                rng=rng
             )[
                 :, habitable_loc_idxs
             ] ./ habitable_areas[:, habitable_loc_idxs]

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -395,8 +395,7 @@ function run_scenario(
                 data_store.site_ranks[:, :, :, idx] .= vals
             end
         elseif k == :coral_dhw_log
-            # Only log coral DHW tolerances if in debug mode
-            if parse(Bool, ENV["ADRIA_DEBUG"]) == true
+            if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
                 getfield(data_store, k)[:, :, :, idx] .= vals
             end
         else
@@ -590,6 +589,7 @@ function run_model(
     end
     # Environment variables are stored as strings, so convert to bool for use
     in_debug_mode = parse(Bool, get(ENV, "ADRIA_DEBUG", "false")) == true
+    log_dhw_tols = parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "true")) == true
 
     # Initialize cover loss tracking for reactive strategies
     max_lookback = Int64(param_set[At("reactive_response_delay")])
@@ -1003,8 +1003,8 @@ function run_model(
                 @view(C_cover[tstep - 1, :, :, :]), c_mean_t, net_growth_rates
             )
 
-            if in_debug_mode
-                # Log dhw tolerances if in debug mode
+            if log_dhw_tols
+                # Log dhw tolerances if requested
                 dhw_tol_mean_log[tstep, :, :] .= reshape(
                     permutedims(c_mean_t, (2, 1, 3)), size(dhw_tol_mean_log)[2:3]
                 )
@@ -1582,7 +1582,7 @@ function run_model(
     # dhw_tol_mean_std = dropdims(mean(dhw_tol_std_log, dims=3), dims=3)
     # collated_dhw_tol_log = DataCube(cat(dhw_tol_mean, dhw_tol_mean_std, dims=3);
     #     timesteps=1:tf, species=corals.coral_id, stat=[:mean, :stdev])
-    if in_debug_mode
+    if log_dhw_tols
         collated_dhw_tol_log = DataCube(
             dhw_tol_mean_log; timesteps=1:tf, species=corals.coral_id, sites=1:n_locs
         )

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -185,7 +185,7 @@ function run_scenarios(
         ) for _ in 1:n_locs
     ]
 
-    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == false
+    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
     @info "ADRIA_DEBUG = $env_debug"
 
     env_num_cores = ENV["ADRIA_NUM_CORES"]
@@ -194,7 +194,7 @@ function run_scenarios(
     para_threshold::Int64 =
         ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain)) ? 8 : 256
     active_cores::Int64 = parse(Int64, env_num_cores)
-    parallel::Bool = env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
+    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1054,7 +1054,8 @@ function run_model(
         # Natural adaptation (doesn't change C_cover_t)
         if tstep <= tf
             adjust_DHW_distribution!(
-                @view(C_cover[tstep - 1, :, :, :]), c_mean_t, net_growth_rates, c_mean_tol_ceil
+                @view(C_cover[tstep - 1, :, :, :]), c_mean_t, net_growth_rates,
+                c_mean_tol_ceil
             )
 
             if log_dhw_tols
@@ -1278,9 +1279,12 @@ function run_model(
 
                 # mc_share is a @NamedTuple{weight::Float64, target_locs::Vector{String}}
                 for mc_share in domain.mc_target_locations
-                    share_candidate_locs = intersect(candidate_locs, mc_share.target_locs)
+                    share_candidate_locs = intersect(
+                        candidate_locs, mc_share.target_locs
+                    )
                     if isempty(share_candidate_locs)
-                        if ADRIA.decision.strategy_type(param_set, "mc") == PeriodicStrategy
+                        if ADRIA.decision.strategy_type(param_set, "mc") ==
+                            PeriodicStrategy
                             @warn """
                                 tstep $tstep: Deployment with PeriodicStrategy on
                                 $(length(mc_share.target_locs)) reefs with weight
@@ -1323,7 +1327,8 @@ function run_model(
                     end
                     if !isempty(selected_mc_ranks)
                         log_val = is_guided ? (1:length(selected_mc_ranks)) : 1.0
-                        log_location_ranks[tstep, At(selected_mc_ranks), At(:mc)] .= log_val
+                        log_location_ranks[tstep, At(selected_mc_ranks), At(:mc)] .=
+                            log_val
                         last_mc_deployment[share_candidate_loc_idx] .= tstep
                     end
 
@@ -1354,7 +1359,8 @@ function run_model(
                                 prop_fecundity[:, mc_loc_idx]
                             )
 
-                            @views recruitment[:, mc_loc_idx] .+= mc_proportional_increase
+                            @views recruitment[:, mc_loc_idx] .+=
+                                mc_proportional_increase
 
                             # Log estimated number of corals moved
                             Ymc[tstep, :, mc_loc_idx] .= n_mc_corals
@@ -1458,7 +1464,9 @@ function run_model(
 
                 # seed_share is a @NamedTuple{weight::Float64, target_locs::Vector{String}}
                 for seed_share in domain.seed_target_locations
-                    share_candidate_locs = intersect(candidate_locs, seed_share.target_locs)
+                    share_candidate_locs = intersect(
+                        candidate_locs, seed_share.target_locs
+                    )
                     if isempty(share_candidate_locs)
                         if ADRIA.decision.strategy_type(param_set, "seed") ==
                             PeriodicStrategy

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -775,6 +775,9 @@ function run_model(
     # Store means before mortality and growth events to use during update
     c_mean_t_1 = copy(c_mean_t)
 
+    # Hard ceiling: tolerance cannot increase more than HEAT_UB DHW-weeks above initial values
+    c_mean_tol_ceil = c_mean_t .+ HEAT_UB
+
     # Snapshot of juvenile tolerance AFTER natural adaptation but BEFORE seeding.
     # Used as the reference base for a_adapt enhancement (c_mean_reference).
     # Storing the post-seeding state would cause a_adapt to compound year-over-year,
@@ -1000,7 +1003,7 @@ function run_model(
         # Natural adaptation (doesn't change C_cover_t)
         if tstep <= tf
             adjust_DHW_distribution!(
-                @view(C_cover[tstep - 1, :, :, :]), c_mean_t, net_growth_rates
+                @view(C_cover[tstep - 1, :, :, :]), c_mean_t, net_growth_rates, c_mean_tol_ceil
             )
 
             if log_dhw_tols
@@ -1315,7 +1318,8 @@ function run_model(
             TP_data,  # ! IMPORTANT: Pass in transition probability matrix, not connectivity!
             recruitment,
             fecundity_per_m²,
-            param_set[At("heritability")]
+            param_set[At("heritability")],
+            c_mean_tol_ceil
         )
 
         # Seeding
@@ -1489,7 +1493,8 @@ function run_model(
                                 c_std,
                                 seed_loc_idx,
                                 _seed_size_groups,
-                                a_adapt
+                                a_adapt,
+                                c_mean_tol_ceil
                             )
                         end
 
@@ -1522,7 +1527,8 @@ function run_model(
             depth_coeff,
             c_std,
             c_mean_t,
-            @view(bleach_dhw[(tstep - 1):tstep, :, :, :])
+            @view(bleach_dhw[(tstep - 1):tstep, :, :, :]),
+            c_mean_tol_ceil
         )
 
         # Store current means to be used in future timesteps.

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -152,13 +152,37 @@ function run_scenarios(
 
     @info "Running $(nrow(scens)) scenarios over $(length(RCP)) RCPs: $RCP"
 
+    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
+    @info "ADRIA_DEBUG = $env_debug"
+
+    env_num_cores = ENV["ADRIA_NUM_CORES"]
+    @info "ADRIA_NUM_CORES = $env_num_cores"
+
+    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
+    para_threshold::Int64 = is_RME_based ? 8 : 20
+    active_cores::Int64 = parse(Int64, env_num_cores)
+    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
+
+    # Compute batch size before setting up the store so chunk sizes match the pmap batch
+    # sizes. In parallel mode: ceil(N/P) gives exactly one batch per worker and the fewest
+    # possible chunk files. In serial mode: fall back to the env var (default 32).
+    env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
+    batch_size::Int = if env_batch > 0
+        env_batch  # explicit override always wins
+    elseif parallel
+        ceil(Int, nrow(scens) / active_cores)
+    else
+        32
+    end
+    @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
+
     # Cross product between rcps and param_df to have every row of param_df for each rcp
     rcps_df = DataFrame(; RCP=parse.(Int64, RCP))
     scenarios_df = crossjoin(scens, rcps_df)
     sort!(scenarios_df, :RCP)
 
     @info "Setting up Result Set"
-    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df)
+    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, batch_size)
 
     # Convert DataFrame to named matrix for faster iteration
     scenarios_matrix::YAXArray = DataCube(
@@ -186,27 +210,14 @@ function run_scenarios(
         ) for _ in 1:n_locs
     ]
 
-    env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
-    @info "ADRIA_DEBUG = $env_debug"
-
-    env_num_cores = ENV["ADRIA_NUM_CORES"]
-    @info "ADRIA_NUM_CORES = $env_num_cores"
-
-    batch_size::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32"))
-    @info "ADRIA_BATCH_SIZE = $batch_size"
-
-    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
-    para_threshold::Int64 = is_RME_based ? 8 : 20
-    active_cores::Int64 = parse(Int64, env_num_cores)
-    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
         spinup_time = @elapsed begin
             _setup_workers()
 
-            # Load ADRIA on workers. Workers only run _collect_scenario_results; all
-            # disk I/O is done on the main process via _write_batch!, so data_store is
-            # never serialised to workers and there are no concurrent chunk writes.
+            # Load ADRIA on workers. Each pmap task runs _run_batch!, which computes
+            # and writes a full batch directly. Workers write to non-overlapping chunk
+            # ranges (chunk size == batch size) so concurrent Zarr writes are safe.
             @sync @async @everywhere @eval begin
                 using ADRIA
             end
@@ -215,11 +226,11 @@ function run_scenarios(
         @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
-    # collect_func captures only functional_groups (no data_store) so serialisation cost
-    # to workers is minimal and disk writes are always single-threaded.
-    collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
-
     if parallel
+        # Each pmap task is one batch: workers compute B scenarios and write them
+        # directly. Only `nothing` returns to the main process — no result IPC.
+        batch_func = (batch) -> _run_batch!(batch, functional_groups, data_store)
+
         try
             for rcp in RCP
                 run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
@@ -231,18 +242,16 @@ function run_scenarios(
                 scen_args = collect(
                     _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
                 )
+                all_batches = [
+                    collect(b) for b in Iterators.partition(scen_args, batch_size)
+                ]
 
-                batches = Iterators.partition(scen_args, batch_size)
                 if show_progress
-                    @showprogress desc = run_msg dt = 4 for batch in batches
-                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
-                        _write_batch!(data_store, first(batch)[2], batch_results)
-                    end
+                    @showprogress desc = run_msg dt = 4 pmap(
+                        batch_func, CachingPool(workers()), all_batches
+                    )
                 else
-                    for batch in batches
-                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
-                        _write_batch!(data_store, first(batch)[2], batch_results)
-                    end
+                    pmap(batch_func, CachingPool(workers()), all_batches)
                 end
             end
         catch err
@@ -251,6 +260,9 @@ function run_scenarios(
             rethrow(err)
         end
     else
+        # Serial: collect B results then write once (batch write, no IPC overhead)
+        collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
+
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
@@ -258,15 +270,17 @@ function run_scenarios(
             scen_args = collect(
                 _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
+            all_batches = [
+                collect(b) for b in Iterators.partition(scen_args, batch_size)
+            ]
 
-            batches = Iterators.partition(scen_args, batch_size)
             if show_progress
-                @showprogress desc = run_msg dt = 4 for batch in batches
+                @showprogress desc = run_msg dt = 4 for batch in all_batches
                     batch_results = map(collect_func, batch)
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             else
-                for batch in batches
+                for batch in all_batches
                     batch_results = map(collect_func, batch)
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
@@ -447,6 +461,27 @@ function _write_batch!(
         end
     end
 
+    return nothing
+end
+
+"""
+    _run_batch!(batch_args, functional_groups, data_store)
+
+Compute and write a contiguous batch of scenarios entirely on the calling worker.
+Each pmap task gets one batch, so result arrays never travel back to the main process.
+Workers write to non-overlapping chunk ranges, so concurrent writes are safe.
+"""
+function _run_batch!(
+    batch_args::AbstractVector,
+    functional_groups::Vector{Vector{FunctionalGroup}},
+    data_store::NamedTuple
+)::Nothing
+    start_idx = batch_args[1][2]
+    results = [
+        _collect_scenario_results(args[1], args[3], functional_groups)
+        for args in batch_args
+    ]
+    _write_batch!(data_store, start_idx, results)
     return nothing
 end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -192,6 +192,9 @@ function run_scenarios(
     env_num_cores = ENV["ADRIA_NUM_CORES"]
     @info "ADRIA_NUM_CORES = $env_num_cores"
 
+    batch_size::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "32"))
+    @info "ADRIA_BATCH_SIZE = $batch_size"
+
     is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
     para_threshold::Int64 = is_RME_based ? 8 : 20
     active_cores::Int64 = parse(Int64, env_num_cores)
@@ -201,45 +204,45 @@ function run_scenarios(
         spinup_time = @elapsed begin
             _setup_workers()
 
-            # Load ADRIA on workers and define helper function
-            # Note: Workers do not share the same cache in parallel workloads.
-            #       Previously, cache would be reserialized so each worker has access to
-            #       a separate cache.
-            #       Using CachingPool() resolves the the repeated reserialization but it
-            #       seems each worker was then attempting to use the same cache, causing the
-            #       Julia kernel to crash in multi-processing contexts.
-            #       Getting each worker to create its own cache reduces serialization time
-            #       (at the cost of increased run time) but resolves the kernel crash issue.
+            # Load ADRIA on workers. Workers only run _collect_scenario_results; all
+            # disk I/O is done on the main process via _write_batch!, so data_store is
+            # never serialised to workers and there are no concurrent chunk writes.
             @sync @async @everywhere @eval begin
                 using ADRIA
-                func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
             end
         end
 
         @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
     end
 
-    if parallel
-        # Define local helper
-        func = (dfx) -> run_scenario(dfx..., functional_groups, data_store)
+    # collect_func captures only functional_groups (no data_store) so serialisation cost
+    # to workers is minimal and disk writes are always single-threaded.
+    collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
 
+    if parallel
         try
             for rcp in RCP
                 run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-                # Switch RCPs so correct data is loaded
                 dom = switch_RCPs!(dom, rcp)
                 target_rows = findall(
                     scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
                 )
-                scen_args = _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                scen_args = collect(
+                    _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+                )
 
+                batches = Iterators.partition(scen_args, batch_size)
                 if show_progress
-                    @showprogress desc = run_msg dt = 4 pmap(
-                        func, CachingPool(workers()), scen_args
-                    )
+                    @showprogress desc = run_msg dt = 4 for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 else
-                    pmap(func, CachingPool(workers()), scen_args)
+                    for batch in batches
+                        batch_results = pmap(collect_func, CachingPool(workers()), batch)
+                        _write_batch!(data_store, first(batch)[2], batch_results)
+                    end
                 end
             end
         catch err
@@ -248,22 +251,25 @@ function run_scenarios(
             rethrow(err)
         end
     else
-        # Define local helper
-        func = dfx -> run_scenario(dfx..., functional_groups, data_store)
-
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-            # Switch RCPs so correct data is loaded
             dom = switch_RCPs!(dom, rcp)
-            scen_args = _scenario_args(
-                dom, scenarios_matrix, rcp, size(scenarios_matrix, 1)
+            scen_args = collect(
+                _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
 
+            batches = Iterators.partition(scen_args, batch_size)
             if show_progress
-                @showprogress desc = run_msg dt = 4 map(func, scen_args)
+                @showprogress desc = run_msg dt = 4 for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             else
-                map(func, scen_args)
+                for batch in batches
+                    batch_results = map(collect_func, batch)
+                    _write_batch!(data_store, first(batch)[2], batch_results)
+                end
             end
         end
     end
@@ -289,6 +295,159 @@ function _scenario_args(dom, scenarios_matrix::YAXArray, rcp::String, n::Int)
     return zip(
         rep_doms, target_rows, eachrow(scenarios_matrix[target_rows, :])
     )
+end
+
+"""
+    _collect_scenario_results(domain, scenario, functional_groups)
+
+Run one scenario and return all computed metric arrays without writing to disk.
+Called by `run_scenario` (single write) and by the batched pmap path in `run_scenarios`.
+"""
+function _collect_scenario_results(
+    domain::Domain,
+    scenario::Union{AbstractVector,DataFrameRow},
+    functional_groups::Vector{Vector{FunctionalGroup}}
+)::NamedTuple
+    result_set = run_model(domain, scenario, functional_groups)
+    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
+
+    rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # 6 location-based metrics — order must match LOC_METRIC_NAMES
+    loc_out = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES))
+    vals = relative_cover(rs_raw);                      vals[vals .< threshold] .= 0.0; loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 3] .= vals
+    vals = relative_juveniles(rs_raw);                  vals[vals .< threshold] .= 0.0; loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk);  vals[vals .< threshold] .= 0.0; loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data);               vals[vals .< threshold] .= 0.0; loc_out[:, :, 6] .= vals
+
+    # Taxa cover (groups axis, not locations)
+    taxa_vals = relative_taxa_cover(rs_raw, lk)
+    taxa_vals[taxa_vals .< threshold] .= 0.0
+
+    # Fog and shade combined into a single (tf, n_locs, 2) buffer
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0f0
+    shade_vals[shade_vals .< threshold] .= 0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+
+    # Remaining log arrays — apply threshold where possible
+    site_ranks_vals = result_set.site_ranks
+    try; site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0); catch err; err isa MethodError ? nothing : rethrow(err); end
+
+    mc_vals = result_set.mc_log
+    mc_vals[mc_vals .< threshold] .= Float32(0.0)
+
+    seed_vals = result_set.seed_log
+    seed_vals[seed_vals .< threshold] .= Float32(0.0)
+
+    # coral_dhw_log / coral_cover_log are false when their env var is disabled
+    dhw_vals = result_set.coral_dhw_log
+    cover_vals = result_set.coral_cover_log
+
+    return (
+        loc_out=loc_out,
+        taxa_cover=taxa_vals,
+        shading=shading_buf,
+        site_ranks=site_ranks_vals,
+        mc_log=mc_vals,
+        seed_log=seed_vals,
+        coral_dhw_log=dhw_vals,
+        coral_cover_log=cover_vals
+    )
+end
+
+"""
+    _write_batch!(data_store, start_idx, results)
+
+Write a contiguous batch of collected scenario results to the Zarr data store.
+All arrays in the batch are stacked into a single in-memory buffer and written in one
+Zarr call per array, so the entire batch lands in a single chunk file per array.
+"""
+function _write_batch!(
+    data_store::NamedTuple, start_idx::Int, results::AbstractVector
+)::Nothing
+    n = length(results)
+    idx_range = start_idx:(start_idx + n - 1)
+
+    # loc_outcomes: (tf, n_locs, n_metrics, n)
+    tf, n_locs, n_metrics = size(results[1].loc_out)
+    loc_batch = Array{Float32}(undef, tf, n_locs, n_metrics, n)
+    for (i, r) in enumerate(results)
+        loc_batch[:, :, :, i] .= r.loc_out
+    end
+    data_store.loc_outcomes[:, :, :, idx_range] .= loc_batch
+
+    # relative_taxa_cover: (tf, n_groups, n)
+    _, n_groups = size(results[1].taxa_cover)
+    taxa_batch = Array{Float32}(undef, tf, n_groups, n)
+    for (i, r) in enumerate(results)
+        taxa_batch[:, :, i] .= r.taxa_cover
+    end
+    data_store.relative_taxa_cover[:, :, idx_range] .= taxa_batch
+
+    # shading_log: (tf, n_locs, 2, n)
+    shading_batch = Array{Float32}(undef, tf, n_locs, 2, n)
+    for (i, r) in enumerate(results)
+        shading_batch[:, :, :, i] .= r.shading
+    end
+    data_store.shading_log[:, :, :, idx_range] .= shading_batch
+
+    # site_ranks: (tf, n_locs, n_interventions, n)
+    if !isnothing(data_store.site_ranks)
+        _, _, n_ivs = size(results[1].site_ranks)
+        ranks_batch = Array{Float32}(undef, tf, n_locs, n_ivs, n)
+        for (i, r) in enumerate(results)
+            ranks_batch[:, :, :, i] .= r.site_ranks
+        end
+        data_store.site_ranks[:, :, :, idx_range] .= ranks_batch
+    end
+
+    # mc_log and seed_log: (tf, n_groups, n_locs, n)
+    _, n_g, n_l = size(results[1].mc_log)
+    mc_batch   = Array{Float32}(undef, tf, n_g, n_l, n)
+    seed_batch = Array{Float32}(undef, tf, n_g, n_l, n)
+    for (i, r) in enumerate(results)
+        mc_batch[:, :, :, i]   .= r.mc_log
+        seed_batch[:, :, :, i] .= r.seed_log
+    end
+    data_store.mc_log[:, :, :, idx_range]   .= mc_batch
+    data_store.seed_log[:, :, :, idx_range] .= seed_batch
+
+    # coral_dhw_log (conditional on ADRIA_LOG_DHW_TOLS)
+    if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
+        dhw_r = results[1].coral_dhw_log
+        if dhw_r !== false && !isnothing(dhw_r)
+            _, n_sp, n_ld = size(dhw_r)
+            dhw_batch = Array{Float32}(undef, tf, n_sp, n_ld, n)
+            for (i, r) in enumerate(results)
+                dhw_batch[:, :, :, i] .= r.coral_dhw_log
+            end
+            data_store.coral_dhw_log[:, :, :, idx_range] .= dhw_batch
+        end
+    end
+
+    # coral_cover_log (conditional on ADRIA_LOG_COVER)
+    if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
+        cc_r = results[1].coral_cover_log
+        if cc_r !== false && !isnothing(cc_r)
+            _, n_sp_c, n_lc = size(cc_r)
+            cc_batch = Array{Float32}(undef, tf, n_sp_c, n_lc, n)
+            for (i, r) in enumerate(results)
+                cc_batch[:, :, :, i] .= r.coral_cover_log
+            end
+            data_store.coral_cover_log[:, :, :, idx_range] .= cc_batch
+        end
+    end
+
+    return nothing
 end
 
 """
@@ -332,94 +491,8 @@ function run_scenario(
         domain = switch_RCPs!(domain, rcp)
     end
 
-    result_set = run_model(domain, scenario, functional_groups)
-
-    # Capture results to disk
-    # Set values below threshold to 0 to save space
-    threshold = parse(Float32, ENV["ADRIA_THRESHOLD"])
-
-    # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
-    rs_raw::Array{Float64} = result_set.raw
-    lk = loc_k_area(domain)
-    coral_spec::DataFrame = to_coral_spec(scenario)
-
-    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
-    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
-    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
-    loc_out = Array{Float32}(
-        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
-    )
-
-    vals = relative_cover(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 1] .= vals
-    vals = relative_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 2] .= vals
-    vals = absolute_shelter_volume(rs_raw, lk, scenario)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 3] .= vals
-    vals = relative_juveniles(rs_raw)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 4] .= vals
-    vals = juvenile_indicator(rs_raw, coral_spec, lk)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 5] .= vals
-    rtc_vals = relative_loc_taxa_cover(rs_raw)
-    vals = coral_evenness(rtc_vals.data)
-    vals[vals .< threshold] .= 0.0
-    loc_out[:, :, 6] .= vals
-
-    data_store.loc_outcomes[:, :, :, idx] .= loc_out
-
-    # Taxa cover uses a groups axis rather than locations — kept as its own store
-    vals = relative_taxa_cover(rs_raw, lk)
-    vals[vals .< threshold] .= 0.0
-    data_store.relative_taxa_cover[:, :, idx] .= vals
-
-    # Write fog and shade together as a single 4-D shading_log chunk
-    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
-    fog_vals = Matrix{Float32}(result_set.fog_log)
-    shade_vals = Matrix{Float32}(result_set.shade_log)
-    fog_vals[fog_vals .< threshold] .= 0.0f0
-    shade_vals[shade_vals .< threshold] .= 0.0f0
-    shading_buf[:, :, 1] .= fog_vals
-    shading_buf[:, :, 2] .= shade_vals
-    data_store.shading_log[:, :, :, idx] .= shading_buf
-
-    # Store remaining logs
-    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
-    for k in log_stores
-        vals = getfield(result_set, k)
-
-        if vals === false || isnothing(vals)
-            continue
-        end
-
-        try
-            vals[vals .< threshold] .= Float32(0.0)
-        catch err
-            err isa MethodError ? nothing : rethrow(err)
-        end
-
-        if k == :seed_log || k == :mc_log
-            getfield(data_store, k)[:, :, :, idx] .= vals
-        elseif k == :site_ranks
-            if !isnothing(data_store.site_ranks)
-                # Squash site ranks down to average rankings over environmental repeats
-                data_store.site_ranks[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_dhw_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        elseif k == :coral_cover_log
-            if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
-                getfield(data_store, k)[:, :, :, idx] .= vals
-            end
-        end
-    end
-
+    result = _collect_scenario_results(domain, scenario, functional_groups)
+    _write_batch!(data_store, idx, [result])
     return nothing
 end
 function run_scenario(

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -926,7 +926,7 @@ function run_model(
     c_mean_reference .= copy(c_mean_t[:, 1, :])
 
     cover_transition_lb = 0.05
-    cover_transition_ub = 0.95
+    cover_transition_ub = 0.80
 
     for tstep::Int64 in 2:tf
         # Convert cover to absolute values to use within CoralBlox model

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -433,7 +433,7 @@ NamedTuple of collated results
 - `fog_log` : Array, Log of fogged locations
 - `shade_log` : Array, Log of shaded locations
 - `site_ranks` : Array, Log of location rankings
-- `bleaching_mortality` : Array, Log of mortalities caused by bleaching
+- `bleaching_mortality` : Array, Log of bleaching DHW (DHW-weeks) per location/group/size class — used as the lower bound of the tolerance distribution in the following timestep
 - `coral_dhw_log` : Array, Log of DHW tolerances / adaptation over time (only logged in debug mode)
 """
 function run_model(
@@ -784,8 +784,10 @@ function run_model(
     # Log of distributions
     dhw_tol_mean_log = cache.dhw_tol_mean_log  # tmp log for mean dhw tolerances
 
-    # Cache for proportional mortality and coral population increases
-    bleaching_mort = zeros(tf, n_groups, n_sizes, n_locs)
+    # Cache for per-location bleaching DHW (DHW-weeks) used as the lower bound of the
+    # tolerance distribution in the following timestep. Sliding window over two timesteps:
+    # dim-1 index 1 = previous timestep's bleaching DHW, 2 = current (being written).
+    bleach_dhw = zeros(tf, n_groups, n_sizes, n_locs)
     #### End coral constants
 
     ## Update ecological parameters based on intervention option
@@ -1520,7 +1522,7 @@ function run_model(
             depth_coeff,
             c_std,
             c_mean_t,
-            @view(bleaching_mort[(tstep - 1):tstep, :, :, :])
+            @view(bleach_dhw[(tstep - 1):tstep, :, :, :])
         )
 
         # Store current means to be used in future timesteps.
@@ -1600,7 +1602,7 @@ function run_model(
         fog_log=Yfog,
         shade_log=Yshade,
         site_ranks=log_location_ranks,
-        bleaching_mortality=bleaching_mort,
+        bleaching_mortality=bleach_dhw,
         coral_dhw_log=collated_dhw_tol_log
     )
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -775,6 +775,12 @@ function run_model(
     # Store means before mortality and growth events to use during update
     c_mean_t_1 = copy(c_mean_t)
 
+    # Snapshot of juvenile tolerance AFTER natural adaptation but BEFORE seeding.
+    # Used as the reference base for a_adapt enhancement (c_mean_reference).
+    # Storing the post-seeding state would cause a_adapt to compound year-over-year,
+    # driving unrealistic tolerance values (>100 DHW-weeks over long runs).
+    c_mean_pre_seed = zeros(n_groups, n_locs)
+
     # Log of distributions
     dhw_tol_mean_log = cache.dhw_tol_mean_log  # tmp log for mean dhw tolerances
 
@@ -1002,6 +1008,11 @@ function run_model(
                 )
             end
         end
+
+        # Snapshot juvenile tolerance after natural adaptation, before seeding modifies it.
+        # This is the correct baseline for a_adapt enhancement: using the post-seeding state
+        # here would cause the enhancement to compound each deployment year.
+        c_mean_pre_seed .= c_mean_t[:, 1, :]
 
         # Reproduction
         # Calculates scope for coral fedundity for each size class and at each location
@@ -1512,11 +1523,13 @@ function run_model(
             @view(bleaching_mort[(tstep - 1):tstep, :, :, :])
         )
 
-        # Store current means to be used in future timesteps
+        # Store current means to be used in future timesteps.
+        # Use pre-seeding snapshot so that a_adapt enhancement is not compounded
+        # into the reference year-over-year.
         if a_adapt_ref > 0
             c_mean_reference[:, :, 2:end] .= c_mean_reference[:, :, 1:(end - 1)]
         end
-        c_mean_reference[:, :, 1] .= c_mean_t[:, 1, :]
+        c_mean_reference[:, :, 1] .= c_mean_pre_seed
 
         # Coral deaths due to selected cyclone scenario
         # Peak cyclone period is January to March

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1006,7 +1006,7 @@ function run_model(
             if in_debug_mode
                 # Log dhw tolerances if in debug mode
                 dhw_tol_mean_log[tstep, :, :] .= reshape(
-                    mean.(c_mean_t), size(dhw_tol_mean_log)[2:3]
+                    permutedims(c_mean_t, (2, 1, 3)), size(dhw_tol_mean_log)[2:3]
                 )
             end
         end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -51,7 +51,8 @@ function setup_cache(domain::Domain)::NamedTuple
         loc_area=Matrix{Float64}(loc_area(domain)'),  # area of locations
         habitable_area=Matrix{Float64}(loc_k_area(domain)'),  # location carrying capacity
         wave_damage=zeros(tf, n_sizes * n_groups, n_locs),  # damage coefficient for each size class
-        dhw_tol_mean_log=zeros(tf, n_sizes * n_groups, n_locs)  # tmp log for mean dhw tolerances
+        dhw_tol_mean_log=zeros(tf, n_sizes * n_groups, n_locs),  # tmp log for mean dhw tolerances
+        cover_log=zeros(tf, n_sizes * n_groups, n_locs)  # tmp log for per-species cover
     )
 
     return cache
@@ -371,7 +372,15 @@ function run_scenario(
 
     # Store logs
     c_dim = Base.ndims(result_set.raw) + 1
-    log_stores = (:site_ranks, :mc_log, :seed_log, :fog_log, :shade_log, :coral_dhw_log)
+    log_stores = (
+        :site_ranks,
+        :mc_log,
+        :seed_log,
+        :fog_log,
+        :shade_log,
+        :coral_dhw_log,
+        :coral_cover_log
+    )
     for k in log_stores
         if k == :seed_log || k == :site_ranks
             concat_dim = c_dim
@@ -396,6 +405,10 @@ function run_scenario(
             end
         elseif k == :coral_dhw_log
             if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
+                getfield(data_store, k)[:, :, :, idx] .= vals
+            end
+        elseif k == :coral_cover_log
+            if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
                 getfield(data_store, k)[:, :, :, idx] .= vals
             end
         else
@@ -590,6 +603,7 @@ function run_model(
     # Environment variables are stored as strings, so convert to bool for use
     in_debug_mode = parse(Bool, get(ENV, "ADRIA_DEBUG", "false")) == true
     log_dhw_tols = parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "true")) == true
+    log_cover = parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
 
     # Initialize cover loss tracking for reactive strategies
     max_lookback = Int64(param_set[At("reactive_response_delay")])
@@ -786,6 +800,7 @@ function run_model(
 
     # Log of distributions
     dhw_tol_mean_log = cache.dhw_tol_mean_log  # tmp log for mean dhw tolerances
+    cover_log = cache.cover_log  # tmp log for per-species cover
 
     # Cache for per-location bleaching DHW (DHW-weeks) used as the lower bound of the
     # tolerance distribution in the following timestep. Sliding window over two timesteps:
@@ -1010,6 +1025,12 @@ function run_model(
                 # Log dhw tolerances if requested
                 dhw_tol_mean_log[tstep, :, :] .= reshape(
                     permutedims(c_mean_t, (2, 1, 3)), size(dhw_tol_mean_log)[2:3]
+                )
+            end
+
+            if log_cover
+                cover_log[tstep, :, :] .= reshape(
+                    permutedims(C_cover[tstep, :, :, :], (2, 1, 3)), size(cover_log)[2:3]
                 )
             end
         end
@@ -1596,10 +1617,19 @@ function run_model(
         collated_dhw_tol_log = false
     end
 
+    if log_cover
+        collated_cover_log = DataCube(
+            cover_log; timesteps=1:tf, species=corals.coral_id, sites=1:n_locs
+        )
+    else
+        collated_cover_log = false
+    end
+
     # Set variables to nothing so garbage collector clears them
     # Leads to memory leak issues in multiprocessing contexts without these.
     wave_scen = nothing
     dhw_tol_mean_log = nothing
+    cover_log = nothing
 
     return (
         raw=C_cover,
@@ -1609,6 +1639,7 @@ function run_model(
         shade_log=Yshade,
         site_ranks=log_location_ranks,
         bleaching_mortality=bleach_dhw,
-        coral_dhw_log=collated_dhw_tol_log
+        coral_dhw_log=collated_dhw_tol_log,
+        coral_cover_log=collated_cover_log
     )
 end

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -191,8 +191,8 @@ function run_scenarios(
     env_num_cores = ENV["ADRIA_NUM_CORES"]
     @info "ADRIA_NUM_CORES = $env_num_cores"
 
-    para_threshold::Int64 =
-        ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain)) ? 8 : 256
+    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
+    para_threshold::Int64 = is_RME_based ? 8 : 20
     active_cores::Int64 = parse(Int64, env_num_cores)
     parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
     if parallel && nworkers() == 1

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -742,10 +742,10 @@ function run_model(
     depth_criteria = identify_within_depth_bounds(
         loc_data.depth_med, param_set[At("depth_min")], param_set[At("depth_offset")]
     )
-    seed_t_locs = vcat(getproperty.(domain.seed_target_locations, :target_locs)...)
-    mc_t_locs = vcat(getproperty.(domain.mc_target_locations, :target_locs)...)
 
     if is_guided
+        seed_t_locs = vcat(getproperty.(domain.seed_target_locations, :target_locs)...)
+        mc_t_locs = vcat(getproperty.(domain.mc_target_locations, :target_locs)...)
         seed_pref, seed_decision_mat, seed_strategy = setup_guided_intervention(
             domain, param_set, depth_criteria, SeedPreferences, seed_t_locs, is_seeding,
             build_seed_strategy

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -340,55 +340,61 @@ function run_scenario(
 
     # rs_raw has dimensions [timesteps ⋅ group ⋅ sizes ⋅ locations]
     rs_raw::Array{Float64} = result_set.raw
+    lk = loc_k_area(domain)
+    coral_spec::DataFrame = to_coral_spec(scenario)
+
+    # Write all 6 location-based metrics into the combined store in one Zarr chunk write.
+    # Order must match LOC_METRIC_NAMES = [:relative_cover, :relative_shelter_volume,
+    #   :absolute_shelter_volume, :relative_juveniles, :juvenile_indicator, :coral_evenness]
+    loc_out = Array{Float32}(
+        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
+    )
+
     vals = relative_cover(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_cover[:, :, idx] .= vals
-
-    vals = absolute_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.absolute_shelter_volume[:, :, idx] .= vals
-    vals = relative_shelter_volume(rs_raw, loc_k_area(domain), scenario)
+    loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_shelter_volume[:, :, idx] .= vals
-
-    coral_spec::DataFrame = to_coral_spec(scenario)
+    loc_out[:, :, 3] .= vals
     vals = relative_juveniles(rs_raw)
     vals[vals .< threshold] .= 0.0
-    data_store.relative_juveniles[:, :, idx] .= vals
-
-    vals = juvenile_indicator(rs_raw, coral_spec, loc_k_area(domain))
+    loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk)
     vals[vals .< threshold] .= 0.0
-    data_store.juvenile_indicator[:, :, idx] .= vals
+    loc_out[:, :, 5] .= vals
+    rtc_vals = relative_loc_taxa_cover(rs_raw)
+    vals = coral_evenness(rtc_vals.data)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 6] .= vals
 
-    vals = relative_taxa_cover(rs_raw, loc_k_area(domain))
+    data_store.loc_outcomes[:, :, :, idx] .= loc_out
+
+    # Taxa cover uses a groups axis rather than locations — kept as its own store
+    vals = relative_taxa_cover(rs_raw, lk)
     vals[vals .< threshold] .= 0.0
     data_store.relative_taxa_cover[:, :, idx] .= vals
 
-    vals = relative_loc_taxa_cover(rs_raw)
+    # Write fog and shade together as a single 4-D shading_log chunk
+    shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
+    fog_vals = Matrix{Float32}(result_set.fog_log)
+    shade_vals = Matrix{Float32}(result_set.shade_log)
+    fog_vals[fog_vals .< threshold] .= 0.0f0
+    shade_vals[shade_vals .< threshold] .= 0.0f0
+    shading_buf[:, :, 1] .= fog_vals
+    shading_buf[:, :, 2] .= shade_vals
+    data_store.shading_log[:, :, :, idx] .= shading_buf
 
-    vals = coral_evenness(vals.data)
-    vals[vals .< threshold] .= 0.0
-    data_store.coral_evenness[:, :, idx] .= vals
-
-    # Store logs
-    c_dim = Base.ndims(result_set.raw) + 1
-    log_stores = (
-        :site_ranks,
-        :mc_log,
-        :seed_log,
-        :fog_log,
-        :shade_log,
-        :coral_dhw_log,
-        :coral_cover_log
-    )
+    # Store remaining logs
+    log_stores = (:site_ranks, :mc_log, :seed_log, :coral_dhw_log, :coral_cover_log)
     for k in log_stores
-        if k == :seed_log || k == :site_ranks
-            concat_dim = c_dim
-        else
-            concat_dim = c_dim - 1
-        end
-
         vals = getfield(result_set, k)
+
+        if vals === false || isnothing(vals)
+            continue
+        end
 
         try
             vals[vals .< threshold] .= Float32(0.0)
@@ -411,8 +417,6 @@ function run_scenario(
             if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
                 getfield(data_store, k)[:, :, :, idx] .= vals
             end
-        else
-            getfield(data_store, k)[:, :, idx] .= vals
         end
     end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -898,7 +898,6 @@ function run_model(
     habitable_loc_idxs = findall(habitable_locs)
 
     # Growth constraints and acceleration caches and masks
-    LIN_EXT_SCALE_FACTOR_THRESHOLD = 0.5
     relative_habitable_cover_cache = zeros(n_locs)
     growth_threshold_mask_cache::BitVector = trues(n_locs)
     cover_threshold_mask::BitVector = falses(n_locs)
@@ -926,6 +925,9 @@ function run_model(
     # tolerance enhancement
     c_mean_reference .= copy(c_mean_t[:, 1, :])
 
+    cover_transition_lb = 0.05
+    cover_transition_ub = 0.95
+
     for tstep::Int64 in 2:tf
         # Convert cover to absolute values to use within CoralBlox model
         C_cover_t[:, :, habitable_locs] .=
@@ -950,7 +952,7 @@ function run_model(
 
         # Growth constrains need to be calculated seperately for differen growth rates
         growth_threshold_mask_cache .=
-            relative_habitable_cover_cache .>= LIN_EXT_SCALE_FACTOR_THRESHOLD
+            relative_habitable_cover_cache .>= cover_transition_ub
         for idx in 1:n_cb_calib_groups
             cover_threshold_mask .=
                 cb_calib_group_masks[:, idx] .&& growth_threshold_mask_cache
@@ -964,8 +966,45 @@ function run_model(
                 habitable_max_projected_cover[cover_threshold_mask]
             )
         end
+
+        # When cover is between cover_transition_lb and cover_transition_ub use a weighted mean
+        growth_threshold_mask_cache .= (
+            cover_transition_lb .<= relative_habitable_cover_cache .<
+            cover_transition_ub
+        )
+        if sum(growth_threshold_mask_cache) > 0
+            for idx in 1:n_cb_calib_groups
+                cover_threshold_mask .=
+                    growth_threshold_mask_cache .&& cb_calib_group_masks[:, idx]
+                transition_scale =
+                    (
+                        relative_habitable_cover_cache[cover_threshold_mask] .-
+                        cover_transition_lb
+                    ) ./ (cover_transition_ub - cover_transition_lb)
+                growth_constraints[cover_threshold_mask] .=
+                    (
+                        transition_scale .*
+                        linear_extension_scale_factors(
+                            C_cover_t[:, :, cover_threshold_mask],
+                            vec_abs_k[cover_threshold_mask],
+                            biogrp_lin_ext[:, :, idx],
+                            _bin_edges,
+                            habitable_max_projected_cover[cover_threshold_mask]
+                        )
+                    ) .+
+                    (
+                        (1 .- transition_scale) .*
+                        growth_acceleration.(
+                            growth_acc_height[idx],
+                            growth_acc_midpoint[idx],
+                            growth_acc_steepness[idx],
+                            relative_habitable_cover_cache[cover_threshold_mask]
+                        )
+                    )
+            end
+        end
         growth_threshold_mask_cache .=
-            relative_habitable_cover_cache .< LIN_EXT_SCALE_FACTOR_THRESHOLD
+            relative_habitable_cover_cache .< cover_transition_lb
         for idx in 1:n_cb_calib_groups
             cover_threshold_mask .=
                 growth_threshold_mask_cache .&& cb_calib_group_masks[:, idx]

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -10,7 +10,8 @@ import CoralBlox:
     timestep!,
     coral_cover,
     max_projected_cover,
-    linear_extension_scale_factors
+    linear_extension_scale_factors,
+    LinearExtensionCache
 
 using .metrics:
     relative_cover,
@@ -1025,6 +1026,10 @@ function run_model(
         )
     end
 
+    # Pre-compute Δd matrices once for the entire simulation — _bin_edges is constant,
+    # so this avoids repeated allocation inside linear_extension_scale_factors each timestep.
+    _le_cache = LinearExtensionCache(_bin_edges)
+
     # Preallocate vector for growth constraints
     growth_constraints::Vector{Float64} = zeros(Float64, n_locs)
 
@@ -1105,11 +1110,11 @@ function run_model(
                 cb_calib_group_masks[:, idx] .&& growth_threshold_mask_cache
 
             # Only apply linear_extension_scale_factors to locations with high cover
-            growth_constraints[cover_threshold_mask] .= linear_extension_scale_factors(
+            @views growth_constraints[cover_threshold_mask] .= linear_extension_scale_factors(
                 C_cover_t[:, :, cover_threshold_mask],
                 vec_abs_k[cover_threshold_mask],
                 biogrp_lin_ext[:, :, idx],
-                _bin_edges,
+                _le_cache,
                 habitable_max_projected_cover[cover_threshold_mask]
             )
         end
@@ -1135,7 +1140,7 @@ function run_model(
                             C_cover_t[:, :, cover_threshold_mask],
                             vec_abs_k[cover_threshold_mask],
                             biogrp_lin_ext[:, :, idx],
-                            _bin_edges,
+                            _le_cache,
                             habitable_max_projected_cover[cover_threshold_mask]
                         )
                     ) .+

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1133,8 +1133,8 @@ function run_model(
         end
 
         # When cover is between cover_transition_lb and cover_transition_ub use a weighted mean
-        growth_threshold_mask_cache .= (
-            cover_transition_lb .<= relative_habitable_cover_cache .<
+        @. growth_threshold_mask_cache = (
+            cover_transition_lb <= relative_habitable_cover_cache <
             cover_transition_ub
         )
         if sum(growth_threshold_mask_cache) > 0

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -743,9 +743,10 @@ function run_model(
         loc_data.depth_med, param_set[At("depth_min")], param_set[At("depth_offset")]
     )
 
+    seed_t_locs = vcat(getproperty.(domain.seed_target_locations, :target_locs)...)
+    mc_t_locs = vcat(getproperty.(domain.mc_target_locations, :target_locs)...)
+
     if is_guided
-        seed_t_locs = vcat(getproperty.(domain.seed_target_locations, :target_locs)...)
-        mc_t_locs = vcat(getproperty.(domain.mc_target_locations, :target_locs)...)
         seed_pref, seed_decision_mat, seed_strategy = setup_guided_intervention(
             domain, param_set, depth_criteria, SeedPreferences, seed_t_locs, is_seeding,
             build_seed_strategy

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -134,16 +134,15 @@ julia> rs_45_60 = ADRIA.run_scenarios(dom, scens, ["45", "60"])
 ResultSet
 """
 function run_scenarios(
-    dom::Domain, scens::DataFrame, RCP::String; show_progress=true, remove_workers=true
+    dom::Domain, scens::DataFrame, RCP::String; show_progress=true
 )::ResultSet
-    return run_scenarios(dom, scens, [RCP]; show_progress, remove_workers)
+    return run_scenarios(dom, scens, [RCP]; show_progress)
 end
 function run_scenarios(
     dom::Domain,
     scens::DataFrame,
     RCP::Vector{String};
-    show_progress=true,
-    remove_workers=true
+    show_progress=true
 )::ResultSet
     # Initialize ADRIA configuration options
     setup()
@@ -156,27 +155,22 @@ function run_scenarios(
     env_debug = parse(Bool, ENV["ADRIA_DEBUG"]) == true
     @info "ADRIA_DEBUG = $env_debug"
 
-    env_num_cores = ENV["ADRIA_NUM_CORES"]
-    @info "ADRIA_NUM_CORES = $env_num_cores"
+    parallel::Bool = !env_debug && (Threads.nthreads() > 1)
 
-    is_RME_based = ((typeof(dom) == RMEDomain) || (typeof(dom) == ReefModDomain))
-    para_threshold::Int64 = is_RME_based ? 8 : 20
-    active_cores::Int64 = parse(Int64, env_num_cores)
-    parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
-
-    # Compute batch size before setting up the store so chunk sizes match the pmap batch
-    # sizes. In parallel mode: a small fixed batch keeps the pmap queue deep enough for
-    # dynamic load balancing — ceil(N/P) would create exactly one task per worker, leaving
-    # fast workers idle. In serial mode: fall back to the env var (default 1).
-    env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
-    batch_size::Int = if env_batch > 0
-        env_batch  # explicit override always wins
+    # chunk_size sets the Zarr chunk size along the scenario axis and controls how many
+    # results the writer accumulates before flushing to disk. Compute scheduling is
+    # per-scenario via a channel, so chunk_size is purely an I/O tuning parameter.
+    # In serial mode: fall back to the env var (default 1).
+    active_threads::Int = Threads.nthreads()
+    env_chunk = parse(Int, get(ENV, "ADRIA_CHUNK_SIZE", "0"))
+    chunk_size::Int = if env_chunk > 0
+        env_chunk  # explicit override always wins
     elseif parallel
-        max(1, min(4, ceil(Int, nrow(scens) / (active_cores * 4))))
+        ceil(Int, nrow(scens) / active_threads)
     else
         1
     end
-    @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
+    @info "ADRIA_CHUNK_SIZE (effective) = $chunk_size"
 
     # Cross product between rcps and param_df to have every row of param_df for each rcp
     rcps_df = DataFrame(; RCP=parse.(Int64, RCP))
@@ -184,88 +178,105 @@ function run_scenarios(
     sort!(scenarios_df, :RCP)
 
     @info "Setting up Result Set"
-    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, batch_size)
+    dom, data_store = ADRIA.setup_result_store!(dom, scenarios_df, chunk_size)
 
     # Convert DataFrame to named matrix for faster iteration
     scenarios_matrix::YAXArray = DataCube(
         Matrix(scenarios_df); scenarios=1:nrow(scenarios_df), factors=names(scenarios_df)
     )
 
-    # The idea to initialise the functional groups here is so that each scenario run can
-    # reuse the memory. After a few scenarios runs there will be very few new
-    # allocations as buffers grow larger and are not exceeded
-    #
-    # The problem is that even if a subsequent run only has to reallocate once, the
-    # buffer is so large it takes very long regardless.
-    #
-    # This is also forced me to added an argument to run_model which breaks
-    # encapsulation, so its quite ugly
+    # Pre-allocate FunctionalGroup buffers so each scenario run can reuse memory.
+    # Buffer contents grow over time as size classes accumulate; reusing avoids repeated
+    # large allocations. In the parallel path one buffer set is created per thread to
+    # avoid data races on the mutable CircularBuffer and TerminalClass fields.
     n_locs::Int64 = dom.coral_growth.n_locs
     n_sizes::Int64 = dom.coral_growth.n_sizes
     n_groups::Int64 = dom.coral_growth.n_groups
     _bin_edges::Matrix{Float64} = bin_edges(; unit=:m)
-    functional_groups = Vector{Vector{FunctionalGroup}}(undef, n_locs)
-    for loc in 1:n_locs
-        functional_groups[loc] =
-            FunctionalGroup.(
-                eachrow(_bin_edges[:, 1:(end - 1)]),
-                eachrow(_bin_edges[:, 2:end]),
-                eachrow(zeros(n_groups, n_sizes))
-            )
-    end
 
-    if parallel && nworkers() == 1
-        @info "Setting up parallel processing..."
-        spinup_time = @elapsed begin
-            _setup_workers()
-
-            # Load ADRIA on workers. Each pmap task runs _run_batch!, which computes
-            # and writes a full batch directly. Workers write to non-overlapping chunk
-            # ranges (chunk size == batch size) so concurrent Zarr writes are safe.
-            @sync @async @everywhere @eval begin
-                using ADRIA
-            end
-        end
-
-        @info "Time taken to spin up workers: $(round(spinup_time; digits=2)) seconds"
-    end
+    _make_fg_buffers() = [
+        FunctionalGroup.(
+            eachrow(_bin_edges[:, 1:(end - 1)]),
+            eachrow(_bin_edges[:, 2:end]),
+            eachrow(zeros(n_groups, n_sizes))
+        )
+        for _ in 1:n_locs
+    ]
 
     if parallel
-        # Each pmap task is one batch: workers compute B scenarios and write them
-        # directly. Only `nothing` returns to the main process — no result IPC.
-        batch_func = (batch) -> _run_batch!(batch, functional_groups, data_store)
+        # One buffer set per thread — threadid() can reach maxthreadid() due to Julia's
+        # internal threads, so size to maxthreadid() not nthreads().
+        thread_fg = [_make_fg_buffers() for _ in 1:Threads.maxthreadid()]
 
-        try
-            for rcp in RCP
-                run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
+        # Prevent BLAS internal threads from competing with Julia threads.
+        BLAS.set_num_threads(1)
 
-                dom = switch_RCPs!(dom, rcp)
-                target_rows = findall(
-                    scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
-                )
-                scen_args = collect(
-                    _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
-                )
-                all_batches = [
-                    collect(b) for b in Iterators.partition(scen_args, batch_size)
-                ]
+        for rcp in RCP
+            run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
 
-                if show_progress
-                    @showprogress desc = run_msg dt = 4 pmap(
-                        batch_func, CachingPool(workers()), all_batches
-                    )
-                else
-                    pmap(batch_func, CachingPool(workers()), all_batches)
+            dom = switch_RCPs!(dom, rcp)
+            target_rows = findall(
+                scenarios_matrix[factors=At("RCP")] .== parse(Float64, rcp)
+            )
+            scen_args = collect(
+                _scenario_args(dom, scenarios_matrix, rcp, length(target_rows))
+            )
+            N_rcp = length(scen_args)
+            first_idx = scen_args[1][2]
+            n_chunks = cld(N_rcp, chunk_size)
+
+            prog =
+                show_progress ?
+                ProgressMeter.Progress(n_chunks; desc=run_msg, dt=4) :
+                nothing
+
+            # Workers push (write_idx, result) to the channel; the single writer task
+            # buffers results and flushes in chunk_size-aligned chunks so all Zarr writes
+            # are chunk-aligned and contention-free, regardless of completion order.
+            ch = Channel{Tuple{Int,NamedTuple}}(2 * Threads.nthreads())
+
+            chunk_start(c) = first_idx + c * chunk_size
+            chunk_len(c) = c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
+
+            writer = Threads.@spawn begin
+                buf = Dict{Int,NamedTuple}()
+                chunk_ready = zeros(Int, n_chunks)
+                next_chunk = 0
+
+                for (idx, result) in ch
+                    buf[idx] = result
+                    c = (idx - first_idx) ÷ chunk_size
+                    chunk_ready[c + 1] += 1
+
+                    while next_chunk < n_chunks &&
+                            chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
+                        s = chunk_start(next_chunk)
+                        n = chunk_len(next_chunk)
+                        results = [buf[s + i] for i in 0:(n - 1)]
+                        for i in 0:(n - 1)
+                            delete!(buf, s + i)
+                        end
+                        _write_batch!(data_store, s, results)
+                        isnothing(prog) || ProgressMeter.next!(prog)
+                        next_chunk += 1
+                    end
                 end
             end
-        catch err
-            # Remove hanging workers if any error occurs
-            _remove_workers()
-            rethrow(err)
+
+            try
+                Threads.@threads :dynamic for i in 1:N_rcp
+                    d, idx, scen = scen_args[i]
+                    result = _collect_scenario_results(d, scen, thread_fg[Threads.threadid()])
+                    put!(ch, (idx, result))
+                end
+            finally
+                close(ch)
+            end
+            wait(writer)
         end
     else
-        # Serial: collect B results then write once (batch write, no IPC overhead)
-        collect_func = (dfx) -> _collect_scenario_results(dfx[1], dfx[3], functional_groups)
+        # Serial: one shared buffer set, collect batch then write.
+        functional_groups = _make_fg_buffers()
 
         for rcp in RCP
             run_msg = "Running $(nrow(scens)) scenarios for RCP $rcp"
@@ -275,25 +286,27 @@ function run_scenarios(
                 _scenario_args(dom, scenarios_matrix, rcp, size(scenarios_matrix, 1))
             )
             all_batches = [
-                collect(b) for b in Iterators.partition(scen_args, batch_size)
+                collect(b) for b in Iterators.partition(scen_args, chunk_size)
             ]
 
             if show_progress
                 @showprogress desc = run_msg dt = 4 for batch in all_batches
-                    batch_results = map(collect_func, batch)
+                    batch_results = map(
+                        dfx -> _collect_scenario_results(dfx[1], dfx[3], functional_groups),
+                        batch
+                    )
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             else
                 for batch in all_batches
-                    batch_results = map(collect_func, batch)
+                    batch_results = map(
+                        dfx -> _collect_scenario_results(dfx[1], dfx[3], functional_groups),
+                        batch
+                    )
                     _write_batch!(data_store, first(batch)[2], batch_results)
                 end
             end
         end
-    end
-
-    if parallel && remove_workers
-        _remove_workers()
     end
 
     return load_results(_result_location(dom, RCP))

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1131,14 +1131,16 @@ function run_model(
         end
 
         @inbounds for i in habitable_loc_idxs
+            cb_idx::Int64 = loc_cb_calib_group_idxs[i]
             net_growth_rates[:, :, i] .=
-                biogrp_lin_ext[:, :, loc_cb_calib_group_idxs[i]] .*
+                @view(biogrp_lin_ext[:, :, cb_idx]) .*
                 growth_constraints[i]
-            @views timestep!(
+
+            timestep!(
                 functional_groups[i],
-                recruitment[:, i],
-                net_growth_rates[:, :, i],
-                biogrp_survival[:, :, loc_cb_calib_group_idxs[i]]
+                @view(recruitment[:, i]),
+                @view(net_growth_rates[:, :, i]),
+                @view(biogrp_survival[:, :, cb_idx])
             )
 
             # Write to the cover matrix

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -164,15 +164,16 @@ function run_scenarios(
     parallel::Bool = !env_debug && (active_cores > 1) && (nrow(scens) >= para_threshold)
 
     # Compute batch size before setting up the store so chunk sizes match the pmap batch
-    # sizes. In parallel mode: ceil(N/P) gives exactly one batch per worker and the fewest
-    # possible chunk files. In serial mode: fall back to the env var (default 32).
+    # sizes. In parallel mode: a small fixed batch keeps the pmap queue deep enough for
+    # dynamic load balancing — ceil(N/P) would create exactly one task per worker, leaving
+    # fast workers idle. In serial mode: fall back to the env var (default 1).
     env_batch = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     batch_size::Int = if env_batch > 0
         env_batch  # explicit override always wins
     elseif parallel
-        ceil(Int, nrow(scens) / active_cores)
+        max(1, min(4, ceil(Int, nrow(scens) / (active_cores * 4))))
     else
-        32
+        1
     end
     @info "ADRIA_BATCH_SIZE (effective) = $batch_size"
 
@@ -202,13 +203,15 @@ function run_scenarios(
     n_sizes::Int64 = dom.coral_growth.n_sizes
     n_groups::Int64 = dom.coral_growth.n_groups
     _bin_edges::Matrix{Float64} = bin_edges(; unit=:m)
-    functional_groups = [
-        FunctionalGroup.(
-            eachrow(_bin_edges[:, 1:(end - 1)]),
-            eachrow(_bin_edges[:, 2:end]),
-            eachrow(zeros(n_groups, n_sizes))
-        ) for _ in 1:n_locs
-    ]
+    functional_groups = Vector{Vector{FunctionalGroup}}(undef, n_locs)
+    for loc in 1:n_locs
+        functional_groups[loc] =
+            FunctionalGroup.(
+                eachrow(_bin_edges[:, 1:(end - 1)]),
+                eachrow(_bin_edges[:, 2:end]),
+                eachrow(zeros(n_groups, n_sizes))
+            )
+    end
 
     if parallel && nworkers() == 1
         @info "Setting up parallel processing..."
@@ -330,14 +333,28 @@ function _collect_scenario_results(
     coral_spec::DataFrame = to_coral_spec(scenario)
 
     # 6 location-based metrics — order must match LOC_METRIC_NAMES
-    loc_out = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES))
-    vals = relative_cover(rs_raw);                      vals[vals .< threshold] .= 0.0; loc_out[:, :, 1] .= vals
-    vals = relative_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 2] .= vals
-    vals = absolute_shelter_volume(rs_raw, lk, scenario); vals[vals .< threshold] .= 0.0; loc_out[:, :, 3] .= vals
-    vals = relative_juveniles(rs_raw);                  vals[vals .< threshold] .= 0.0; loc_out[:, :, 4] .= vals
-    vals = juvenile_indicator(rs_raw, coral_spec, lk);  vals[vals .< threshold] .= 0.0; loc_out[:, :, 5] .= vals
+    loc_out = Array{Float32}(
+        undef, size(rs_raw, 1), size(rs_raw, 4), length(LOC_METRIC_NAMES)
+    )
+    vals = relative_cover(rs_raw)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 1] .= vals
+    vals = relative_shelter_volume(rs_raw, lk, scenario)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 2] .= vals
+    vals = absolute_shelter_volume(rs_raw, lk, scenario)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 3] .= vals
+    vals = relative_juveniles(rs_raw)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 4] .= vals
+    vals = juvenile_indicator(rs_raw, coral_spec, lk)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 5] .= vals
     rtc_vals = relative_loc_taxa_cover(rs_raw)
-    vals = coral_evenness(rtc_vals.data);               vals[vals .< threshold] .= 0.0; loc_out[:, :, 6] .= vals
+    vals = coral_evenness(rtc_vals.data)
+    vals[vals .< threshold] .= 0.0
+    loc_out[:, :, 6] .= vals
 
     # Taxa cover (groups axis, not locations)
     taxa_vals = relative_taxa_cover(rs_raw, lk)
@@ -347,14 +364,18 @@ function _collect_scenario_results(
     shading_buf = Array{Float32}(undef, size(rs_raw, 1), size(rs_raw, 4), 2)
     fog_vals = Matrix{Float32}(result_set.fog_log)
     shade_vals = Matrix{Float32}(result_set.shade_log)
-    fog_vals[fog_vals .< threshold] .= 0f0
-    shade_vals[shade_vals .< threshold] .= 0f0
+    fog_vals[fog_vals .< threshold] .= 0.0f0
+    shade_vals[shade_vals .< threshold] .= 0.0f0
     shading_buf[:, :, 1] .= fog_vals
     shading_buf[:, :, 2] .= shade_vals
 
     # Remaining log arrays — apply threshold where possible
     site_ranks_vals = result_set.site_ranks
-    try; site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0); catch err; err isa MethodError ? nothing : rethrow(err); end
+    try
+        site_ranks_vals[site_ranks_vals .< threshold] .= Float32(0.0)
+    catch err
+        err isa MethodError ? nothing : rethrow(err)
+    end
 
     mc_vals = result_set.mc_log
     mc_vals[mc_vals .< threshold] .= Float32(0.0)
@@ -426,13 +447,13 @@ function _write_batch!(
 
     # mc_log and seed_log: (tf, n_groups, n_locs, n)
     _, n_g, n_l = size(results[1].mc_log)
-    mc_batch   = Array{Float32}(undef, tf, n_g, n_l, n)
+    mc_batch = Array{Float32}(undef, tf, n_g, n_l, n)
     seed_batch = Array{Float32}(undef, tf, n_g, n_l, n)
     for (i, r) in enumerate(results)
-        mc_batch[:, :, :, i]   .= r.mc_log
+        mc_batch[:, :, :, i] .= r.mc_log
         seed_batch[:, :, :, i] .= r.seed_log
     end
-    data_store.mc_log[:, :, :, idx_range]   .= mc_batch
+    data_store.mc_log[:, :, :, idx_range] .= mc_batch
     data_store.seed_log[:, :, :, idx_range] .= seed_batch
 
     # coral_dhw_log (conditional on ADRIA_LOG_DHW_TOLS)
@@ -1036,10 +1057,23 @@ function run_model(
 
     # Keeps track of the heat tolerance means of juvenilles to use as a base for thermal
     # tolerance enhancement
-    c_mean_reference .= copy(c_mean_t[:, 1, :])
+    c_mean_reference .= c_mean_t[:, 1, :]
 
     cover_transition_lb = 0.05
     cover_transition_ub = 0.80
+
+    # Preallocate per-timestep buffers to avoid repeated allocation in the hot loop
+    Δcover_loss_proportion = zeros(n_locs)
+    _is_reactive = any(
+        is_reactive(param_set[At(["seed_strategy", "fog_strategy", "mc_strategy"])])
+    )
+    dhw_p = is_guided ? similar(dhw_scen) : nothing
+    current_loc_cover = zeros(n_locs)
+    _loc_coral_cover = zeros(n_locs)
+    leftover_space_m² = zeros(n_locs)
+    _recruitment_col_sum = zeros(n_locs)
+    _recruitment_col_sum_2d = reshape(_recruitment_col_sum, 1, n_locs)
+    _permuted_buf = zeros(n_sizes, n_groups, n_locs)
 
     for tstep::Int64 in 2:tf
         # Convert cover to absolute values to use within CoralBlox model
@@ -1055,9 +1089,9 @@ function run_model(
         # Settlers from t-1 grow into observable sizes.
         C_cover_t[:, 1, habitable_locs] .+= recruitment
 
-        habitable_max_projected_cover =
-            cache_habitable_max_projected_cover .+
-            dropdims(sum(recruitment; dims=1); dims=1)
+        sum!(_recruitment_col_sum_2d, recruitment)
+        habitable_max_projected_cover .=
+            cache_habitable_max_projected_cover .+ _recruitment_col_sum
 
         relative_habitable_cover_cache[habitable_locs] .=
             loc_coral_cover(C_cover_t[:, :, habitable_locs]) ./
@@ -1175,15 +1209,15 @@ function run_model(
 
             if log_dhw_tols
                 # Log dhw tolerances if requested
+                permutedims!(_permuted_buf, c_mean_t, (2, 1, 3))
                 dhw_tol_mean_log[tstep, :, :] .= reshape(
-                    permutedims(c_mean_t, (2, 1, 3)), size(dhw_tol_mean_log)[2:3]
+                    _permuted_buf, size(dhw_tol_mean_log)[2:3]
                 )
             end
 
             if log_cover
-                cover_log[tstep, :, :] .= reshape(
-                    permutedims(C_cover[tstep, :, :, :], (2, 1, 3)), size(cover_log)[2:3]
-                )
+                permutedims!(_permuted_buf, @view(C_cover[tstep, :, :, :]), (2, 1, 3))
+                cover_log[tstep, :, :] .= reshape(_permuted_buf, size(cover_log)[2:3])
             end
         end
 
@@ -1198,11 +1232,15 @@ function run_model(
 
         for l in 1:n_locs
             s = sum(fec_scope[:, l])
-            prop_fecundity[:, l] .= s > 0.0 ? fec_scope[:, l] ./ s : 0.0
+            if s > 0.0
+                prop_fecundity[:, l] .= fec_scope[:, l] ./ s
+            else
+                prop_fecundity[:, l] .= 0.0
+            end
         end
 
-        _loc_coral_cover = loc_coral_cover(C_cover_t)
-        leftover_space_m² = relative_leftover_space(_loc_coral_cover) .* vec_abs_k
+        _loc_coral_cover .= loc_coral_cover(C_cover_t)
+        leftover_space_m² .= relative_leftover_space(_loc_coral_cover) .* vec_abs_k
 
         # Reset potential settlers to zero
         potential_settlers .= 0.0
@@ -1229,7 +1267,8 @@ function run_model(
         # Reset fecundity scope before next run
         fec_scope .= 0.0
 
-        leftover_space_m² .-= dropdims(sum(recruitment; dims=1); dims=1) .* vec_abs_k
+        sum!(_recruitment_col_sum_2d, recruitment)
+        leftover_space_m² .-= _recruitment_col_sum .* vec_abs_k
 
         # Determine intervention locations whose deployment is assumed to occur
         # between November to February.
@@ -1259,7 +1298,7 @@ function run_model(
 
         if is_guided
             # Use modified projected DHW (may have been affected by shading)
-            dhw_p = copy(dhw_scen)
+            dhw_p .= dhw_scen
             dhw_p[tstep, :] .= dhw_t
             dhw_projection .= weighted_projection(dhw_p, tstep, plan_horizon, decay, tf)
 
@@ -1276,7 +1315,7 @@ function run_model(
             )
 
             # Calculate current location cover
-            current_loc_cover = dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
+            current_loc_cover .= dropdims(sum(C_cover_t; dims=(1, 2)); dims=(1, 2))
         end
 
         # Fogging
@@ -1689,7 +1728,7 @@ function run_model(
         # Apply disturbances
 
         # ΔC_cover_t should only hold changes in cover due to env. disturbances
-        ΔC_cover_t .= copy(C_cover_t)
+        ΔC_cover_t .= C_cover_t
 
         # Store current c_mean before bleaching. This will be used in the next timestep to
         # update the settler's DHW tolerance dists.
@@ -1726,10 +1765,11 @@ function run_model(
         cyclone_mortality!(C_cover_t, cyclone_mortality_scen[tstep, :, :]')
 
         # Calculate survival_rate due to env. disturbances
-        no_mortality_mask = ΔC_cover_t .== 0.0
-        survival_rate_cache[.!no_mortality_mask] .= (C_cover_t ./ ΔC_cover_t)[.!no_mortality_mask]
-        survival_rate_cache[no_mortality_mask] .= 1.0
-        @assert sum(survival_rate_cache .> 1) == 0 "Survival rate should be <= 1"
+        @inbounds for i in eachindex(survival_rate_cache)
+            d = ΔC_cover_t[i]
+            survival_rate_cache[i] = d == 0.0 ? 1.0 : C_cover_t[i] / d
+        end
+        @assert !any(>(1.0), survival_rate_cache) "Survival rate should be <= 1"
 
         for loc in 1:n_locs
             apply_mortality!(
@@ -1742,13 +1782,10 @@ function run_model(
         C_cover[tstep, :, :, :] .= C_cover_t
 
         # Track cover loss for reactive strategies
-        _is_reactive = any(
-            is_reactive(param_set[At(["seed_strategy", "fog_strategy", "mc_strategy"])])
-        )
         if is_guided && _is_reactive && (tstep > 1)
             # Calculate proportional cover loss at each location
             # due to disturbances this timestep
-            Δcover_loss_proportion = zeros(n_locs)
+            Δcover_loss_proportion .= 0.0
             for loc in 1:n_locs
                 cover_before = sum(@view(ΔC_cover_t[:, :, loc]))
                 cover_after = sum(@view(C_cover_t[:, :, loc]))

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -236,7 +236,8 @@ function run_scenarios(
             ch = Channel{Tuple{Int,NamedTuple}}(2 * Threads.nthreads())
 
             chunk_start(c) = first_idx + c * chunk_size
-            chunk_len(c) = c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
+            chunk_len(c) =
+                c < n_chunks - 1 ? chunk_size : N_rcp - (n_chunks - 1) * chunk_size
 
             writer = Threads.@spawn begin
                 buf = Dict{Int,NamedTuple}()
@@ -249,7 +250,7 @@ function run_scenarios(
                     chunk_ready[c + 1] += 1
 
                     while next_chunk < n_chunks &&
-                            chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
+                        chunk_ready[next_chunk + 1] >= chunk_len(next_chunk)
                         s = chunk_start(next_chunk)
                         n = chunk_len(next_chunk)
                         results = [buf[s + i] for i in 0:(n - 1)]
@@ -266,7 +267,9 @@ function run_scenarios(
             try
                 Threads.@threads :dynamic for i in 1:N_rcp
                     d, idx, scen = scen_args[i]
-                    result = _collect_scenario_results(d, scen, thread_fg[Threads.threadid()])
+                    result = _collect_scenario_results(
+                        d, scen, thread_fg[Threads.threadid()]
+                    )
                     put!(ch, (idx, result))
                 end
             finally

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1514,10 +1514,7 @@ function run_model(
                     if has_mc_locs
                         mc_loc_idx = findall(domain.loc_ids .∈ [selected_mc_ranks])
 
-                        # Discount recruits added via seeding from leftover space
-                        @views available_space =
-                            leftover_space_m²[mc_loc_idx] .-
-                            dropdims(sum(recruitment[:, mc_loc_idx]; dims=1); dims=1)
+                        @views available_space = leftover_space_m²[mc_loc_idx]
 
                         locs_with_space = findall(available_space .> 0.0)
 
@@ -1536,6 +1533,9 @@ function run_model(
 
                             @views recruitment[:, mc_loc_idx] .+=
                                 mc_proportional_increase
+                            leftover_space_m²[mc_loc_idx] .-=
+                                vec(sum(Array(mc_proportional_increase); dims=1)) .*
+                                vec_abs_k[mc_loc_idx]
 
                             # Log estimated number of corals moved
                             Ymc[tstep, :, mc_loc_idx] .= n_mc_corals
@@ -1725,6 +1725,9 @@ function run_model(
 
                             # Add coral seeding to recruitment
                             recruitment[:, seed_loc_idx] .+= proportional_increase
+                            leftover_space_m²[seed_loc_idx] .-=
+                                vec(sum(Array(proportional_increase); dims=1)) .*
+                                vec_abs_k[seed_loc_idx]
 
                             update_tolerance_distribution!(
                                 proportional_increase,

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -12,21 +12,23 @@ function setup()::Nothing
     try
         # Load in configuration settings
         config = TOML.parsefile(joinpath(pwd(), "config.toml"))
+        config_operation = config["operation"]
         ENV["ADRIA_OUTPUT_DIR"] = config["results"]["output_dir"]
-        ENV["ADRIA_NUM_CORES"] = config["operation"]["num_cores"]
-        ENV["ADRIA_THRESHOLD"] = config["operation"]["threshold"]
+        ENV["ADRIA_NUM_CORES"] = config_operation["num_cores"]
+        ENV["ADRIA_THRESHOLD"] = config_operation["threshold"]
         ENV["ADRIA_DEBUG"] =
-            haskey(config["operation"], "debug") ? config["operation"]["debug"] : false
+            haskey(config_operation, "debug") ? config_operation["debug"] : false
 
         ENV["ADRIA_LOG_DHW_TOLS"] =
-            haskey(config["operation"], "log_dhw_tols") ?
-            config["operation"]["log_dhw_tols"] :
+            haskey(config_operation, "log_dhw_tols") ?
+            config_operation["log_dhw_tols"] :
             false
 
         ENV["ADRIA_LOG_COVER"] =
-            haskey(config["operation"], "log_cover") ?
-            config["operation"]["log_cover"] :
-            false
+            haskey(config_operation, "log_cover") ? config_operation["log_cover"] : false
+
+        ENV["ADRIA_RNG_SEED"] =
+            haskey(config_operation, "rng_seed") ? config_operation["rng_seed"] : false
     catch
         @warn "Could not find config.toml file.\nApplying default configuration and saving results to 'Outputs' in current directory."
 
@@ -84,4 +86,21 @@ end
 
 function is_test_env()::Bool
     return get(ENV, "ADRIA_TEST", "false") == "true"
+end
+
+"""
+    set_random_seed(param_set)::Nothing
+
+Set the RNG seed from `ENV["ADRIA_RNG_SEED"]`. If unset or `"false"`, derives the seed
+from the sum of all non-RCP parameters in `param_set`.
+
+# Arguments
+- `param_set` : YAXArray of scenario parameter values for a single run.
+"""
+function set_random_seed(param_set::YAXArray)::AbstractRNG
+    rnd_seed_val::Int64 =
+        ENV["ADRIA_RNG_SEED"] == "false" ?
+        floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
+        parse(Int64, ENV["ADRIA_RNG_SEED"])
+    return Xoshiro(rnd_seed_val)
 end

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -99,7 +99,7 @@ from the sum of all non-RCP parameters in `param_set`.
 """
 function set_random_seed(param_set::YAXArray)::AbstractRNG
     rnd_seed_val::Int64 =
-        ENV["ADRIA_RNG_SEED"] == "false" ?
+        get(ENV, "ADRIA_RNG_SEED", "false") == "false" ?
         floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
         parse(Int64, ENV["ADRIA_RNG_SEED"])
     return Xoshiro(rnd_seed_val)

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -17,6 +17,11 @@ function setup()::Nothing
         ENV["ADRIA_THRESHOLD"] = config["operation"]["threshold"]
         ENV["ADRIA_DEBUG"] =
             haskey(config["operation"], "debug") ? config["operation"]["debug"] : false
+
+        ENV["ADRIA_LOG_DHW_TOLS"] =
+            haskey(config["operation"], "log_dhw_tols") ?
+            config["operation"]["log_dhw_tols"] :
+            false
     catch
         @warn "Could not find config.toml file.\nApplying default configuration and saving results to 'Outputs' in current directory."
 
@@ -25,6 +30,7 @@ function setup()::Nothing
         ENV["ADRIA_NUM_CORES"] = 1
         ENV["ADRIA_THRESHOLD"] = Float32(1e-8)
         ENV["ADRIA_DEBUG"] = false
+        ENV["ADRIA_LOG_DHW_TOLS"] = false
     end
 
     return nothing

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -22,6 +22,11 @@ function setup()::Nothing
             haskey(config["operation"], "log_dhw_tols") ?
             config["operation"]["log_dhw_tols"] :
             false
+
+        ENV["ADRIA_LOG_COVER"] =
+            haskey(config["operation"], "log_cover") ?
+            config["operation"]["log_cover"] :
+            false
     catch
         @warn "Could not find config.toml file.\nApplying default configuration and saving results to 'Outputs' in current directory."
 
@@ -31,6 +36,7 @@ function setup()::Nothing
         ENV["ADRIA_THRESHOLD"] = Float32(1e-8)
         ENV["ADRIA_DEBUG"] = false
         ENV["ADRIA_LOG_DHW_TOLS"] = false
+        ENV["ADRIA_LOG_COVER"] = false
     end
 
     return nothing

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -100,7 +100,7 @@ from the sum of all non-RCP parameters in `param_set`.
 """
 function set_random_seed(param_set::YAXArray)::AbstractRNG
     rnd_seed_val::Int64 =
-        ENV["ADRIA_RNG_SEED"] == "false" ?
+        get(ENV, "ADRIA_RNG_SEED", "false") == "false" ?
         floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
         parse(Int64, ENV["ADRIA_RNG_SEED"])
     return Xoshiro(rnd_seed_val)

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -99,7 +99,7 @@ from the sum of all non-RCP parameters in `param_set`.
 """
 function set_random_seed(param_set::YAXArray)::AbstractRNG
     rnd_seed_val::Int64 =
-        get(ENV, "ADRIA_RNG_SEED", "false") == "false" ?
+        ENV["ADRIA_RNG_SEED"] == "false" ?
         floor(Int64, sum(param_set[Where(x -> x != "RCP")])) : # select everything except RCP
         parse(Int64, ENV["ADRIA_RNG_SEED"])
     return Xoshiro(rnd_seed_val)

--- a/src/utils/setup.jl
+++ b/src/utils/setup.jl
@@ -14,7 +14,9 @@ function setup()::Nothing
         config = TOML.parsefile(joinpath(pwd(), "config.toml"))
         config_operation = config["operation"]
         ENV["ADRIA_OUTPUT_DIR"] = config["results"]["output_dir"]
-        ENV["ADRIA_NUM_CORES"] = config_operation["num_cores"]
+        if haskey(config_operation, "num_cores")
+            @warn "config.toml: `num_cores` is deprecated and has no effect. Control parallelism by launching Julia with `--threads=N` (e.g. `julia --threads=auto`)."
+        end
         ENV["ADRIA_THRESHOLD"] = config_operation["threshold"]
         ENV["ADRIA_DEBUG"] =
             haskey(config_operation, "debug") ? config_operation["debug"] : false
@@ -34,7 +36,6 @@ function setup()::Nothing
 
         # Note: anything stored in ENV will be stored as String.
         ENV["ADRIA_OUTPUT_DIR"] = "./Outputs"
-        ENV["ADRIA_NUM_CORES"] = 1
         ENV["ADRIA_THRESHOLD"] = Float32(1e-8)
         ENV["ADRIA_DEBUG"] = false
         ENV["ADRIA_LOG_DHW_TOLS"] = false

--- a/test/config.toml
+++ b/test/config.toml
@@ -2,6 +2,7 @@
 num_cores = 1         # No. of cores to use. Values <= 0 will use all available cores.
 threshold = 1e-6      # Result values below this will be set to 0.0
 log_dhw_tols = true   # Log per-location coral DHW tolerance trajectories
+log_cover = false     # Log per-species per-size-class cover (expensive; enable for targeted runs only)
 
 [results]
 output_dir = "./outputs"  # save to current working directory

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,6 +1,7 @@
 [operation]
-num_cores = 1    # No. of cores to use. Values <= 0 will use all available cores.
-threshold = 1e-6  # Result values below this will be set to 0.0
+num_cores = 1         # No. of cores to use. Values <= 0 will use all available cores.
+threshold = 1e-6      # Result values below this will be set to 0.0
+log_dhw_tols = true   # Log per-location coral DHW tolerance trajectories
 
 [results]
 output_dir = "./outputs"  # save to current working directory

--- a/test/domain.jl
+++ b/test/domain.jl
@@ -15,7 +15,6 @@ end
 
         # Ensure environment variables are set
         @test haskey(ENV, "ADRIA_OUTPUT_DIR")
-        @test haskey(ENV, "ADRIA_NUM_CORES")
         @test haskey(ENV, "ADRIA_THRESHOLD")
     end
 


### PR DESCRIPTION
## Summary

This PR included a major refactor of the parallel scenario runner, a fix for a threading data race that caused silent result corruption, several coral growth model corrections, and performance improvements.

### Parallel runner: Distributed → Julia threads

- Replaced `Distributed`/`pmap` with `Threads.@threads` in `run_scenarios`, removing
  the `ADRIA_NUM_CORES` / `_setup_workers()` infrastructure entirely
- Removed `remove_workers` keyword argument from `run_scenarios` (no longer relevant)
- Results are now written via a dedicated writer task receiving from a `Channel`, with
  Zarr chunk sizes aligned to the effective batch size for I/O efficiency

### Coral growth model corrections

- Fix double-subtraction and units error in leftover-space accounting
- Fix `a_adapt` tolerance compounding across seeding years
- Fix undeployed functional groups receiving heat-stress improvement
- Fix DHW stored in `bleach_dhw` cache (was storing mortality fraction instead)
- Fix mix weights and lower bound in `update_tolerance_distribution!`
- Fix `settler_DHW_tolerance!` using `findall` instead of `1:count`
- Fix axis permutation when writing `coral_dhw_tol_log`
- Cap heat tolerance gain to +8 DHW from initial mean
- Update `cover_transition_ub` to 0.8; change `HEAT_LB`; make growth scale factor
  vary continuously

### Performance

- Pre-compute `LinearExtensionCache` once per `run_model` call instead of per timestep
- Align Zarr chunk sizes with effective batch size in `combine_results`

### Other

- Add `cover_log` (per-species, non-aggregated coral cover) and `dhw_tol_mean_log`
  to the result cache
- Add `set_depth_med!` to `Domain`
- Allow setting RNG seed via config file; default `ADRIA_RNG_SEED` to `false` when unset
- Fall back to indegree centrality when eigenvector centrality fails
- Fix RME domain DHW spatial dimension name
- Rename `intervention` result axis to `interventions`
- Viz: support plotting scenario results without a `ResultSet`
- Update CoralBlox to v1.1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)