### PR TITLE
fix: support dynamic year axis in Plotly backend

### DIFF
--- a/ADRIAviz/ext/ADRIAvizPlotlyExt/helpers.jl
+++ b/ADRIAviz/ext/ADRIAvizPlotlyExt/helpers.jl
@@ -53,8 +53,13 @@ Returns `(tickvals, ticktext)` for a Plotly x-axis. Labels timestep integers
 as calendar years starting from 2025.
 """
 function _year_ticks(x_vals)
-    base_year = 2025
     tickvals = collect(x_vals)
-    ticktext = string.(base_year .+ tickvals .- first(tickvals))
+    if first(tickvals) < 1900
+        @warn "Timesteps do not appear to be calendar years. Defaulting to 2025 base year offset."
+        base_year = 2025
+        ticktext = string.(base_year .+ tickvals .- first(tickvals))
+    else
+        ticktext = string.(tickvals)
+    end
     return tickvals, ticktext
 end


### PR DESCRIPTION
The Plotly backend in ADRIAviz always hardcoded a 2025 base year offset for the x-axis, shifting actual calendar years (like 2015–2100) by 10 years to 2025–2110.

This PR updates `_year_ticks` to check if the axis values are relative timesteps (e.g. 1 to n) or actual calendar years:
- **Relative timesteps (e.g. < 1900):** Default to the 2025 base year offset and issue a warning log.
- **Calendar years (e.g. >= 1900):** Use the dataset's coordinate years directly on the x-axis.

This is an image using PlotlyJS, noting that other x-axis is probably more readable as I am having some difficulties getting wsl to work with backends.

<img width="700" height="500" alt="testing" src="https://github.com/user-attachments/assets/b9ea78b2-58b1-43af-9c2a-266107371278" />
