### PR TITLE
feat(io): tag ResultSet inputs DataFrame columns with ptype/label metadata

### DIFF
--- a/ADRIA/src/io/ResultSet.jl
+++ b/ADRIA/src/io/ResultSet.jl
@@ -3,7 +3,7 @@ using Dates: now
 using Zarr
 
 using Setfield: @set!
-using DataFrames: DataFrame
+using DataFrames: DataFrame, colmetadata!
 using ADRIA: Domain, EnvLayer
 
 const CONNECTIVITY = "connectivity"
@@ -96,6 +96,26 @@ function _load_shading_log(log_set::Zarr.ZGroup)::YAXArray
     )
 end
 
+"""
+    _tag_inputs_metadata!(inputs::DataFrame, model_spec::DataFrame)::DataFrame
+
+Tag each column of `inputs` that has a matching entry (by `fieldname`) in `model_spec`
+with `"ptype"` and `"label"` column metadata (sourced from `model_spec`'s `ptype` and
+`name` columns respectively). Uses `style=:note` so the metadata survives `copy()` and
+column-/row-subsetting operations performed by downstream analysis code.
+"""
+function _tag_inputs_metadata!(inputs::DataFrame, model_spec::DataFrame)::DataFrame
+    for row in eachrow(model_spec)
+        col = row.fieldname
+        if hasproperty(inputs, col)
+            colmetadata!(inputs, col, "ptype", row.ptype; style=:note)
+            colmetadata!(inputs, col, "label", row.name; style=:note)
+        end
+    end
+
+    return inputs
+end
+
 function ResultSet(
     input_set::AbstractArray,
     env_layer_md::EnvLayer,
@@ -109,6 +129,9 @@ function ResultSet(
     model_spec::DataFrame
 )::ResultSet
     rcp = "RCP" in keys(input_set.attrs) ? input_set.attrs["RCP"] : input_set.attrs["rcp"]
+
+    _tag_inputs_metadata!(inputs_used, model_spec)
+
     return ADRIAResultSet(
         input_set.attrs["name"],
         string(rcp),

--- a/ADRIA/src/io/rme_result_io.jl
+++ b/ADRIA/src/io/rme_result_io.jl
@@ -130,6 +130,8 @@ function load_results(
 
     mod_spec::DataFrame = _create_model_spec(inputs)
 
+    _tag_inputs_metadata!(inputs, mod_spec)
+
     return RMEResultSet(
         name,
         netcdf_rcp,

--- a/ADRIA/test/io/result_set_metadata.jl
+++ b/ADRIA/test/io/result_set_metadata.jl
@@ -1,0 +1,64 @@
+using ADRIA.DataFrames: colmetadata, colmetadata!, Not, nrow, insertcols!
+
+if !@isdefined(TEST_RS)
+    const TEST_DOM, TEST_N_SAMPLES, TEST_SCENS, TEST_RS = test_rs()
+end
+
+@testset "ResultSet inputs colmetadata" begin
+    rs = TEST_RS
+
+    # Pick a second known column (besides :guided) that is both a real model_spec
+    # factor and present in rs.inputs, so the test doesn't rely on a guessed name.
+    other_col = first(
+        f for f in rs.model_spec.fieldname if
+              f != :guided && hasproperty(rs.inputs, f)
+    )
+
+    @testset "metadata present on known columns" begin
+        for col in (:guided, other_col)
+            ptype = colmetadata(rs.inputs, col, "ptype", "MISSING")
+            label = colmetadata(rs.inputs, col, "label", "MISSING")
+
+            @test ptype != "MISSING"
+            @test label != "MISSING"
+
+            spec_row = rs.model_spec[rs.model_spec.fieldname .== col, :]
+            @test ptype == spec_row[1, :ptype]
+            @test label == spec_row[1, :name]
+        end
+    end
+
+    @testset "metadata survives feature_set-style DataFrame operations" begin
+        scens = copy(rs.inputs)
+        @test colmetadata(scens, :guided, "ptype", "MISSING") != "MISSING"
+        @test colmetadata(scens, :guided, "label", "MISSING") != "MISSING"
+
+        # Boolean row masking
+        mask = trues(nrow(scens))
+        scens2 = scens[mask, :]
+        @test colmetadata(scens2, :guided, "ptype", "MISSING") != "MISSING"
+        @test colmetadata(scens2, :guided, "label", "MISSING") != "MISSING"
+
+        # Not() column selection (drop a real droppable column, keep :guided)
+        scens3 = scens[:, Not(:dhw_scenario)]
+        @test colmetadata(scens3, :guided, "ptype", "MISSING") != "MISSING"
+        @test colmetadata(scens3, :guided, "label", "MISSING") != "MISSING"
+    end
+
+    @testset "metadata does NOT auto-appear on genuinely new columns" begin
+        scens = copy(rs.inputs)
+
+        # insertcols! with a brand new column
+        insertcols!(scens, :dummy_new_col => 1.0)
+        @test colmetadata(scens, :dummy_new_col, "ptype", "MISSING") == "MISSING"
+        @test colmetadata(scens, :dummy_new_col, "label", "MISSING") == "MISSING"
+
+        # Arithmetic derived column also does not inherit metadata from its source
+        scens[!, :guided_plus_one] = scens.guided .+ 1
+        @test colmetadata(scens, :guided_plus_one, "ptype", "MISSING") == "MISSING"
+        @test colmetadata(scens, :guided_plus_one, "label", "MISSING") == "MISSING"
+
+        # Original source column metadata is untouched
+        @test colmetadata(scens, :guided, "ptype", "MISSING") != "MISSING"
+    end
+end

--- a/ADRIA/test/runtests.jl
+++ b/ADRIA/test/runtests.jl
@@ -82,6 +82,7 @@ _abort_if_failed(tier4, "Tier 4 (Simulation Gate)")
 @testset "Tier 5: Simulation-Dependent" begin
     include("domain.jl")
     include("io/result_io.jl")
+    include("io/result_set_metadata.jl")
     include("example_run.jl")
     include("interventions/interventions.jl")
     include("interventions/seeding.jl")


### PR DESCRIPTION
## Summary
- Adds `_tag_inputs_metadata!` to stamp each `inputs` column with its `model_spec` `ptype` and `name` (label) as DataFrame column metadata (`style=:note`, survives `copy()`/subsetting).
- Wired into both the standard (`ResultSet.jl`) and RME (`rme_result_io.jl`) result loaders, so downstream analysis/plotting code can recover factor type and display label without re-joining against `model_spec`.

Not itself an Issue #1132 checklist item, but supporting infrastructure for downstream analysis/labeling.

## Test plan
- [x] New test: `ADRIA/test/io/result_set_metadata.jl`, wired into `runtests.jl`