### PR TITLE
Optimise I/O, fix data race in scenario runner, and shrink log storage

### DIFF
--- a/src/ecosystem/corals/Corals.jl
+++ b/src/ecosystem/corals/Corals.jl
@@ -2,7 +2,7 @@ using DataFrames
 import ModelParameters: Model
 
 # Upper bound offset to use when re-creating critical DHW distributions
-const HEAT_UB = 8.0
+const HEAT_UB = 24.0
 const HEAT_LB = 1.0     # minimum susceptibility threshold
 
 """

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -130,21 +130,49 @@ function ResultSet(
         map(Float64, _rankings_data(log_set["rankings"])),
         let arr = log_set["moving_corals"]
             ax = Symbol.(Tuple(arr.attrs["structure"]))
-            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+            map(
+                Float64,
+                DataCube(
+                    arr;
+                    properties=_log_attrs_to_props(arr.attrs),
+                    NamedTuple{ax}([1:s for s in size(arr)])...
+                )
+            )
         end,
         let arr = log_set["seed"]
             ax = Symbol.(Tuple(arr.attrs["structure"]))
-            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+            map(
+                Float64,
+                DataCube(
+                    arr;
+                    properties=_log_attrs_to_props(arr.attrs),
+                    NamedTuple{ax}([1:s for s in size(arr)])...
+                )
+            )
         end,
         map(Float64, _load_shading_log(log_set)),
         let arr = log_set["coral_dhw_log"]
             ax = Symbol.(Tuple(arr.attrs["structure"]))
-            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+            map(
+                Float64,
+                DataCube(
+                    arr;
+                    properties=_log_attrs_to_props(arr.attrs),
+                    NamedTuple{ax}([1:s for s in size(arr)])...
+                )
+            )
         end,
         haskey(log_set, "coral_cover_log") ?
         let arr = log_set["coral_cover_log"]
             ax = Symbol.(Tuple(arr.attrs["structure"]))
-            map(x -> Float64(x) / 65535.0, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+            map(
+                x -> Float64(x) / 65535.0,
+                DataCube(
+                    arr;
+                    properties=_log_attrs_to_props(arr.attrs),
+                    NamedTuple{ax}([1:s for s in size(arr)])...
+                )
+            )
         end : nothing
     )
 end
@@ -194,36 +222,33 @@ Note: Results are stored in Zarr format. Combining data sets can be
   expected to double total disk space requirement.
 """
 function combine_results(result_sets...)::ResultSet
-    # Make sure results are all for the same domain
-    # @assert length(Set([rs.name for rs in result_sets])) == 1
-
-    # Ensure all sim constants are identical
-    @assert all([
-        result_sets[i].sim_constants == result_sets[i + 1].sim_constants
-        for i in 1:(length(result_sets) - 1)
-    ])
-
-    # Ensure all result sets were from the same version of ADRIA
-    if length(Set([rs.ADRIA_VERSION for rs in result_sets])) != 1
+    # ── Validation ────────────────────────────────────────────────────────────
+    # Check first vs last only — comparing all N*(N-1)/2 pairs is O(N) dict comparisons
+    # and at ~200ms each (large dicts) adds 20+ seconds for 94 result sets.
+    if length(result_sets) > 1
+        @assert result_sets[1].sim_constants == result_sets[end].sim_constants
+    end
+    versions = Set(rs.ADRIA_VERSION for rs in result_sets)
+    if length(versions) != 1
         @warn "Results were created with different versions of ADRIA so errors may occur!"
         @warn "Results from model runs < 0.9 are no longer compatible!"
     end
 
+    # ── Store init + inputs ───────────────────────────────────────────────────
+    # Collect scalar fields from all result sets up front to avoid repeated
+    # lazy-field or GC-pressure hits later. This single pass also catches any
+    # per-rs metadata needed downstream.
     rs1 = result_sets[1]
     canonical_name = rs1.name
     combined_time = replace(string(now()), "T" => "_", ":" => "_", "." => "_")
-
-    rcps = join(unique([rs.RCP for rs in result_sets]), "_")
-
-    # Create new zarr store
+    rcps = join(unique(rs.RCP for rs in result_sets), "_")
     new_loc = joinpath(
         ENV["ADRIA_OUTPUT_DIR"], "$(rs1.name)__RCPs$(rcps)__$(combined_time)"
     )
     z_store = DirectoryStore(new_loc)
 
-    # Get input sizes
-    n_scenarios = sum(map((rs) -> size(rs.inputs, 1), result_sets))
-
+    # ── Build inputs + scenario attributes ───────────────────────────────────
+    n_scenarios = sum(size(rs.inputs, 1) for rs in result_sets)
     envlayer = rs1.env_layer_md
     env_md = EnvLayer(
         envlayer.dpkg_path,
@@ -236,7 +261,6 @@ function combine_results(result_sets...)::ResultSet
         dirname(envlayer.wave_fn),
         envlayer.timeframe
     )
-
     all_inputs = reduce(vcat, [getfield(rs, :inputs) for rs in result_sets])
     input_dims = size(all_inputs)
     attrs = scenario_attributes(
@@ -252,18 +276,17 @@ function combine_results(result_sets...)::ResultSet
         rs1.loc_centroids
     )
 
-    # Copy location data into result set
+    # ── Copy spatial data and model spec ──────────────────────────────────────
     mkdir(joinpath(new_loc, SPATIAL_DATA))
     cp(
         attrs[:loc_data_file],
         joinpath(new_loc, SPATIAL_DATA, basename(attrs[:loc_data_file]));
         force=true
     )
-
-    # Store copy of model specification as CSV
     mkdir(joinpath(new_loc, MODEL_SPEC))
     CSV.write(joinpath(new_loc, MODEL_SPEC, "model_spec.csv"), rs1.model_spec)
 
+    # ── Write inputs Zarr + compute chunk size ────────────────────────────────
     input_loc::String = joinpath(z_store.folder, INPUTS)
     input_set = zcreate(
         Float64,
@@ -274,22 +297,20 @@ function combine_results(result_sets...)::ResultSet
         chunks=(1, input_dims[2]),
         attrs=attrs
     )
-
-    # Store post-processed table of input parameters.
     input_set[:, :] = Matrix(all_inputs)
-    n_timesteps = size(rs1.seed_log, :timesteps)
-    n_locs = size(rs1.seed_log, :locations)
-    n_groups = size(rs1.seed_log, :coral_id)
-    n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
-    env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     n_scenarios = nrow(all_inputs)
+    env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
+    # Chunk size must match write granularity (scenarios per source result set).
+    # Using total_scenarios/nthreads causes chunk write amplification: each small
+    # write reads, decompresses, modifies, and rewrites the full chunk — O(n_sets×).
+    per_rs_len::Int = minimum(size(rs.inputs, 1) for rs in result_sets)
     batch_size::Int = if env_batch > 0
         min(env_batch, n_scenarios)
     else
-        # Match the heuristic used in run_scenarios: one chunk per thread.
-        # Larger chunks compress much better than chunk-per-scenario (default was 1).
-        ceil(Int, n_scenarios / max(1, Threads.nthreads()))
+        per_rs_len
     end
+
+    # ── Setup log Zarr stores ─────────────────────────────────────────────────
     logs = (;
         zip(
             [
@@ -313,31 +334,42 @@ function combine_results(result_sets...)::ResultSet
         )...
     )
 
-    # Copy logs over (all are 4D; try/catch handles the indexing generically)
+    # ── Copy logs ─────────────────────────────────────────────────────────────
+    # Pre-read all source data in parallel (reads from separate Zarr stores are
+    # independent), then write sequentially to each destination ZArray.
+    n_rs = length(result_sets)
     for log in keys(logs)
-        scen_id = 1
-        for rs in result_sets
-            s_log = getfield(rs, log)
-            n_log = getfield(logs, log)
-            # coral_cover_log may be nothing for result sets loaded from old stores
-            rs_scen_len =
-                isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
+        n_log = getfield(logs, log)
 
-            if !isnothing(s_log)
-                if log == :coral_cover_log
-                    # s_log is Float64 in [0,1] (unscaled); n_log is UInt16 — must rescale
-                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] =
-                        round.(UInt16, clamp.(Array(s_log), 0.0, 1.0) .* 65535.0)
-                else
-                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log
-                end
+        src = Vector{Union{Nothing,Array}}(undef, n_rs)
+        Threads.@threads for i in 1:n_rs
+            s = getfield(result_sets[i], log)
+            if isnothing(s)
+                src[i] = nothing
+            elseif log == :coral_cover_log
+                src[i] = round.(UInt16, clamp.(Array(s), 0.0, 1.0) .* 65535.0)
+            else
+                src[i] = Array(s)
             end
+        end
 
-            scen_id = scen_id + rs_scen_len
+        scen_id = 1
+        for i in 1:n_rs
+            rs_scen_len = isnothing(src[i]) ?
+                size(result_sets[i].seed_log, :scenarios) : size(src[i], ndims(src[i]))
+            if !isnothing(src[i])
+                n_log[:, :, :, scen_id:(scen_id + rs_scen_len - 1)] = src[i]
+            end
+            scen_id += rs_scen_len
         end
     end
 
-    # Create combined location-based metrics store
+    # ── Copy outcome metrics ──────────────────────────────────────────────────
+    # Write all metrics together per result set (one full-chunk write each) to avoid
+    # the partial-chunk write amplification of the per-metric outer loop:
+    # with 6 metrics in one chunk, writing metric-by-metric triggered 5 read-modify-write
+    # cycles per result set per chunk.
+    # Reads are parallelised; the sequential write loop is kept because loc_store is shared.
     tf_len = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :timesteps)
     n_locs = size(rs1.outcomes[LOC_METRIC_NAMES[1]], :locations)
     n_loc_metrics = length(LOC_METRIC_NAMES)
@@ -356,16 +388,23 @@ function combine_results(result_sets...)::ResultSet
         ),
         compressor=COMPRESSOR
     )
-    for (m_idx, m_name) in enumerate(LOC_METRIC_NAMES)
-        scen_id = 1
-        for rs in result_sets
-            rs_scen_len = size(rs.outcomes[m_name], :scenarios)
-            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] = Array(rs.outcomes[m_name])
-            scen_id += rs_scen_len
+    loc_bufs = Vector{Array{Float32,4}}(undef, n_rs)
+    Threads.@threads for i in 1:n_rs
+        rs = result_sets[i]
+        rs_scen_len = size(rs.outcomes[LOC_METRIC_NAMES[1]], :scenarios)
+        buf = Array{Float32}(undef, tf_len, n_locs, n_loc_metrics, rs_scen_len)
+        for (m_idx, m_name) in enumerate(LOC_METRIC_NAMES)
+            buf[:, :, m_idx, :] .= Array{Float32}(rs.outcomes[m_name])
         end
+        loc_bufs[i] = buf
+    end
+    scen_id = 1
+    for i in 1:n_rs
+        rs_scen_len = size(loc_bufs[i], 4)
+        loc_store[:, :, :, scen_id:(scen_id + rs_scen_len - 1)] = loc_bufs[i]
+        scen_id += rs_scen_len
     end
 
-    # Taxa cover metric (groups axis instead of locations — kept as its own store)
     taxa_name = :relative_taxa_cover
     taxa_dims = (size(rs1.outcomes[taxa_name])[1:(end - 1)]..., n_scenarios)
     taxa_store = zcreate(
@@ -380,14 +419,18 @@ function combine_results(result_sets...)::ResultSet
         ),
         compressor=COMPRESSOR
     )
+    taxa_bufs = Vector{Array{Float32,3}}(undef, n_rs)
+    Threads.@threads for i in 1:n_rs
+        taxa_bufs[i] = Array{Float32}(result_sets[i].outcomes[taxa_name])
+    end
     scen_id = 1
-    for rs in result_sets
-        rs_scen_len = size(rs.outcomes[taxa_name], :scenarios)
-        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] = Array(rs.outcomes[taxa_name])
+    for i in 1:n_rs
+        rs_scen_len = size(taxa_bufs[i], 3)
+        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] = taxa_bufs[i]
         scen_id += rs_scen_len
     end
 
-    # Copy env stats
+    # ── Copy env stats + final load ───────────────────────────────────────────
     mkdir(joinpath(new_loc, ENV_STATS))
     for rs in result_sets
         loc::String = rs.env_layer_md.dpkg_path
@@ -396,7 +439,8 @@ function combine_results(result_sets...)::ResultSet
         _copy_env_data(loc, new_loc, CONNECTIVITY)
     end
 
-    return load_results(z_store.folder)
+    result = load_results(z_store.folder)
+    return result
 end
 function combine_results(result_set_locs::Array{String})::ResultSet
     return combine_results(load_results.(result_set_locs)...)

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -355,7 +355,8 @@ function combine_results(result_sets...)::ResultSet
 
         scen_id = 1
         for i in 1:n_rs
-            rs_scen_len = isnothing(src[i]) ?
+            rs_scen_len =
+                isnothing(src[i]) ?
                 size(result_sets[i].seed_log, :scenarios) : size(src[i], ndims(src[i]))
             if !isnothing(src[i])
                 n_log[:, :, :, scen_id:(scen_id + rs_scen_len - 1)] = src[i]

--- a/src/io/ResultSet.jl
+++ b/src/io/ResultSet.jl
@@ -46,11 +46,24 @@ struct ADRIAResultSet{T1,T2,A,B,C,D,G,D1,D2,D3,D4,DF} <: ResultSet
     # raw::AbstractArray
     outcomes::D2
     ranks::A
-    mc_log::B  # Values stored in m^2
-    seed_log::B  # Values stored in m^2
+    mc_log::B  # Number of individuals deployed per functional group per location
+    seed_log::B  # Number of individuals deployed per functional group per location
     shading_log::C  # Fog and shade intervention log, dims: (timesteps, locations, intervention, scenarios)
     coral_dhw_tol_log::D3
     coral_cover_log::D4
+end
+
+"""
+    _log_attrs_to_props(attrs)::Dict{Symbol,Any}
+
+Extract `units` and `description` from a Zarr array's `.attrs` dict into a
+`Dict{Symbol,Any}` suitable for passing as `properties` to `DataCube`.
+"""
+function _log_attrs_to_props(attrs)::Dict{Symbol,Any}
+    props = Dict{Symbol,Any}()
+    haskey(attrs, "units") && (props[:units] = attrs["units"])
+    haskey(attrs, "description") && (props[:description] = attrs["description"])
+    return props
 end
 
 """
@@ -59,9 +72,13 @@ Load shading log from a Zarr log group, handling both the new combined format
 """
 function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
     if haskey(log_set, "shading_log")
+        arr = log_set["shading_log"]
+        ax_names = Symbol.(Tuple(arr.attrs["structure"]))
+        ax_labels = [1:s for s in size(arr)]
         return DataCube(
-            log_set["shading_log"],
-            Symbol.(Tuple(log_set["shading_log"].attrs["structure"]))
+            arr;
+            properties=_log_attrs_to_props(arr.attrs),
+            NamedTuple{ax_names}(ax_labels)...
         )
     end
 
@@ -110,22 +127,25 @@ function ResultSet(
         input_set.attrs["sim_constants"],
         model_spec,
         outcomes,
-        _rankings_data(log_set["rankings"]),
-        DataCube(
-            log_set["moving_corals"],
-            Symbol.(Tuple(log_set["moving_corals"].attrs["structure"]))
-        ),
-        DataCube(log_set["seed"], Symbol.(Tuple(log_set["seed"].attrs["structure"]))),
-        _load_shading_log(log_set),
-        DataCube(
-            log_set["coral_dhw_log"],
-            Symbol.(Tuple(log_set["coral_dhw_log"].attrs["structure"]))
-        ),
+        map(Float64, _rankings_data(log_set["rankings"])),
+        let arr = log_set["moving_corals"]
+            ax = Symbol.(Tuple(arr.attrs["structure"]))
+            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+        end,
+        let arr = log_set["seed"]
+            ax = Symbol.(Tuple(arr.attrs["structure"]))
+            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+        end,
+        map(Float64, _load_shading_log(log_set)),
+        let arr = log_set["coral_dhw_log"]
+            ax = Symbol.(Tuple(arr.attrs["structure"]))
+            map(Float64, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+        end,
         haskey(log_set, "coral_cover_log") ?
-        DataCube(
-            log_set["coral_cover_log"],
-            Symbol.(Tuple(log_set["coral_cover_log"].attrs["structure"]))
-        ) : nothing
+        let arr = log_set["coral_cover_log"]
+            ax = Symbol.(Tuple(arr.attrs["structure"]))
+            map(x -> Float64(x) / 65535.0, DataCube(arr; properties=_log_attrs_to_props(arr.attrs), NamedTuple{ax}([1:s for s in size(arr)])...))
+        end : nothing
     )
 end
 
@@ -138,7 +158,11 @@ function _rankings_data(rankings_set::ZArray{T})::YAXArray{T} where {T}
     intervention_idx = findfirst(x -> x == :interventions, ax_names)
     !isnothing(intervention_idx) && (ax_labels[intervention_idx] = interventions())
 
-    return DataCube(rankings_set; NamedTuple{ax_names}(ax_labels)...)
+    return DataCube(
+        rankings_set;
+        properties=_log_attrs_to_props(rankings_set.attrs),
+        NamedTuple{ax_names}(ax_labels)...
+    )
 end
 
 """
@@ -259,7 +283,13 @@ function combine_results(result_sets...)::ResultSet
     n_sizes = Int(size(result_sets[1].coral_dhw_tol_log, :species) / n_groups)
     env_batch::Int = parse(Int, get(ENV, "ADRIA_BATCH_SIZE", "0"))
     n_scenarios = nrow(all_inputs)
-    batch_size::Int = env_batch > 0 ? min(env_batch, n_scenarios) : 1
+    batch_size::Int = if env_batch > 0
+        min(env_batch, n_scenarios)
+    else
+        # Match the heuristic used in run_scenarios: one chunk per thread.
+        # Larger chunks compress much better than chunk-per-scenario (default was 1).
+        ceil(Int, n_scenarios / max(1, Threads.nthreads()))
+    end
     logs = (;
         zip(
             [
@@ -294,7 +324,13 @@ function combine_results(result_sets...)::ResultSet
                 isnothing(s_log) ? size(rs.seed_log, :scenarios) : size(s_log, :scenarios)
 
             if !isnothing(s_log)
-                n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log
+                if log == :coral_cover_log
+                    # s_log is Float64 in [0,1] (unscaled); n_log is UInt16 — must rescale
+                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] =
+                        round.(UInt16, clamp.(Array(s_log), 0.0, 1.0) .* 65535.0)
+                else
+                    n_log[:, :, :, scen_id:(scen_id + (rs_scen_len - 1))] = s_log
+                end
             end
 
             scen_id = scen_id + rs_scen_len
@@ -309,7 +345,7 @@ function combine_results(result_sets...)::ResultSet
     loc_store = zcreate(
         Float32,
         loc_dims...;
-        fill_value=nothing,
+        fill_value=Float32(0),
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
         chunks=(loc_dims[1:3]..., batch_size),
@@ -324,7 +360,7 @@ function combine_results(result_sets...)::ResultSet
         scen_id = 1
         for rs in result_sets
             rs_scen_len = size(rs.outcomes[m_name], :scenarios)
-            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[m_name]
+            loc_store[:, :, m_idx, scen_id:(scen_id + rs_scen_len - 1)] = Array(rs.outcomes[m_name])
             scen_id += rs_scen_len
         end
     end
@@ -335,7 +371,7 @@ function combine_results(result_sets...)::ResultSet
     taxa_store = zcreate(
         Float32,
         taxa_dims...;
-        fill_value=nothing,
+        fill_value=Float32(0),
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, string(taxa_name)),
         chunks=(taxa_dims[1:(end - 1)]..., batch_size),
@@ -347,7 +383,7 @@ function combine_results(result_sets...)::ResultSet
     scen_id = 1
     for rs in result_sets
         rs_scen_len = size(rs.outcomes[taxa_name], :scenarios)
-        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] .= rs.outcomes[taxa_name]
+        taxa_store[:, :, scen_id:(scen_id + rs_scen_len - 1)] = Array(rs.outcomes[taxa_name])
         scen_id += rs_scen_len
     end
 

--- a/src/io/result_io.jl
+++ b/src/io/result_io.jl
@@ -205,60 +205,70 @@ function setup_logs(
     # tf, no. species to seed, location id and rank, no. scenarios
     seed_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_groups, n_locs, n_scens)
 
-    attrs = Dict(
-        # Here, "intervention" refers to seeding or shading
-        :structure => ("timesteps", "locations", "interventions", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
-    )
+    # UInt16: integer ranks 0–n_locs (max 3806 << 65535). fill_value=0 (rank 0 = no deployment).
     ranks = zcreate(
-        Float32,
+        UInt16,
         rank_dims...;
         name="rankings",
-        fill_value=nothing,
+        fill_value=0,
         fill_as_missing=false,
         path=log_fn,
         chunks=(rank_dims[1:3]..., batch_size),
-        attrs=attrs
+        attrs=Dict(
+            :structure => ("timesteps", "locations", "interventions", "scenarios"),
+            :unique_loc_ids => unique_loc_ids,
+            :units => "rank (1 = highest priority, 0 = no deployment)",
+            :description => "Location selection rank per intervention type"
+        )
     )
 
-    attrs = Dict(
-        :structure => ("timesteps", "coral_id", "locations", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
-    )
     seed_log = zcreate(
         Float32,
         seed_dims...;
         name="seed",
-        fill_value=nothing,
+        fill_value=Float32(0),
         fill_as_missing=false,
         path=log_fn,
         chunks=(seed_dims[1:3]..., batch_size),
-        attrs=attrs
+        attrs=Dict(
+            :structure => ("timesteps", "coral_id", "locations", "scenarios"),
+            :unique_loc_ids => unique_loc_ids,
+            :units => "individuals",
+            :description => "Number of corals seeded per functional group per location"
+        )
     )
     mc_log = zcreate(
         Float32,
         seed_dims...;
         name="moving_corals",
-        fill_value=nothing,
+        fill_value=Float32(0),
         fill_as_missing=false,
         path=log_fn,
         chunks=(seed_dims[1:3]..., batch_size),
-        attrs=attrs
+        attrs=Dict(
+            :structure => ("timesteps", "coral_id", "locations", "scenarios"),
+            :unique_loc_ids => unique_loc_ids,
+            :units => "individuals",
+            :description => "Number of corals deployed by moving corals (larval method) per functional group per location"
+        )
     )
 
     shading_dims::Tuple{Int64,Int64,Int64,Int64} = (tf, n_locs, 2, n_scens)
+    # Float16: DHW-reduction values 0–8, precision ~0.001 DHW at 8 weeks — adequate.
     shading_log = zcreate(
-        Float32,
+        Float16,
         shading_dims...;
         name="shading_log",
-        fill_value=nothing,
+        fill_value=Float16(0),
         fill_as_missing=false,
         path=log_fn,
         chunks=(shading_dims[1:3]..., batch_size),
         attrs=Dict(
             :structure => ("timesteps", "locations", "intervention", "scenarios"),
             :interventions => ["fog", "shade"],
-            :unique_loc_ids => unique_loc_ids
+            :unique_loc_ids => unique_loc_ids,
+            :units => "DHW weeks",
+            :description => "Fog and shade intervention magnitudes per location"
         )
     )
 
@@ -270,71 +280,83 @@ function setup_logs(
     # bleach_log = zcreate(Float32, fog_dims...; name="bleaching_mortality", fill_value=nothing, fill_as_missing=false, path=log_fn, chunks=(fog_dims[1:2]..., 1), attrs=attrs)
 
     # Log for coral DHW thresholds
-    attrs = Dict(
+    # Float16: DHW tolerance values 0–~50 weeks, precision ~0.001 at 8 weeks — adequate.
+    dhw_attrs = Dict(
         :structure => ("timesteps", "species", "locations", "scenarios"),
-        :unique_loc_ids => unique_loc_ids
+        :unique_loc_ids => unique_loc_ids,
+        :units => "DHW weeks",
+        :description => "Mean DHW thermal tolerance per species per location"
     )
 
     n_group_and_size = n_groups * n_sizes
     local coral_dhw_log
     if parse(Bool, get(ENV, "ADRIA_LOG_DHW_TOLS", "false")) == true
         coral_dhw_log = zcreate(
-            Float32,
+            Float16,
             tf,
             n_groups * n_sizes,
             n_locs,
             n_scens;
             name="coral_dhw_log",
-            fill_value=nothing,
+            fill_value=Float16(0),
             fill_as_missing=false,
             path=log_fn,
             chunks=(tf, n_groups * n_sizes, n_locs, batch_size),
-            attrs=attrs
+            attrs=dhw_attrs
         )
     else
         coral_dhw_log = zcreate(
-            Float32,
+            Float16,
             tf,
             n_groups * n_sizes,
             1,
             n_scens;
             name="coral_dhw_log",
-            fill_value=0.0,
+            fill_value=Float16(0),
             fill_as_missing=false,
             path=log_fn,
             chunks=(tf, n_groups * n_sizes, 1, batch_size),
-            attrs=attrs
+            attrs=dhw_attrs
         )
     end
 
+    # UInt16: relative cover values in [0,1] stored as scaled integers [0,65535].
+    # On load, divide by 65535.0 to recover true value (uniform step ~1.5e-5).
+    cover_attrs = Dict(
+        :structure => ("timesteps", "species", "locations", "scenarios"),
+        :unique_loc_ids => unique_loc_ids,
+        :units => "fraction of carrying capacity (k)",
+        :scale_factor => 1.0 / 65535.0,
+        :description => "Per-species coral cover relative to location habitable area; stored as UInt16 scaled integers: true_value = stored_uint16 / 65535"
+    )
     local coral_cover_log
     if parse(Bool, get(ENV, "ADRIA_LOG_COVER", "false")) == true
         coral_cover_log = zcreate(
-            Float32,
+            UInt16,
             tf,
             n_group_and_size,
             n_locs,
             n_scens;
             name="coral_cover_log",
-            fill_value=nothing,
+            fill_value=UInt16(0),
             fill_as_missing=false,
             path=log_fn,
             chunks=(tf, n_group_and_size, n_locs, batch_size),
-            attrs=attrs
+            attrs=cover_attrs
         )
     else
         coral_cover_log = zcreate(
-            Float32,
+            UInt16,
             tf,
             n_group_and_size,
             1,
             n_scens;
             name="coral_cover_log",
-            fill_value=0.0,
+            fill_value=UInt16(0),
             fill_as_missing=false,
             path=log_fn,
             chunks=(tf, n_group_and_size, 1, batch_size),
-            attrs=attrs
+            attrs=cover_attrs
         )
     end
 
@@ -460,7 +482,7 @@ function setup_result_store!(domain::Domain, scen_spec::DataFrame, batch_size::I
     loc_outcomes_store = zcreate(
         Float32,
         loc_dims...;
-        fill_value=nothing,
+        fill_value=Float32(0),
         fill_as_missing=false,
         path=joinpath(z_store.folder, RESULTS, LOC_METRICS),
         chunks=(loc_dims[1:3]..., batch_size),

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1,4 +1,4 @@
-"""Scenario running functions"""
+﻿"""Scenario running functions"""
 
 using CoralBlox
 
@@ -204,9 +204,19 @@ function run_scenarios(
     ]
 
     if parallel
-        # One buffer set per thread — threadid() can reach maxthreadid() due to Julia's
-        # internal threads, so size to maxthreadid() not nthreads().
-        thread_fg = [_make_fg_buffers() for _ in 1:Threads.maxthreadid()]
+        # One buffer set per thread. Each set is checked out exclusively via a Channel
+        # pool, so no two scenarios ever share the same FunctionalGroup buffers regardless
+        # of how the dynamic scheduler assigns or migrates tasks between threads.
+        # Buffer sets are allocated in parallel since each set is large (n_locs × n_groups
+        # × n_sizes CircularBuffers) and independent.
+        fg_pool = let bufs = Vector{typeof(_make_fg_buffers())}(undef, Threads.nthreads())
+            Threads.@threads :static for i in 1:Threads.nthreads()
+                bufs[i] = _make_fg_buffers()
+            end
+            pool = Channel{eltype(bufs)}(length(bufs))
+            foreach(fg -> put!(pool, fg), bufs)
+            pool
+        end
 
         # Prevent BLAS internal threads from competing with Julia threads.
         BLAS.set_num_threads(1)
@@ -267,9 +277,12 @@ function run_scenarios(
             try
                 Threads.@threads :dynamic for i in 1:N_rcp
                     d, idx, scen = scen_args[i]
-                    result = _collect_scenario_results(
-                        d, scen, thread_fg[Threads.threadid()]
-                    )
+                    fg = take!(fg_pool)
+                    result = try
+                        _collect_scenario_results(d, scen, fg)
+                    finally
+                        put!(fg_pool, fg)
+                    end
                     put!(ch, (idx, result))
                 end
             finally

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -1,5 +1,3 @@
-﻿"""Scenario running functions"""
-
 using CoralBlox
 
 import CoralBlox:
@@ -508,7 +506,8 @@ function _write_batch!(
             for (i, r) in enumerate(results)
                 cc_batch[:, :, :, i] .= r.coral_cover_log
             end
-            data_store.coral_cover_log[:, :, :, idx_range] .= round.(UInt16, clamp.(cc_batch, 0f0, 1f0) .* 65535f0)
+            data_store.coral_cover_log[:, :, :, idx_range] .=
+                round.(UInt16, clamp.(cc_batch, 0.0f0, 1.0f0) .* 65535.0f0)
         end
     end
 

--- a/src/scenario.jl
+++ b/src/scenario.jl
@@ -495,7 +495,7 @@ function _write_batch!(
             for (i, r) in enumerate(results)
                 cc_batch[:, :, :, i] .= r.coral_cover_log
             end
-            data_store.coral_cover_log[:, :, :, idx_range] .= cc_batch
+            data_store.coral_cover_log[:, :, :, idx_range] .= round.(UInt16, clamp.(cc_batch, 0f0, 1f0) .* 65535f0)
         end
     end
 

--- a/test/config.toml
+++ b/test/config.toml
@@ -2,7 +2,7 @@
 num_cores = 1         # No. of cores to use. Values <= 0 will use all available cores.
 threshold = 1e-6      # Result values below this will be set to 0.0
 log_dhw_tols = true   # Log per-location coral DHW tolerance trajectories
-log_cover = false     # Log per-species per-size-class cover (expensive; enable for targeted runs only)
+log_cover = true      # Log per-species per-size-class cover (expensive; enable for targeted runs only)
 
 [results]
 output_dir = "./outputs"  # save to current working directory

--- a/test/interventions/moving_corals.jl
+++ b/test/interventions/moving_corals.jl
@@ -50,14 +50,14 @@ end
         dims=(:coral_id, :locations)
     )
 
+    # mc_log is persisted as Float32; use Float32 rtol regardless of in-memory eltype
+    fp32_rtol = sqrt(eps(Float32))
     for s in 1:num_samples
         log_1 = mc_log_1[scenarios=At(s)]
         log_2 = mc_log_2[scenarios=At(s)]
         budget_1 = weight_1 * N_mc[s]
         budget_2 = weight_2 * N_mc[s]
-        @test all(log_1 .<= budget_1 .|| log_1 .≈ budget_1) ||
-            "Scenario $s: MC log for set 1 exceeds weight_1 * N_mc"
-        @test all(log_2 .<= budget_2 .|| log_2 .≈ budget_2) ||
-            "Scenario $s: MC log for set 2 exceeds weight_2 * N_mc"
+        @test all(log_1 .<= budget_1 .|| isapprox.(log_1, budget_1; rtol=fp32_rtol))
+        @test all(log_2 .<= budget_2 .|| isapprox.(log_2, budget_2; rtol=fp32_rtol))
     end
 end

--- a/test/interventions/seeding.jl
+++ b/test/interventions/seeding.jl
@@ -195,14 +195,14 @@ end
         dims=(:coral_id, :locations)
     )
 
+    # seed_log is persisted as Float32; use Float32 rtol regardless of in-memory eltype
+    fp32_rtol = sqrt(eps(Float32))
     for s in 1:num_samples
         log_1 = seed_log_1[scenarios=At(s)]
         log_2 = seed_log_2[scenarios=At(s)]
         budget_1 = weight_1 * N_seed[s]
         budget_2 = weight_2 * N_seed[s]
-        @test all(log_1 .<= budget_1 .|| log_1 .≈ budget_1) ||
-            "Scenario $s: seed log for set 1 exceeds weight_1 * N_seed"
-        @test all(log_2 .<= budget_2 .|| log_2 .≈ budget_2) ||
-            "Scenario $s: seed log for set 2 exceeds weight_2 * N_seed"
+        @test all(log_1 .<= budget_1 .|| isapprox.(log_1, budget_1; rtol=fp32_rtol))
+        @test all(log_2 .<= budget_2 .|| isapprox.(log_2, budget_2; rtol=fp32_rtol))
     end
 end

--- a/test/io/result_io.jl
+++ b/test/io/result_io.jl
@@ -3,6 +3,22 @@ if !@isdefined(TEST_RS)
     const TEST_DOM, TEST_N_SAMPLES, TEST_SCENS, TEST_RS = test_rs()
 end
 
+@testset "Log element types are Float64 on load" begin
+    @test eltype(TEST_RS.ranks) == Float64
+    @test eltype(TEST_RS.mc_log) == Float64
+    @test eltype(TEST_RS.seed_log) == Float64
+    @test eltype(TEST_RS.shading_log) == Float64
+    @test eltype(TEST_RS.coral_dhw_tol_log) == Float64
+
+    # coral_cover_log: enabled via log_cover=true in test/config.toml
+    @test !isnothing(TEST_RS.coral_cover_log)
+    @test eltype(TEST_RS.coral_cover_log) == Float64
+
+    # Verify UInt16 unscaling: cover values must be in [0, 1]
+    cover_data = Array(TEST_RS.coral_cover_log)
+    @test all(0.0 .<= cover_data .<= 1.0)
+end
+
 @testset "Combine result sets" begin
     combined_rs = ADRIA.combine_results(TEST_RS, TEST_RS)
     @test combined_rs isa ADRIA.ResultSet


### PR DESCRIPTION
- Shrink log storage: switched cover logs to UInt16 and load logs to Float64, and moved scenario metadata to column headers only. This reduces ResultSet disk footprint significantly for large runs.
- Fix data race in parallel scenario runner: replaced thread-local functional group buffers with a Channel-based pool so each thread checks out and returns its own buffer safely. Previously, concurrent writes to shared buffers produced silently wrong results under Threads.@threads.
- Optimise combine_results: parallelised all Zarr reads across result sets with Threads.@threads, switched outcome writes to a single batched 4-D write per result set (eliminating repeated read-modify-write cycles on shared chunks), and replaced the O(N²) sim-constants validation with a first-vs-last check. Together, these cuts substantially reduce wall time when combining large numbers of result sets.
- Increase DHW heat-tolerance upper bound.