### PR TITLE
 Align intervention `target_location` types in ReefMod domains

### DIFF
--- a/ADRIA/src/ExtInterface/ReefMod/RMEDomain.jl
+++ b/ADRIA/src/ExtInterface/ReefMod/RMEDomain.jl
@@ -40,9 +40,9 @@ mutable struct RMEDomain <: AbstractReefModDomain
     cyclone_mortality_scens::YAXArray{Float64}
 
     # Strategy target locations
-    seed_target_locations::Vector{String}  # locations eligible for seeding
+    seed_target_locations::Vector{@NamedTuple{weight::Float64, target_locs::Vector{String}}}  # locations eligible for seeding
     fog_target_locations::Vector{String}   # locations eligible for fogging
-    mc_target_locations::Vector{String}   # locations eligible for moving corals
+    mc_target_locations::Vector{@NamedTuple{weight::Float64, target_locs::Vector{String}}}  # locations eligible for moving corals
     shade_target_locations::Vector{String}    # locations eligible for shading
 
     model::ModelParameters.Model
@@ -320,9 +320,9 @@ function load_domain(
             dhw_scens,
             wave_scens,
             cyc_scens,
+            [(weight=1.0, target_locs=reef_ids)],
             reef_ids,
-            reef_ids,
-            reef_ids,
+            [(weight=1.0, target_locs=reef_ids)],
             reef_ids,
             model,
             SimConstants()

--- a/ADRIA/src/ExtInterface/ReefMod/ReefModDomain.jl
+++ b/ADRIA/src/ExtInterface/ReefMod/ReefModDomain.jl
@@ -33,10 +33,10 @@ mutable struct ReefModDomain <: AbstractReefModDomain
     cyclone_mortality_scens
 
     # Strategy target locations
-    seed_target_locations::Vector{String}       # locations eligible for seeding
+    seed_target_locations::Vector{@NamedTuple{weight::Float64, target_locs::Vector{String}}}  # locations eligible for seeding
     fog_target_locations::Vector{String}        # locations eligible for fogging
     shade_target_locations::Vector{String}    # locations eligible for shading
-    mc_target_locations::Vector{String}   # locations eligible for moving corals
+    mc_target_locations::Vector{@NamedTuple{weight::Float64, target_locs::Vector{String}}}  # locations eligible for moving corals
 
     model
     sim_constants::SimConstants
@@ -187,10 +187,10 @@ function load_domain(
         dhw_scens,
         wave_scens,
         cyclone_mortality_scens,
+        [(weight=1.0, target_locs=location_ids)],
         location_ids,
         location_ids,
-        location_ids,
-        location_ids,
+        [(weight=1.0, target_locs=location_ids)],
         model,
         SimConstants()
     )

--- a/ADRIA/test/example_run.jl
+++ b/ADRIA/test/example_run.jl
@@ -23,6 +23,29 @@ using ADRIA
         )
         @test typeof(reefmod_dom) <: ADRIA.ReefModDomain
         reefmod_samples = ADRIA.sample(reefmod_dom, n_samples)
+
+        half = length(reefmod_dom.loc_ids) ÷ 2
+        target_locs = reefmod_dom.loc_ids[1:half]
+        ADRIA.set_seed_target_locations!(
+            reefmod_dom,
+            [(weight=TEST_TARGET_WEIGHT_1, target_locs=target_locs),
+                (
+                    weight=TEST_TARGET_WEIGHT_2,
+                    target_locs=reefmod_dom.loc_ids[(half + 1):end]
+                )]
+        )
+        ADRIA.set_mc_target_locations!(
+            reefmod_dom,
+            [(weight=TEST_TARGET_WEIGHT_1, target_locs=target_locs),
+                (
+                    weight=TEST_TARGET_WEIGHT_2,
+                    target_locs=reefmod_dom.loc_ids[(half + 1):end]
+                )]
+        )
+        @test reefmod_dom.seed_target_locations[1].weight == TEST_TARGET_WEIGHT_1
+        @test reefmod_dom.seed_target_locations[2].weight == TEST_TARGET_WEIGHT_2
+        @test reefmod_dom.mc_target_locations[1].weight == TEST_TARGET_WEIGHT_1
+        @test reefmod_dom.mc_target_locations[2].weight == TEST_TARGET_WEIGHT_2
     end
     @testset "RMEDomain run" begin
         rme_dom = ADRIA.load_domain(
@@ -30,6 +53,23 @@ using ADRIA
         )
         @test typeof(rme_dom) <: ADRIA.RMEDomain
         rme_samples = ADRIA.sample(rme_dom, n_samples)
+
+        half = length(rme_dom.loc_ids) ÷ 2
+        target_locs = rme_dom.loc_ids[1:half]
+        ADRIA.set_seed_target_locations!(
+            rme_dom,
+            [(weight=TEST_TARGET_WEIGHT_1, target_locs=target_locs),
+                (weight=TEST_TARGET_WEIGHT_2, target_locs=rme_dom.loc_ids[(half + 1):end])]
+        )
+        ADRIA.set_mc_target_locations!(
+            rme_dom,
+            [(weight=TEST_TARGET_WEIGHT_1, target_locs=target_locs),
+                (weight=TEST_TARGET_WEIGHT_2, target_locs=rme_dom.loc_ids[(half + 1):end])]
+        )
+        @test rme_dom.seed_target_locations[1].weight == TEST_TARGET_WEIGHT_1
+        @test rme_dom.seed_target_locations[2].weight == TEST_TARGET_WEIGHT_2
+        @test rme_dom.mc_target_locations[1].weight == TEST_TARGET_WEIGHT_1
+        @test rme_dom.mc_target_locations[2].weight == TEST_TARGET_WEIGHT_2
 
         rme_dom = ADRIA.load_domain(
             RMEDomain, joinpath(TEST_DATA_DIR, "RME_test_domain"), "45";

--- a/ADRIA/test/interventions/moving_corals.jl
+++ b/ADRIA/test/interventions/moving_corals.jl
@@ -15,8 +15,8 @@ end
     locs_1 = dom.loc_ids[1:half]
     locs_2 = dom.loc_ids[(half + 1):end]
 
-    weight_1 = 0.4
-    weight_2 = 0.6
+    weight_1 = TEST_TARGET_WEIGHT_1
+    weight_2 = TEST_TARGET_WEIGHT_2
 
     ADRIA.set_mc_target_locations!(
         dom, [(weight=weight_1, target_locs=locs_1), (weight=weight_2, target_locs=locs_2)]

--- a/ADRIA/test/interventions/seeding.jl
+++ b/ADRIA/test/interventions/seeding.jl
@@ -154,8 +154,8 @@ end
     locs_1 = dom.loc_ids[1:half]
     locs_2 = dom.loc_ids[(half + 1):end]
 
-    weight_1 = 0.4
-    weight_2 = 0.6
+    weight_1 = TEST_TARGET_WEIGHT_1
+    weight_2 = TEST_TARGET_WEIGHT_2
 
     ADRIA.set_seed_target_locations!(
         dom, [(weight=weight_1, target_locs=locs_1), (weight=weight_2, target_locs=locs_2)]

--- a/ADRIA/test/runtests.jl
+++ b/ADRIA/test/runtests.jl
@@ -6,6 +6,8 @@ using ADRIA: CSV, DataFrames, YAXArrays, YAXArrays.At
 
 ENV["ADRIA_TEST"] = "true"
 
+include("test_constants.jl")
+
 # Helper: abort if a tier recorded any failures or errors.
 # Uses Test.get_test_counts() available in Julia 1.9+.
 function _abort_if_failed(ts, tier_name::String)

--- a/ADRIA/test/test_constants.jl
+++ b/ADRIA/test/test_constants.jl
@@ -1,0 +1,5 @@
+# Shared constants for use across all test files.
+
+# Weights for weighted target-location tests (seed, mc) across all domain types.
+const TEST_TARGET_WEIGHT_1 = 0.4
+const TEST_TARGET_WEIGHT_2 = 0.6


### PR DESCRIPTION
## Summary

- Changes the type of `seed_target_locations` and `mc_target_locations` in `RMEDomain` and `ReefModDomain` from `Vector{String}` to `Vector{@NamedTuple{weight::Float64, target_locs::Vector{String}}}`, matching the existing type used in the base `Domain`.
- Initialises both fields with a single entry at weight `1.0` wrapping all reef IDs on `load_domain`, preserving existing behaviour.
- Extends the `ReefModDomain` and `RMEDomain` example-run tests to verify that `set_seed_target_locations!` / `set_mc_target_locations!` round-trip correctly and that weights are preserved.
- Extracts hardcoded weight literals in intervention tests to shared constants (`TEST_TARGET_WEIGHT_1`, `TEST_TARGET_WEIGHT_2`).

## Test plan

- [x] Existing seeding and moving-corals intervention tests pass with the new type.
- [x] New weighted target-location assertions in `example_run.jl` pass for both `ReefModDomain` and `RMEDomain`.
- [x] `load_domain` for both ReefMod domain types returns domains whose `seed/mc_target_locations` wrap all locations at weight `1.0`.
