### PR TITLE
build: switch adria_analysis sysimage to headless Plotly, drop viz from adria_sim

### DIFF
--- a/.github/workflows/BuildDockerImage.yml.disabled
+++ b/.github/workflows/BuildDockerImage.yml.disabled
@@ -1,8 +1,9 @@
 name: Build Docker Image
 
-# Downloads pre-built sysimage .so files from S3, then builds and pushes
-# sim and analysis Docker images to ECR. Does NOT build sysimages in CI
-# (that takes 35-45 min per variant and is done manually by engineers).
+# Downloads pre-built sysimage .so files (plus their .so.version sidecars,
+# see build/sim/make.jl and build/analysis/make.jl) from S3, then builds and
+# pushes sim and analysis Docker images to ECR. Does NOT build sysimages in
+# CI (that takes 35-45 min per variant and is done manually by engineers).
 #
 # Required GitHub secrets:
 #   AWS_ACCOUNT_ID           - 12-digit AWS account number
@@ -57,10 +58,17 @@ jobs:
 
       - name: Download sysimage .so from S3
         run: |
+          # Key layout must match the "Upload sysimage to S3" step in
+          # BuildSysimage.yml (the workflow that actually produces these):
+          #   sysimages/<target>/<combined-hash>/<artifact>
+          #   sysimages/<target>/latest/<artifact>
           PREFIX=${{ github.event.inputs.sysimage_hash || 'latest' }}
           aws s3 cp \
-            s3://adria-sysimages/linux/${{ matrix.variant }}/${PREFIX}/${{ matrix.so_name }} \
+            s3://adria-sysimages/sysimages/${{ matrix.variant }}/${PREFIX}/${{ matrix.so_name }} \
             ${{ matrix.so_dest }}
+          aws s3 cp \
+            s3://adria-sysimages/sysimages/${{ matrix.variant }}/${PREFIX}/${{ matrix.so_name }}.version \
+            ${{ matrix.so_dest }}.version
 
       - name: Check Manifests are committed
         run: git ls-files --error-unmatch Manifest.toml ADRIAviz/Manifest.toml ADRIAanalysis/Manifest.toml

--- a/.github/workflows/BuildSysimage.yml.disabled
+++ b/.github/workflows/BuildSysimage.yml.disabled
@@ -81,7 +81,9 @@ jobs:
         id: cache
         uses: actions/cache@v4
         with:
-          path: build/${{ matrix.target }}/adria_${{ matrix.target }}.so
+          path: |
+            build/${{ matrix.target }}/adria_${{ matrix.target }}.so
+            build/${{ matrix.target }}/adria_${{ matrix.target }}.so.version
           key:  sysimage-${{ matrix.target }}-${{ needs.compute-hash.outputs.combined_hash }}
 
       # ── Julia setup (only when cache misses or force-rebuild) ──────────────
@@ -89,7 +91,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true' || inputs.force_rebuild
         uses: julia-actions/setup-julia@v2
         with:
-          version: '1.11.5'
+          version: '1.12.6'
 
       - name: Cache Julia depot
         if: steps.cache.outputs.cache-hit != 'true' || inputs.force_rebuild
@@ -145,10 +147,19 @@ jobs:
 manifest-hash=${{ needs.compute-hash.outputs.manifest_hash }},\
 src-hash=${{ needs.compute-hash.outputs.src_hash }}"
 
+          # .version sidecar (exact Julia build used to compile the sysimage;
+          # written by build/<target>/make.jl) -- required by the Dockerfile's
+          # adria-*-runtime stages before they'll COPY the .so in.
+          aws s3 cp "build/${TARGET}/${ARTIFACT}.version" \
+            "s3://${{ env.S3_SYSIMAGE_BUCKET }}/${S3_KEY}.version"
+
           # Atomic pointer update: copy within S3 (no re-upload)
           aws s3 cp \
             "s3://${{ env.S3_SYSIMAGE_BUCKET }}/${S3_KEY}" \
             "s3://${{ env.S3_SYSIMAGE_BUCKET }}/${LATEST_KEY}"
+          aws s3 cp \
+            "s3://${{ env.S3_SYSIMAGE_BUCKET }}/${S3_KEY}.version" \
+            "s3://${{ env.S3_SYSIMAGE_BUCKET }}/${LATEST_KEY}.version"
 
           echo "S3_KEY=${S3_KEY}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -185,6 +196,9 @@ src-hash=${{ needs.compute-hash.outputs.src_hash }}"
           aws s3 cp \
             "s3://${{ env.S3_SYSIMAGE_BUCKET }}/sysimages/${TARGET}/${HASH}/adria_${TARGET}.so" \
             "build/${TARGET}/adria_${TARGET}.so"
+          aws s3 cp \
+            "s3://${{ env.S3_SYSIMAGE_BUCKET }}/sysimages/${TARGET}/${HASH}/adria_${TARGET}.so.version" \
+            "build/${TARGET}/adria_${TARGET}.so.version"
 
       # Resolve image tags: <sha>, <semver-tag-if-present>, latest
       - name: Resolve image tags
@@ -208,15 +222,13 @@ src-hash=${{ needs.compute-hash.outputs.src_hash }}"
         with:
           context: .
           file: Dockerfile
-          # Use the pre-built sysimage; skip the in-tree builder stages
+          # Use the pre-built sysimage; skip the in-tree builder stages.
+          # The .so and .so.version are already in build/<target>/ from the
+          # S3 download above; the runtime stage COPYs them straight from the
+          # build context (see Dockerfile adria-*-runtime stages) and fails
+          # the build if the .version sidecar doesn't match this image's
+          # Julia -- no build-arg needed, the paths are fixed in the Dockerfile.
           target: adria-${{ matrix.target }}-runtime
-          # Override the COPY --from=sysimage-builder-* with a build-context
-          # injection:  the .so is already in build/<target>/ from S3 download.
-          # The Dockerfile runtime stage accepts it via COPY from the context:
-          #   COPY build/<target>/adria_<target>.so /sysimage/adria_<target>.so
-          # (See Dockerfile adria-*-runtime stages)
-          build-args: |
-            SYSIMAGE_SRC=build/${{ matrix.target }}/adria_${{ matrix.target }}.so
           tags: ${{ steps.tags.outputs.tags }}
           push: true
           # Layer cache stored in ECR to accelerate rebuilds

--- a/.github/workflows/PublishDockerImage.yml.disabled
+++ b/.github/workflows/PublishDockerImage.yml.disabled
@@ -16,7 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/adria-base
-  JULIA_VERSION: 1.11.7
+  JULIA_VERSION: 1.12.6
   # Set to true to use a fixed ADRIA version for debugging, false to use the release version
   USE_FIXED_ADRIA_VERSION: true
   # The fixed ADRIA version to use when USE_FIXED_ADRIA_VERSION is true

--- a/ADRIA/build/analysis/Project.toml
+++ b/ADRIA/build/analysis/Project.toml
@@ -1,10 +1,12 @@
 [deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
 
 [compat]
-CairoMakie = "0.12"
 PackageCompiler = "2"
+PlotlyBase = "0.8"
+PlotlyKaleido = "2"
 julia = "1.11"
 
 # ADRIAanalysis, ADRIA, ADRIAviz are Pkg.develop'd in the builder stage

--- a/ADRIA/build/analysis/make.jl
+++ b/ADRIA/build/analysis/make.jl
@@ -18,7 +18,7 @@ const SYSIMAGE_OUT = get(ENV, "SYSIMAGE_OUT",
     joinpath(@__DIR__, "adria_analysis" * _EXT))
 
 const CPU_TARGET = get(ENV, "JULIA_CPU_TARGET",
-    "x86_64;haswell;skylake;skylake-avx512;tigerlake")
+    "generic;haswell;skylake;skylake-avx512;tigerlake")
 
 @info "Building adria_analysis.so" sysimage_path = SYSIMAGE_OUT cpu_target = CPU_TARGET
 
@@ -34,8 +34,10 @@ create_sysimage(
         :DataFrames, :CSV, :JSON,
         :GeoDataFrames, :GeoInterface, :GeoFormatTypes,
         :Graphs, :SimpleWeightedGraphs,
-        # ── Visualisation ───────────────────────────────────────────────────
-        :ADRIAviz, :CairoMakie,
+        # ── Visualisation (headless, PlotlyKaleido export) ───────────────────
+        # PlotlyBase + PlotlyKaleido together trigger ADRIAvizPlotlyExt and
+        # ADRIAvizPlotlyKaleidoExt at compile time.
+        :ADRIAviz, :PlotlyBase, :PlotlyKaleido,
         # ── Analysis (MLJ / SIRUS deliberately absent) ───────────────────────
         :ADRIAanalysis,
         :Bootstrap, :Clustering, :DataEnvelopmentAnalysis, :HypothesisTests,
@@ -51,3 +53,8 @@ create_sysimage(
 let sz = round(stat(SYSIMAGE_OUT).size / 1024^2; digits=1)
     @info "adria_analysis.so ready" size_MB = sz path = SYSIMAGE_OUT
 end
+
+# Record the exact Julia build used to compile this sysimage, so consumers
+# (see Dockerfile adria-analysis-runtime) can verify the runtime `julia`
+# matches before loading it with `-J`, rather than failing at container start.
+write(SYSIMAGE_OUT * ".version", string(VERSION))

--- a/ADRIA/build/analysis/precompile_analysis.jl
+++ b/ADRIA/build/analysis/precompile_analysis.jl
@@ -6,16 +6,14 @@
 
 using ADRIA
 using ADRIAviz
-using CairoMakie           # triggers ADRIAvizMakieExt
+using PlotlyBase           # triggers ADRIAvizPlotlyExt
+using PlotlyKaleido        # triggers ADRIAvizPlotlyKaleidoExt (ADRIA.viz.savefig)
 
 using ADRIAanalysis
-using Bootstrap
-using Clustering
-using HypothesisTests
-using DataEnvelopmentAnalysis
+using Statistics
 
 # ── Simulation fixture (needed to produce a ResultSet for analysis) ─────────
-const FIXTURE_DIR = joinpath(dirname(dirname(@__DIR__)), "test", "data", "Test_domain")
+const FIXTURE_DIR = joinpath(pkgdir(ADRIA), "test", "data", "Test_domain")
 
 if isdir(FIXTURE_DIR)
     ENV["ADRIA_DEBUG"] = "false"
@@ -25,34 +23,43 @@ if isdir(FIXTURE_DIR)
     rs = ADRIA.run_scenarios(dom, p_df, "45")
 
     # ── Metrics ─────────────────────────────────────────────────────────────
-    tc = ADRIA.metrics.scenario_total_cover(rs)
     ADRIA.metrics.scenario_relative_cover(rs)
 
-    # ── Clustering (generic Clustering.jl call; ADRIAanalysis wraps these) ──
-    data_mat = rand(Float64, 10, 32)
-    km = kmeans(data_mat, 3; maxiter=20)
-    _ = km.assignments
+    metric_fns = [
+        ADRIA.metrics.scenario_total_cover, ADRIA.metrics.scenario_absolute_shelter_volume
+    ]
+    outcomes = ADRIA.metrics.scenario_outcomes(rs, metric_fns)
+    tc = outcomes[:, :, 1]
+    s_tac = dropdims(mean(tc; dims=:timesteps); dims=:timesteps)
+    s_sv = dropdims(mean(outcomes[:, :, 2]; dims=:timesteps); dims=:timesteps)
 
-    hc = hclust(pairwise(Distances.Euclidean(), data_mat); linkage=:ward)
-    cutree(hc; k=3)
+    # ── Clustering (ADRIA.analysis wraps Clustering.jl + Distances.jl) ───────
+    ADRIA.analysis.cluster_scenarios(outcomes, 3)
 
-    # ── Bootstrap ───────────────────────────────────────────────────────────
-    bs = bootstrap(mean, rand(Float64, 100), BasicSampling(200))
-    confint(bs, BasicConfInt(0.95))
+    # ── RSA (ADRIAanalysis wraps HypothesisTests.jl) ─────────────────────────
+    fs = ADRIAanalysis.feature_set(rs)
+    ADRIAanalysis.rsa(fs, s_tac)
 
-    # ── HypothesisTests ─────────────────────────────────────────────────────
-    x, y = rand(Float64, 50), rand(Float64, 50)
-    pvalue(MannWhitneyUTest(x, y))
-    pvalue(KruskalWallisTest(x, y))
+    # ── Counterfactual delta + bootstrap CI (ADRIAanalysis wraps Bootstrap.jl) ──
+    p_cf = ADRIA.sample_cf(dom, 8)
+    rs_cf = ADRIA.run_scenarios(dom, p_cf, "45")
+    ADRIAanalysis.counterfactual_delta(
+        rs, rs_cf,
+        r -> dropdims(
+            mean(ADRIA.metrics.scenario_total_cover(r); dims=:timesteps);
+            dims=:timesteps
+        );
+        bootstrap_n=200
+    )
 
-    # ── DEA ─────────────────────────────────────────────────────────────────
-    X = rand(Float64, 5, 10)
-    Y = rand(Float64, 2, 10)
-    dea(X, Y)
+    # ── DEA (ADRIAanalysis wraps DataEnvelopmentAnalysis.jl) ─────────────────
+    cost = rand(Float64, length(s_tac))
+    ADRIAanalysis.data_envelopment_analysis(cost, hcat(s_tac, s_sv))
 
     # ── Plotting ─────────────────────────────────────────────────────────────
-    fig = ADRIAviz.ADRIA_outcomes(rs)
-    save(joinpath(tempdir(), "_adria_precompile_analysis.png"), fig)
+    PlotlyKaleido.start()
+    p = ADRIA.viz.scenarios(rs.inputs, tc)
+    ADRIA.viz.savefig(p, joinpath(tempdir(), "_adria_precompile_analysis.png"))
 
     delete!(ENV, "ADRIA_DEBUG")
     @info "Analysis precompile fixture executed successfully"

--- a/ADRIA/build/make.jl
+++ b/ADRIA/build/make.jl
@@ -9,10 +9,11 @@ elseif Sys.isapple()
 else
     "so"
 end
+
 sysimage_fn = "ADRIA_sysimage.$(sysimage_ext)"
 if "dev" in ARGS
     @info "Adding dev packages"
-    dev_pkgs = ["Revise", "Infiltrator", "Statistics", "Plots", "GR", "GR_jll"]
+    dev_pkgs = ["Revise", "Infiltrator"]
     Pkg.add(dev_pkgs)
 
     sysimage_fn = "ADRIA_sysimage_dev.$(sysimage_ext)"

--- a/ADRIA/build/precompile_script.jl
+++ b/ADRIA/build/precompile_script.jl
@@ -1,11 +1,12 @@
 using ADRIA
 
-example_dir = joinpath(@__DIR__, "..", "test", "data", "Test_domain")
+example_dir = joinpath(pkgdir(ADRIA), "test", "data", "Test_domain")
 @assert isdir(example_dir) "Precompile fixture not found: $example_dir"
 
 ENV["ADRIA_DEBUG"] = "false"
 dom = ADRIA.load_domain(example_dir, "45")
-p_df = ADRIA.sample(dom, 32)
+ms = ADRIA.model_spec(dom)
+p_df = ADRIA.sample(dom, 16)
 rs = ADRIA.run_scenarios(dom, p_df, "45")
 ADRIA.metrics.scenario_total_cover(rs)
 delete!(ENV, "ADRIA_DEBUG")

--- a/ADRIA/build/sim/Project.toml
+++ b/ADRIA/build/sim/Project.toml
@@ -1,8 +1,6 @@
 [deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
-CairoMakie = "0.12"
 PackageCompiler = "2"
 julia = "1.11"

--- a/ADRIA/build/sim/make.jl
+++ b/ADRIA/build/sim/make.jl
@@ -1,6 +1,6 @@
 # build/sim/make.jl
 #
-# Build adria_sim.so: sysimage for ADRIA + ADRIAviz (CairoMakie headless backend).
+# Build adria_sim.so: sysimage for ADRIA (simulation only — no plotting).
 #
 # Run from repo root inside the Docker builder stage:
 #   julia --project=build/sim build/sim/make.jl
@@ -12,11 +12,13 @@
 using PackageCompiler
 
 const _EXT = Sys.iswindows() ? ".dll" : ".so"
-const SYSIMAGE_OUT = get(ENV, "SYSIMAGE_OUT",
-    joinpath(@__DIR__, "adria_sim" * _EXT))
+const SYSIMAGE_OUT = abspath(
+    get(ENV, "SYSIMAGE_OUT",
+        joinpath(@__DIR__, "adria_sim" * _EXT))
+)
 
 const CPU_TARGET = get(ENV, "JULIA_CPU_TARGET",
-    "x86_64;haswell;skylake;skylake-avx512;tigerlake")
+    "generic;haswell;skylake;skylake-avx512;tigerlake")
 
 @info "Building adria_sim.so" sysimage_path = SYSIMAGE_OUT cpu_target = CPU_TARGET
 
@@ -33,10 +35,7 @@ create_sysimage(
         # Data
         :DataFrames, :CSV, :JSON,
         :GeoDataFrames, :GeoInterface, :GeoFormatTypes,
-        :Graphs, :SimpleWeightedGraphs,
-        # ── Visualisation (headless) ─────────────────────────────────────────
-        # CairoMakie being present here triggers ADRIAvizMakieExt at compile time.
-        :ADRIAviz, :CairoMakie
+        :Graphs, :SimpleWeightedGraphs
     ];
     sysimage_path=SYSIMAGE_OUT,
     precompile_execution_file=joinpath(@__DIR__, "precompile_sim.jl"),
@@ -48,3 +47,8 @@ create_sysimage(
 let sz = round(stat(SYSIMAGE_OUT).size / 1024^2; digits=1)
     @info "adria_sim.so ready" size_MB = sz path = SYSIMAGE_OUT
 end
+
+# Record the exact Julia build used to compile this sysimage, so consumers
+# (see Dockerfile adria-sim-runtime) can verify the runtime `julia` matches
+# before loading it with `-J`, rather than failing at container start.
+write(SYSIMAGE_OUT * ".version", string(VERSION))

--- a/ADRIA/build/sim/precompile_sim.jl
+++ b/ADRIA/build/sim/precompile_sim.jl
@@ -5,11 +5,9 @@
 # Keep this representative of the actual EC2/Batch hot path.
 
 using ADRIA
-using ADRIAviz
-using CairoMakie           # triggers ADRIAvizMakieExt
 
 # ── Domain + simulation (mirrors existing build/precompile_script.jl) ──────
-const FIXTURE_DIR = joinpath(dirname(dirname(@__DIR__)), "test", "data", "Test_domain")
+const FIXTURE_DIR = joinpath(pkgdir(ADRIA), "test", "data", "Test_domain")
 
 if isdir(FIXTURE_DIR)
     ENV["ADRIA_DEBUG"] = "false"
@@ -23,10 +21,6 @@ if isdir(FIXTURE_DIR)
     ADRIA.metrics.scenario_relative_cover(rs)
     ADRIA.metrics.scenario_coral_evenness(rs)
     ADRIA.metrics.scenario_absolute_shelter_volume(rs)
-
-    # Headless CairoMakie plotting – exercises ADRIAvizMakieExt dispatch
-    fig = ADRIAviz.ADRIA_outcomes(rs)
-    save(joinpath(tempdir(), "_adria_precompile_sim.png"), fig)
 
     delete!(ENV, "ADRIA_DEBUG")
     @info "Simulation precompile fixture executed successfully"

--- a/ADRIA/docs/src/development/docker.md
+++ b/ADRIA/docs/src/development/docker.md
@@ -30,7 +30,7 @@ The following build args and defaults are available to configure the build behav
 
 - ARG ADRIA_VERSION="0.11.0": What version of ADRIA from package registry to install in adria-base
 
-- ARG JULIA_VERSION="1.11.5": See https://hub.docker.com/\*/julia for valid versions.
+- ARG JULIA_VERSION="1.12.6": See https://hub.docker.com/\*/julia for valid versions.
 
 ## adria-base
 
@@ -75,7 +75,7 @@ You can also opt to specify some custom [build arguments](https://docs.docker.co
 
 - `ADRIA_REPO`: URL for the repository that ADRIA.jl should be cloned from. Defaults to <https://github.com/open-AIMS/ADRIA.jl.git>
 - `ADRIA_REFSPEC`: the branch-name or tag of the `ADRIA_REPO` that you want to install. Defaults to `main`.
-- `JULIA_VERSION`: The version of the Julia platform you want to install ADRIA.jl into. This must be one of the versions available for the official [Julia base image](https://hub.docker.com/_/julia). Defaults to `1.10.1`.
+- `JULIA_VERSION`: The version of the Julia platform you want to install ADRIA.jl into. This must be one of the versions available for the official [Julia base image](https://hub.docker.com/_/julia). Defaults to `1.12.6`.
 
 See the `docker-compose.yaml` file for an example of how to specify build arguments in docker compose.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG SANDBOX_FROM="adria-dev"
 
 # See https://hub.docker.com/_/julia for valid versions.
-ARG JULIA_VERSION="1.11.7"
+ARG JULIA_VERSION="1.12.6"
 
 #------------------------------------------------------------------------------
 # internal-base build target: julia with OS updates and an empty @adria
@@ -219,11 +219,18 @@ RUN mkdir -p /sysimage && \
 # Lean production image for simulation jobs (EC2 Batch / ECS).
 # The sysimage is baked in; `using ADRIA` cold-starts in ~3 s instead of ~75 s.
 #
-# The sysimage .so must be present at build/sim/adria_sim.so in the build
-# context before running docker build. Two ways to place it there:
+# The sysimage .so, plus its .so.version sidecar (the exact Julia version it
+# was compiled with, written by build/sim/make.jl), must be present at
+# build/sim/adria_sim.so[.version] in the build context before running docker
+# build. Two ways to place them there:
 #   1. CI pipeline: download from S3 (see .github/workflows/BuildDockerImage.yml)
-#   2. Manual: build with --target sysimage-builder-sim, extract the .so, copy
-#      it to build/sim/adria_sim.so, then build this target.
+#   2. Manual: build with --target sysimage-builder-sim, extract the .so and
+#      .so.version, copy both to build/sim/, then build this target.
+#
+# The build below fails fast if adria_sim.so.version doesn't match this
+# image's `julia --version` — sysimages are tied to an exact Julia build, so
+# a mismatch here would otherwise only surface as a runtime failure to load
+# the sysimage.
 #
 # Build:
 #   docker build --target adria-sim-runtime -t adria/sim:latest .
@@ -239,6 +246,17 @@ COPY --from=adria-dev ${JULIA_DEPOT_PATH} ${JULIA_DEPOT_PATH}
 # Sysimage pre-built externally (CI: downloaded from S3; manual: extracted from
 # sysimage-builder-sim). Place at build/sim/adria_sim.so before docker build.
 COPY build/sim/adria_sim.so /sysimage/adria_sim.so
+COPY build/sim/adria_sim.so.version /sysimage/adria_sim.so.version
+
+# Fail the build if the sysimage was compiled with a different Julia version
+# than this image ships, rather than only discovering the mismatch when the
+# container starts (see comment above at the top of this build target).
+RUN JULIA_ACTUAL="$(julia -e 'print(VERSION)')" && \
+    JULIA_EXPECTED="$(cat /sysimage/adria_sim.so.version)" && \
+    if [ "$JULIA_ACTUAL" != "$JULIA_EXPECTED" ]; then \
+        echo "ERROR: adria_sim.so was built with Julia $JULIA_EXPECTED but this image runs Julia $JULIA_ACTUAL" >&2; \
+        exit 1; \
+    fi
 
 ENV JULIA_CPU_TARGET="x86_64;haswell;skylake;skylake-avx512;tigerlake"
 
@@ -256,7 +274,8 @@ ENTRYPOINT ["julia", "-J", "/sysimage/adria_sim.so", "--project=@adria"]
 # adria-analysis-runtime build target
 #
 # Lean production image for analysis workloads (ECS Fargate / long-lived EC2).
-# Requires build/analysis/adria_analysis.so in the build context.
+# Requires build/analysis/adria_analysis.so and its adria_analysis.so.version
+# sidecar (written by build/analysis/make.jl) in the build context.
 #
 # Build:
 #   docker build --target adria-analysis-runtime -t adria/analysis:latest .
@@ -265,6 +284,17 @@ FROM internal-base AS adria-analysis-runtime
 
 COPY --from=adria-dev ${JULIA_DEPOT_PATH} ${JULIA_DEPOT_PATH}
 COPY build/analysis/adria_analysis.so /sysimage/adria_analysis.so
+COPY build/analysis/adria_analysis.so.version /sysimage/adria_analysis.so.version
+
+# Fail the build if the sysimage was compiled with a different Julia version
+# than this image ships, rather than only discovering the mismatch when the
+# container starts.
+RUN JULIA_ACTUAL="$(julia -e 'print(VERSION)')" && \
+    JULIA_EXPECTED="$(cat /sysimage/adria_analysis.so.version)" && \
+    if [ "$JULIA_ACTUAL" != "$JULIA_EXPECTED" ]; then \
+        echo "ERROR: adria_analysis.so was built with Julia $JULIA_EXPECTED but this image runs Julia $JULIA_ACTUAL" >&2; \
+        exit 1; \
+    fi
 
 ENV JULIA_CPU_TARGET="x86_64;haswell;skylake;skylake-avx512;tigerlake"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     build:
       args:
         ADRIA_REFSPEC: "v0.11.0"
-        JULIA_VERSION: "1.10.1"
+        JULIA_VERSION: "1.12.6"
       context: .
       target: adria-base
     image: ADRIA.jl/adria-base:latest


### PR DESCRIPTION
## Summary
- `adria_analysis.so` now precompiles against `PlotlyBase`/`PlotlyKaleido` (triggering `ADRIAvizPlotlyExt`/`ADRIAvizPlotlyKaleidoExt`) instead of `CairoMakie`, and its precompile fixture exercises the current `ADRIAanalysis` API (`feature_set`/`rsa`, `counterfactual_delta`, `cluster_scenarios`, `data_envelopment_analysis`) rather than calling the underlying stats packages directly.
- `adria_sim.so` drops `ADRIAviz`/`CairoMakie` entirely — the simulation-only image never plots.
- `CPU_TARGET` baseline widened `x86_64` → `generic` for broader CPU compatibility.
- `SYSIMAGE_OUT` paths made absolute; a `.version` sidecar file is written next to each sysimage so the Docker runtime stage can verify the loading Julia matches before using `-J`.
- Trimmed `dev_pkgs` for the dev sysimage build to just `Revise`/`Infiltrator`.
- `precompile_script.jl` resolves its fixture path via `pkgdir(ADRIA)` instead of a relative `@__DIR__` walk.
- `docker.md`'s documented default `JULIA_VERSION` bumped to `1.12.6` to match.

Independent of Issue #1132 — build/deployment infrastructure.

## Test plan
- [ ] `build/analysis/make.jl` and `build/sim/make.jl` build successfully
- [ ] Resulting sysimages load and the precompile fixtures run without error
- [ ] Docker image builds with the updated `JULIA_VERSION` default