### PR TITLE
Fix CI/docs deploy: scoped tag filter and tag_prefix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: '*'
+    tags: 'ADRIA-v*'
   pull_request:
     branches:
       - main

--- a/ADRIA/docs/make.jl
+++ b/ADRIA/docs/make.jl
@@ -87,5 +87,6 @@ deploydocs(;
     repo="github.com/open-AIMS/ADRIA.jl.git",
     devbranch="main",
     target="build",
-    push_preview=false
+    push_preview=false,
+    tag_prefix="ADRIA-"
 )


### PR DESCRIPTION
Two small CI/docs configuration fixes:

- **`.github/workflows/documentation.yml`**: narrow the tag trigger from `tags: '*'` to `tags: 'ADRIA-v*'` so that releases of `ADRIAviz` and `ADRIAanalysis` no longer spuriously re-trigger the ADRIA docs deployment.
- **`ADRIA/docs/make.jl`**: add `tag_prefix="ADRIA-"` to `deploydocs()` so Documenter correctly resolves versioned doc URLs when the monorepo uses package-scoped tags.

No Julia source changes. Safe to merge independently.