### PR TITLE
Add pre-commit config: auto-format with JuliaFormatter v2.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/domluna/JuliaFormatter.jl
+    rev: v2.5.1        # pin to match CI
+    hooks:
+      - id: julia-formatter
+        args: [--check]  # remove --check to auto-fix in-place instead of fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/domluna/JuliaFormatter.jl
-    rev: v2.5.1        # pin to match CI
+    rev: v2.5.1  # pin to match CI (Format.yml)
     hooks:
       - id: julia-formatter
-        args: [--check]  # remove --check to auto-fix in-place instead of fail
+        files: '\.jl$'  # only run on Julia source files

--- a/ADRIA/docs/src/development/development_setup.md
+++ b/ADRIA/docs/src/development/development_setup.md
@@ -218,6 +218,40 @@ format(".")
 Formatter configuration is defined in `.JuliaFormatter.toml`, see
 [JuliaFormatter docs](https://domluna.github.io/JuliaFormatter.jl/stable/).
 
+### With the pre-commit hook (recommended)
+
+The repository ships a `.pre-commit-config.yaml` that automatically formats staged `.jl`
+files before every commit, using the same JuliaFormatter version pinned by CI. This means
+formatting issues are caught locally rather than in a CI review cycle.
+
+!!! note
+    These steps assume Python is available on your system. If not, install it first via
+    [python.org](https://www.python.org/downloads/) or your system package manager.
+
+**One-time setup:**
+
+1. Install [pre-commit](https://pre-commit.com/):
+
+   ```bash
+   pip install pre-commit
+   ```
+
+2. Activate the hook in your local clone:
+
+   ```bash
+   pre-commit install
+   ```
+
+After this, every `git commit` will auto-format any staged Julia files. The first commit
+after installation will be slower (~30 s) while the hook's Julia environment is cached;
+subsequent commits are fast.
+
+To run the formatter manually across all files without committing:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Git blame ignore revs
 
 If you have GitLens (or similar extension), it will show the author of a line of code using git blame.

--- a/ADRIA/docs/src/development/development_setup.md
+++ b/ADRIA/docs/src/development/development_setup.md
@@ -225,8 +225,16 @@ files before every commit, using the same JuliaFormatter version pinned by CI. T
 formatting issues are caught locally rather than in a CI review cycle.
 
 !!! note
-    These steps assume Python is available on your system. If not, install it first via
-    [python.org](https://www.python.org/downloads/) or your system package manager.
+    These steps assume Python is available on your system. If not, the easiest way to get
+    it is via [uv](https://docs.astral.sh/uv/getting-started/installation/) — a fast Python
+    package manager that also manages Python installations:
+
+    ```bash
+    # Install uv, then use it to run pre-commit without a separate pip install
+    uv tool install pre-commit
+    ```
+
+    Skip the `pip install pre-commit` step below if you install via `uv`.
 
 **One-time setup:**
 


### PR DESCRIPTION
Adds a `.pre-commit-config.yaml` using the [`domluna/JuliaFormatter.jl`](https://github.com/domluna/JuliaFormatter.jl) hook, pinned to **v2.5.1** to match the version used by the CI format check in `.github/workflows/Format.yml`.

### Setup (one-time, per contributor)
```sh
pip install pre-commit
pre-commit install
```

On every `git commit`, the hook will auto-format any staged `.jl` files using the project's `.JuliaFormatter.toml` settings before the commit lands. First run downloads the Julia environment (~30 s); subsequent runs are fast.