### PR TITLE
feat(interventions): widen reactive_absolute_threshold sampling range

### DIFF
--- a/ADRIA/src/interventions/Interventions.jl
+++ b/ADRIA/src/interventions/Interventions.jl
@@ -271,7 +271,7 @@ Base.@kwdef struct Intervention <: EcoModel
         0.95;
         ptype="ordered discrete",
         dist=DiscreteOrderedUniformDist,
-        dist_params=(0.7, 0.95, 0.05),
+        dist_params=(0.2, 0.95, 0.05),
         name="Cover Absolute Threshold",
         description="Deploy when coral cover falls below this proportion (for reactive strategy)"
     )


### PR DESCRIPTION
## Summary
- Widens the lower bound of `reactive_absolute_threshold` (the reactive deployment cover-threshold factor) from 0.7 to 0.2, to explore a broader "what if" range of reactive deployment triggers.

Unrelated to Issue #1132 — a factor-definition exploration tweak.

## Test plan
- [ ] Existing intervention/sampling tests pass with the new bound