### PR TITLE
perf(io): switch result compressor from Zstd to Blosc+zstd

### DIFF
--- a/ADRIA/src/io/result_io.jl
+++ b/ADRIA/src/io/result_io.jl
@@ -1,4 +1,4 @@
-const COMPRESSOR = Zarr.ZstdCompressor(; level=6)
+const COMPRESSOR = Zarr.BloscCompressor(; cname="zstd", clevel=5, shuffle=1)
 
 """
     summarize_env_data(data_cube::AbstractArray)


### PR DESCRIPTION
## Summary
- Switches the result-writing compressor from `Zarr.ZstdCompressor` to `Zarr.BloscCompressor(cname="zstd", clevel=5, shuffle=1)` for improved compression throughput/ratio on ADRIA's numeric result arrays via Blosc's shuffle filter.

Unrelated to Issue #1132 — an independent storage perf tweak.

## Test plan
- [ ] Existing result I/O tests pass
- [ ] Spot-check written result set size/throughput against previous Zstd output