### PR TITLE
Fixes NaN in Dirichlet sampling

### DIFF
--- a/ADRIA/src/io/sampling/sampling_interface.jl
+++ b/ADRIA/src/io/sampling/sampling_interface.jl
@@ -251,6 +251,7 @@ Taking the quantiles from a Gamma distribution with α:=1 creates a uniform Diri
 Vector of values that sum to 1.
 """
 function gamma_to_dirichlet(p; G=Gamma(1))
+    p = clamp.(p, eps(), prevfloat(1.0))
     gamma_samples = quantile.(G, p)
     return gamma_samples ./ sum(gamma_samples)
 end


### PR DESCRIPTION
Ensures valid probability inputs for the gamma-to-Dirichlet conversion.

This change prevents potential `NaN` values from occurring during scenario sampling by clamping input probabilities to be strictly between `eps()` and `prevfloat(1.0)`, ensuring robust calculations.