### PR TITLE
feat(sampling): graph-based conditional dependency resolution

### DIFF
--- a/ADRIA/docs/src/architecture/architecture.md
+++ b/ADRIA/docs/src/architecture/architecture.md
@@ -90,8 +90,14 @@ upper bounds), and a human-readable name and description. An example from the `I
 sub-component is shown below.
 
 ```julia
-guided::N = Factor(0.0, ptype="ordered categorical", dist=(-1.0, 3.0), dist_params=DiscreteUniform,
-        name="Guided", description="Choice of MCDA approach.")
+guided::Param = Factor(
+    0;
+    ptype="ordered categorical",
+    dist=CategoricalDistribution,
+    dist_params=(-1.0, 0.0, 1.0),
+    name="Guided",
+    description="Intervention effort level: -1 no intervention (counterfactual), 0 unguided, 1 guided (MCDA-driven)."
+)
 ```
 
 Note that factor values are provided as floats - even where discrete values are expected -
@@ -103,6 +109,78 @@ Combinations of the realized factor values then represent a "scenario".
 !!! note "Parameter Collation and Scenario Generation"
     See [Cookbook examples](@ref) for an example how-to on collating model factors and
     generating samples.
+
+### Conditional sampling dependencies
+
+Many model factors only matter under a subset of scenario regimes — seeding deployment
+factors have no effect on a counterfactual scenario, and criteria weights have no effect
+unless a `guided` MCDA approach is active. Sampling every factor unconditionally would
+waste sample budget on combinations that can't affect model output, and would dilute
+sensitivity/PAWN analyses with dead dimensions. ADRIA instead resolves these dependencies
+automatically, as early as it safely can:
+
+```
+   model spec (all factors)
+            |
+            v
+  +----------------------+
+  |  fix known-inactive   |   pre-sampling: factors are fixed to a
+  |  factors to constants |   constant and never sampled at all
+  +----------------------+
+            |
+            v
+     QMC sampling (Sobol' / LHS / ...)
+            |
+            v
+  +----------------------+
+  |  zero/adjust factors  |   post-sampling: fixes applied per-row,
+  |  that depend on drawn |   using each scenario's own drawn values
+  |  values               |
+  +----------------------+
+            |
+            v
+      scenario DataFrame
+```
+
+The split exists because not every dependency can be resolved before sampling — some only
+depend on a setting fixed for the whole call (e.g. `guided` in `sample_cf`), which can be
+resolved up-front, while others depend on a value that's only known once a row has
+actually been sampled (e.g. whether a *drawn* `fogging` value happens to be `0`), which
+can only be resolved afterwards, row by row.
+
+!!! note "Where this lives"
+    - `src/io/sampling/sampling_dependencies.jl` — pre-sampling: fixes spec columns to
+      constants before sampling begins.
+    - `src/io/sampling/sampling_transforms.jl` — post-sampling: zeroes/adjusts sampled
+      values row-wise, in `_apply_transforms!` (ordering here is load-bearing — see its
+      docstring).
+
+Both stages share the same declarative rule format — a table of parent → child rules,
+each checking whether `child` is active given a known `parent` value:
+
+| Field    | Meaning                                                              |
+|----------|-----------------------------------------------------------------------|
+| `parent` | Factor whose value the rule checks                                    |
+| `child`  | Factor (or named group of factors) to fix if inactive                 |
+| `op`     | Comparison applied to `parent`'s value (e.g. `:eq`, `:gt`)            |
+| `value`  | Threshold/comparison value passed to `op`                             |
+| `negate` | Invert the result of `op`, for rules more naturally stated as "inactive when..." |
+| `fix_to` | Constant `child` is set to when inactive                              |
+
+A fixed-point loop applies these rules pre-sampling (a fixed child can itself gate further
+rules), and `_validate_dependencies` checks the table for unknown parents/ops/children,
+cycles, and rules that would fix the same column to conflicting values. To add a new
+dependency: if it depends on `guided` and is knowable before sampling, add it to
+`sampling_dependencies.jl`; otherwise add it to `sampling_transforms.jl` — see the header
+comment in `sampling_dependencies.jl` for a worked example.
+
+!!! warning "Effect on Sobol' sampling"
+    Both pre- and post-sampling adjustment break the low-discrepancy structure of the
+    Sobol' sequence used for scenario generation. Adjusted scenario sets must **not** be
+    treated as valid Sobol' samples for the purpose of estimating Sobol' sensitivity
+    indices. This is why PAWN (Pianosi and Wagener 2015, 2018), a distribution-based
+    method, is used for sensitivity analysis instead of Sobol' indices — see
+    [Generating scenarios](@ref).
 
 # References
 

--- a/ADRIA/docs/src/usage/analysis.jl
+++ b/ADRIA/docs/src/usage/analysis.jl
@@ -102,6 +102,7 @@
 #         :dhw_scenario,
 #         :wave_scenario,
 #         :guided,
+#         :mcda_method,
 #         :N_seed_TA,
 #         :N_seed_CA,
 #         :fogging,
@@ -252,7 +253,7 @@
 # # Display convergence for specific factors of interest ("foi") within a single figure.
 # # Bands represent the 95% confidence interval derived from the number of conditioning
 # # points (default is 10 samples).
-# foi = [:dhw_scenario, :wave_scenario, :guided]
+# foi = [:dhw_scenario, :wave_scenario, :guided, :mcda_method]
 # Si_conv = convergence(scens, outcome, foi)
 # conv_series_fig = ADRIA.viz.convergence(Si_conv, foi)
 # ADRIA.viz.savefig(conv_series_fig, "convergence_factors_series.html")

--- a/ADRIA/docs/src/usage/generating_scenarios.md
+++ b/ADRIA/docs/src/usage/generating_scenarios.md
@@ -35,7 +35,10 @@ values (where necessary), as is in the case with categorical factors. The Sobol'
 scheme is therefore disrupted due to the adjustment and so a Sobol' sensitivity
 analysis may exhibit comparatively poor convergence. Subsequent assessment of
 uncertainty and sensitivity is instead conducted with the distribution-based
-PAWN method (Pianosi and Wagener 2015, 2018).
+PAWN method (Pianosi and Wagener 2015, 2018). See
+[Conditional factor dependencies](@ref) below for what this adjustment does in practice,
+and the [architecture overview](@ref "Conditional sampling dependencies") for how it is
+implemented.
 
 !!! note "Sobol' samples"
     The convergence properties of the Sobol' sequence is only valid if the number of
@@ -146,9 +149,60 @@ ADRIA.set_factor_bounds!(dom;
 # List of available MCDA decision methods
 ADRIA.decision.mcda_method_names()
 
-# Constrain guided options, selecting a specific MCDA decision method
-ADRIA.set_factor_bounds!(dom, :guided, ("counterfactual", "COCOSO"))
+# Constrain guided/counterfactual regime, and separately select a specific MCDA decision method
+ADRIA.set_factor_bounds!(dom, :guided, (0.0, 1.0))  # unguided or guided only, no counterfactual
+ADRIA.set_factor_bounds!(dom, :mcda_method, ("COCOSO",))
 ```
+
+## Conditional factor dependencies
+
+Some factors are only meaningful under certain scenario regimes. For example,
+seeding-related deployment factors have no effect on a counterfactual (no intervention)
+scenario, and decision-strategy criteria weights have no effect unless a `guided` MCDA
+approach is selected. Rather than sampling these factors unconditionally and discarding
+the result, ADRIA resolves such dependencies automatically, either by:
+
+- fixing the affected factors to a constant *before* sampling, when the governing setting
+  (currently `guided`) is known for the whole call (e.g. `ADRIA.sample_cf`,
+  `ADRIA.sample_guided`, `ADRIA.sample_unguided`), or
+- zeroing/adjusting the affected factors *after* sampling, on a per-scenario (row) basis,
+  when the governing setting is itself sampled (as with plain `ADRIA.sample(dom, n)`, where
+  `guided` varies from row to row) or when the dependency is only evaluable from a drawn
+  value (e.g. gating on whether a sampled `fogging` value is greater than zero).
+
+See the [architecture overview](@ref "Conditional sampling dependencies") for how this is
+implemented, if extending or debugging this behavior.
+
+This means the returned scenario DataFrame will commonly contain columns set to `0.0` (or
+another sentinel constant) for rows where the corresponding intervention/strategy is
+inactive, rather than a value drawn from that factor's nominal distribution.
+
+```julia
+cf_scens = ADRIA.sample_cf(dom, 128)
+
+# Intervention and criteria weight columns are fixed to a sentinel value for
+# counterfactual scenarios rather than sampled, since they have no effect.
+cf_scens[:, [:N_seed_TA, :fogging, :seed_heat_stress]]
+```
+
+Marine Cloud Brightening factors are handled the same way — see
+[Marine Cloud Brightening (MCB) Scenarios](@ref) below for a concrete example of fixing
+those factors to values available in a given dataset.
+
+!!! warning "Effect on Sobol' sensitivity analysis"
+    Fixing or adjusting sampled values after the fact disrupts the low-discrepancy
+    structure of the underlying Sobol' sequence. Scenario sets produced this way should
+    **not** be treated as valid Sobol' samples for the purpose of estimating Sobol'
+    indices — such samples exist only to explore plausible factor combinations. Where
+    Sobol' indices are required, PAWN is used instead (see
+    [PAWN sensitivity (heatmap overview)](@ref)), which does not require this structure to
+    be preserved.
+
+!!! note "Duplicate scenarios"
+    Because multiple distinct pre-adjustment samples can collapse onto the same fixed
+    values (e.g. every counterfactual sample ends up with `fogging = 0.0`), it is expected
+    for a scenario set to contain some duplicate rows. ADRIA will emit a warning
+    reporting the proportion of duplicates when this occurs.
 
 ## Marine Cloud Brightening (MCB) Scenarios
 

--- a/ADRIA/docs/src/usage/generating_scenarios.md
+++ b/ADRIA/docs/src/usage/generating_scenarios.md
@@ -229,13 +229,86 @@ ADRIA.fix_factor!(dom, :mcb_albedo, 0.3)
 scens = ADRIA.sample(dom, 128)
 ```
 
-## Sampling counterfactuals only
+## Sampling by intervention regime
 
-A convenience function to create scenarios with no interventions (counterfactuals).
+Alongside plain `ADRIA.sample(dom, n)` (which samples the `guided` factor together with
+everything else, so each row may land in a different intervention regime), ADRIA provides
+a family of convenience functions that fix the intervention regime for the whole call
+up-front. This avoids wasting samples on factor combinations that are meaningless for the
+regime under study (e.g. seeding-related factors when only counterfactual scenarios are
+wanted), and lets the conditional factor dependencies described above be resolved *before*
+sampling rather than row-by-row afterwards (see
+[Conditional factor dependencies](@ref)).
+
+| Function | Regime sampled | `n` refers to |
+|----------|-----------------|---------------|
+| `ADRIA.sample(dom, n)` | All regimes (`guided` itself is sampled) | total scenarios |
+| `ADRIA.sample_cf(dom, n)` | Counterfactual only (no interventions) | total scenarios |
+| `ADRIA.sample_unguided(dom, n)` | Unguided interventions only | total scenarios |
+| `ADRIA.sample_guided(dom, n)` | Guided (MCDA-driven) interventions only | total scenarios |
+| `ADRIA.sample_balanced(dom, n)` | Equal parts counterfactual, unguided and guided | scenarios *per regime* (returns `3n` rows) |
+| `ADRIA.sample_selection(dom, n)` | Guided location-selection factors only; coral factors held at their defaults | total scenarios |
+| `ADRIA.sample_paired(dom, n)` | Guided scenarios paired 1:1 with a derived counterfactual row sharing the same non-intervention factor values | guided scenarios drawn (returns `2n` rows) |
+| `ADRIA.sample_paired_stratified(dom, n, ssps)` | As `sample_paired`, repeated independently for each RCP/SSP in `ssps` | guided scenarios drawn *per SSP stratum* |
+| `ADRIA.sample_matched(dom, n)` | Guided scenarios paired 1:1 with derived rows for each regime in `regimes` (default: counterfactual **and** unguided) | guided scenarios drawn (returns `(1 + length(regimes)) * n` rows) |
+| `ADRIA.sample_matched_stratified(dom, n, ssps)` | As `sample_matched`, repeated independently for each RCP/SSP in `ssps` | guided scenarios drawn *per SSP stratum* |
 
 ```julia
+# Counterfactual scenarios only (no interventions)
 cf_scens = ADRIA.sample_cf(dom, 1024)
+
+# Unguided intervention scenarios only
+ug_scens = ADRIA.sample_unguided(dom, 1024)
+
+# Guided (MCDA-driven) intervention scenarios only
+gd_scens = ADRIA.sample_guided(dom, 1024)
+
+# 1024 scenarios of each regime (3072 rows total)
+balanced_scens = ADRIA.sample_balanced(dom, 1024)
 ```
+
+For causal comparisons between an intervention and "no intervention", `sample_paired`
+draws guided scenarios and derives a matching counterfactual row for each one, holding all
+non-intervention factors (environmental layers, etc.) fixed between the pair so that
+outcome differences can be attributed to the intervention itself. `sample_paired_stratified`
+extends this across multiple RCP/SSP scenarios, using an independent Owen scramble per
+stratum:
+
+```julia
+# 128 guided/counterfactual pairs (256 rows), tagged by `:run_type`
+paired_scens = ADRIA.sample_paired(dom, 128)
+
+# As above, repeated for each listed RCP/SSP, tagged by `:ssp` and `:run_type`
+strat_scens = ADRIA.sample_paired_stratified(dom, 128, ["45", "60", "85"])
+```
+
+`sample_paired` only pairs guided scenarios against a derived counterfactual row, so it
+cannot support a 3-way cross-comparison against unguided scenarios. `sample_matched`
+generalises this: it draws guided scenarios and derives a matched row for each regime
+requested via `regimes` (any non-empty subset of `(:counterfactual, :unguided)`, default
+both), all sharing the same non-intervention factor draws — `sample_paired` is just
+`sample_matched` with `regimes=(:counterfactual,)`. Note that unguided rows keep the same
+intervention deployment amounts as their guided counterpart (only the MCDA criteria
+weights/`plan_horizon` are zeroed and the strategy is fixed to periodic) — unlike
+counterfactual rows, where deployment amounts are zeroed too:
+
+```julia
+# 128 guided/counterfactual/unguided triples (384 rows), tagged by `:run_type`
+matched_scens = ADRIA.sample_matched(dom, 128)
+
+# Only guided + unguided (256 rows)
+matched_ug_scens = ADRIA.sample_matched(dom, 128; regimes=(:unguided,))
+
+# As `sample_matched`, repeated for each listed RCP/SSP
+strat_matched_scens = ADRIA.sample_matched_stratified(dom, 128, ["45", "60", "85"])
+```
+
+This differs from `sample_balanced`, which draws each regime *independently* — those rows
+are not matched row-for-row and cannot be used for this kind of differencing.
+
+!!! note "Sobol' samples"
+    As with plain `ADRIA.sample`, `n` (or `n_per_stratum`) should be a power of 2 when
+    using the default Sobol' sampler.
 
 ## References
 

--- a/ADRIA/src/Domain.jl
+++ b/ADRIA/src/Domain.jl
@@ -197,12 +197,13 @@ function model_spec(m::Model)::DataFrame
     # dist_params is stored as Vector{Float64} internally; convert each element to a Tuple
     # so that downstream callers (e.g. distribution constructors) receive the expected type.
     spec[!, :dist_params] = Tuple.(spec.dist_params)
+    spec[!, :default_dist_params] = Tuple.(spec.default_dist_params)
 
     DataFrames.hcat!(
         spec,
         DataFrame(
-            :lower_bound => factor_lower_bounds.(eachrow(spec)),
-            :upper_bound => factor_upper_bounds.(eachrow(spec))
+            :lower_bound => distribution_lower_bound.(spec.dist, spec.dist_params),
+            :upper_bound => distribution_upper_bound.(spec.dist, spec.dist_params)
         )
     )
 

--- a/ADRIA/src/decision/location_selection.jl
+++ b/ADRIA/src/decision/location_selection.jl
@@ -144,7 +144,7 @@ function rank_locations(
             @warn "No valid fogging locations found for scenario $(scen_idx)"
         end
 
-        MCDA_approach = mcda_methods()[Int64(scen[factors = At("guided")][1])]
+        MCDA_approach = mcda_methods()[Int64(scen[factors = At("mcda_method")][1])]
 
         seed_pref = SeedPreferences(dom, scen)
         fog_pref = FogPreferences(dom, scen)

--- a/ADRIA/src/factors/Factors.jl
+++ b/ADRIA/src/factors/Factors.jl
@@ -142,13 +142,6 @@ function distribution_upper_bound(
     return getindex(dist_params, 2)
 end
 
-function factor_lower_bounds(factor::DataFrameRow)::Float64
-    return distribution_lower_bound(factor.dist, factor.dist_params)
-end
-function factor_upper_bounds(factor::DataFrameRow)::Float64
-    return distribution_upper_bound(factor.dist, factor.dist_params)
-end
-
 function _set_factor_defaults(kwargs::NT) where {NT<:NamedTuple}
     missing_defaults = (; default_dist_params=kwargs.dist_params)
 

--- a/ADRIA/src/interventions/Interventions.jl
+++ b/ADRIA/src/interventions/Interventions.jl
@@ -3,11 +3,19 @@ Base.@kwdef struct Intervention <: EcoModel
     # Bounds are defined as floats to maintain type stability
     guided::Param = Factor(
         0;
+        ptype="ordered categorical",
+        dist=CategoricalDistribution,
+        dist_params=(-1.0, 0.0, 1.0),
+        name="Guided",
+        description="Intervention effort level: -1 no intervention (counterfactual), 0 unguided, 1 guided (MCDA-driven)."
+    )
+    mcda_method::Param = Factor(
+        1;
         ptype="unordered categorical",
         dist=CategoricalDistribution,
-        dist_params=(Tuple(-1:Float64(length(decision.mcda_methods())))),
-        name="Guided",
-        description="Choice of MCDA approach."
+        dist_params=(Tuple(1:Float64(length(decision.mcda_methods())))),
+        name="MCDA Method",
+        description="Which multi-criteria decision analysis method to use for location selection (only active when `guided` > 0)."
     )
     N_seed_TA::Param = Factor(
         0;

--- a/ADRIA/src/io/sampling/sampling.jl
+++ b/ADRIA/src/io/sampling/sampling.jl
@@ -20,6 +20,7 @@ include("sampling_unguided.jl")
 include("sampling_guided.jl")
 include("sampling_interventions.jl")
 include("sampling_balanced.jl")
+include("sampling_stratified.jl")
 
 const DISCRETE_FACTOR_TYPES = [
     "ordered categorical", "unordered categorical", "ordered discrete"

--- a/ADRIA/src/io/sampling/sampling.jl
+++ b/ADRIA/src/io/sampling/sampling.jl
@@ -12,6 +12,8 @@ import QuasiMonteCarlo: SobolSample, OwenScramble
 using ADRIA: model_spec, component_params
 using .decision: mcda_normalize
 
+include("sampling_dependencies.jl")
+include("sampling_transforms.jl")
 include("sampling_interface.jl")
 include("sampling_cf.jl")
 include("sampling_unguided.jl")
@@ -135,8 +137,8 @@ function sample(
     samples[:, const_mask] .= Float64.(spec.val[const_mask])'
     samples[:, vary_mask] .= samples_tmp
 
-    # Ensure unguided scenarios do not have superfluous factor combinations
-    return adjust_samples(spec, DataFrame(samples, spec.fieldname))
+    # Apply post-sampling reparameterisation and conditional zeroing
+    return _apply_transforms!(spec, DataFrame(samples, spec.fieldname))
 end
 
 """
@@ -170,6 +172,9 @@ function sample_selection(
 
     # Only sample guided intervention scenarios
     _adjust_guided_lower_bound!(subset_spec, 1)
+
+    # Pre-sampling resolution for guided regime (top-split only)
+    _resolve_conditional_spec!(subset_spec, (guided=1.0,))
 
     # Create and fill scenario spec
     # Only Intervention, EnvironmentalLayer and CriteriaWeights factors are perturbed,

--- a/ADRIA/src/io/sampling/sampling_cf.jl
+++ b/ADRIA/src/io/sampling/sampling_cf.jl
@@ -17,13 +17,14 @@ function sample_cf(
     cb_calib_groups::Vector{Int64} = d.loc_data.CB_CALIB_GROUPS
     spec_df = _filtered_model_spec(model_spec(d), cb_calib_groups)
 
-    # Unguided scenarios only
+    # Counterfactual scenarios only
     guided_col = spec_df.fieldname .== :guided
     spec_df[guided_col, [:val, :lower_bound, :upper_bound, :dist_params, :is_constant]] .=
         [-1 -1 -1 (-1.0, -1.0) true]
 
-    # Remove intervention scenarios as an option
-    deactivate_interventions(spec_df)
+    # Pre-sampling resolution: fix all intervention/strategy/criteria columns
+    # to their CF constants. Supersedes the old deactivate_interventions call.
+    _resolve_conditional_spec!(spec_df, (guided=-1.0,))
 
     return sample(spec_df, n, sample_method)
 end

--- a/ADRIA/src/io/sampling/sampling_dependencies.jl
+++ b/ADRIA/src/io/sampling/sampling_dependencies.jl
@@ -1,0 +1,377 @@
+# sampling_dependencies.jl
+#
+# Many sampled parameters are only meaningful under certain scenario settings
+# (e.g. seeding/fogging deployment parameters only matter when an intervention
+# is actually enabled, and decision-strategy weights only matter under
+# :guided). Sampling every parameter unconditionally wastes sample budget on
+# combinations that don't affect model output and dilutes sensitivity/PAWN
+# analyses with dead dimensions.
+#
+# This file defines a declarative parent→child dependency table
+# (_PARAM_DEPENDENCIES) plus resolution logic that, given a known top-level
+# setting (e.g. `guided`), fixes every dependent parameter that is rendered
+# inactive to a constant value before sampling — rather than sampling it and
+# discarding the result. Parameter groups (_GROUP_MEMBERS) let a single rule
+# fix many physical spec columns at once.
+#
+# Only rows whose parent is :guided can fire here, since that is the only
+# value known at pre-sampling resolve time. Dependencies on other settings are
+# resolved later in sampling_transforms.jl.
+
+using ADRIA.decision: is_reactive, DECISION_STRATEGY
+
+# ---------------------------------------------------------------------------
+# Op registry (scalar conditions only; broadcast use is in
+# sampling_transforms.jl)
+# ---------------------------------------------------------------------------
+
+const _CONDITIONS = Dict{Symbol,Function}(
+    :gt => (x, t) -> x > t,
+    :lt => (x, t) -> x < t,
+    :ge => (x, t) -> x >= t,
+    :le => (x, t) -> x <= t,
+    :eq => (x, t) -> x == t,
+    :neq => (x, t) -> x != t,
+    :is_reactive => (x, _) -> is_reactive(x),
+    :is_periodic => (x, _) -> x == DECISION_STRATEGY[:periodic]
+)
+
+# ---------------------------------------------------------------------------
+# Dependency table. Rows with a parent other than :guided are structurally
+# unreachable at pre-sampling resolve time; they are handled post-sampling in
+# sampling_transforms.jl instead.
+#
+# Both :strategy_group rows use negate=false. The CF row's fix_to is -1.0,
+# not 0.0, to distinguish it from the :intervention_group columns (see
+# _GROUP_MEMBERS below).
+#
+# Each row is a NamedTuple with fields:
+#   parent  — spec column whose (known) value the condition is evaluated against
+#   child   — spec column, or a key into _GROUP_MEMBERS, to fix when inactive
+#   op      — key into _CONDITIONS; op(parent_value, value) determines whether
+#             the child is considered "active"
+#   value   — threshold/comparison value passed to `op`
+#   negate  — if true, invert the boolean result of `op(parent_value, value)`
+#             before it is used as the activity check. Needed when the
+#             natural predicate is stated as the INACTIVE condition rather
+#             than the active one — e.g. :strategy_group's CF row wants
+#             "active unless guided == -1", which is `op=:neq` on -1.0
+#             directly (negate=false); but if a rule were instead phrased as
+#             "inactive when guided == -1", you'd write `op=:eq, value=-1.0,
+#             negate=true` to get the same activity result.
+#   fix_to  — constant the child is fixed to when NOT active
+#
+# Rows are grouped by parent (all rows here have parent=:guided — see note
+# above on why other parents are structurally unreachable at this stage).
+#
+# To add a new rule:
+#   1. If it depends on `guided` and is knowable pre-sampling, add a row here.
+#      Otherwise it belongs in sampling_transforms.jl instead.
+#   2. If `child` covers more than one physical spec column, add an entry to
+#      _GROUP_MEMBERS mapping the child name to those column names.
+#   3. Run `_validate_dependencies` (called from the sampling entry point) to
+#      catch unknown parents/ops/children, cycles, and conflicting fix_to
+#      values on shared columns.
+#
+# e.g. if :my_param only matters under a guided strategy, it should be
+# fixed to 0.0 for every other regime (CF, unguided). That is:
+# Example — fix :my_param to 0.0 whenever guided <= 0 (i.e. not guided):
+#   (parent=:guided, child=:my_param, op=:gt, value=0.0, negate=false, fix_to=0.0)
+# ---------------------------------------------------------------------------
+
+const _PARAM_DEPENDENCIES = [
+    # parent=:guided
+    (
+        parent=:guided,
+        child=:intervention_group,
+        op=:neq,
+        value=-1.0,
+        negate=false,
+        fix_to=0.0
+    ),
+    (parent=:guided, child=:criteria_weights, op=:gt, value=0.0, negate=false, fix_to=0.0),
+    # mcda_method is only meaningful in the guided regime (guided > 0); fix_to=0.0
+    # is a sentinel meaning "no MCDA method selected", never a valid method index,
+    # since decision.mcda_methods() is indexed from 1.
+    (parent=:guided, child=:mcda_method, op=:gt, value=0.0, negate=false, fix_to=0.0),
+    (parent=:guided, child=:plan_horizon, op=:neq, value=0.0, negate=false, fix_to=0.0),
+    (
+        parent=:guided,
+        child=:depth_thresholds,
+        op=:neq,
+        value=-1.0,
+        negate=false,
+        fix_to=0.0
+    ),
+    (parent=:guided, child=:strategy_group, op=:neq, value=-1.0, negate=false, fix_to=-1.0),
+    (
+        parent=:guided,
+        child=:strategy_group,
+        op=:gt,
+        value=0.0,
+        negate=false,
+        fix_to=DECISION_STRATEGY[:periodic]
+    )
+]
+
+# ---------------------------------------------------------------------------
+# Group membership (explicit Dict; pre-sampling groups only)
+#
+# :seed_strategy/:fog_strategy/:mc_strategy appear ONLY in :strategy_group,
+# not in :intervention_group. :strategy_group fixes them to -1.0 for CF and
+# to DECISION_STRATEGY[:periodic] for unguided; including them in
+# :intervention_group (fix_to=0.0) would produce a conflicting fix_to for the
+# same column in _fix_child!.
+#
+# Possible improvement: _GROUP_MEMBERS is a hand-maintained list of column
+# names per group. If the model spec's own component definitions (the same
+# ones used with component_params in sampling_transforms.jl) already encode
+# equivalent groupings, deriving these entries from those component
+# definitions instead of hand-maintaining them here would remove a source of
+# drift between the two representations.
+# ---------------------------------------------------------------------------
+
+const _GROUP_MEMBERS = Dict{Symbol,Vector{Symbol}}(
+    :intervention_group => [
+        :N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM,
+        :N_mc_settlers, :seeding_devices_per_m2, :min_iv_locations,
+        :mc_min_iv_locations, :fogging, :SRM, :a_adapt, :a_adapt_ref,
+        :seed_years, :shade_years, :fog_years, :plan_horizon,
+        :seed_deployment_freq, :fog_deployment_freq, :shade_deployment_freq,
+        :mc_deployment_freq, :seed_year_start, :shade_year_start,
+        :fog_year_start, :mc_year_start, :mc_years,
+        :mcb_albedo, :mcb_duration, :mcb_deployment_freq,
+        # NOTE: :seed_strategy/:fog_strategy/:mc_strategy are intentionally
+        # excluded here — they belong exclusively to :strategy_group (see above).
+        :reactive_absolute_threshold, :reactive_loss_threshold,
+        :reactive_min_cover_remaining, :reactive_response_delay,
+        :reactive_cooldown_period
+    ],
+    :criteria_weights => [
+        :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,
+        :seed_out_connectivity, :seed_depth, :seed_coral_cover,
+        :seed_cluster_diversity, :seed_geographic_separation,
+        :fog_heat_stress, :fog_wave_stress, :fog_in_connectivity,
+        :fog_out_connectivity, :fog_depth, :fog_coral_cover,
+        :fog_cluster_diversity, :fog_geographic_separation,
+        :mc_heat_stress, :mc_wave_stress, :mc_in_connectivity,
+        :mc_out_connectivity, :mc_depth, :mc_coral_cover,
+        :mc_cluster_diversity, :mc_geographic_separation
+    ], :depth_thresholds => [:depth_min, :depth_offset],
+    :strategy_group => [:seed_strategy, :fog_strategy, :mc_strategy]
+)
+
+# ---------------------------------------------------------------------------
+# _fix_child!  (no-op if already fixed, to the same value or a caller-chosen one)
+# ---------------------------------------------------------------------------
+
+"""
+    _fix_child!(spec::DataFrame, child::Symbol, fix_to::Real)::Nothing
+
+Fix a spec column (or all members of a named group) to `fix_to` as a constant.
+
+- No-op if the column is already `is_constant=true` with a value `isequal` to `fix_to`.
+- Also a no-op (with a `@debug` note) if the column is already `is_constant=true` with a
+  *different* value — `fix_to` here is a dead-dimension sentinel (the column doesn't
+  matter under the current regime), and a column the caller already fixed via
+  `fix_factor!`/`set_factor_bounds!` has already achieved that "no longer varies" goal,
+  just to a real value instead of the sentinel. Genuine rule-vs-rule disagreements
+  (two `_PARAM_DEPENDENCIES` rows wanting different fix_to values for the same column)
+  are caught statically by `_validate_dependencies`, not here.
+- Otherwise sets `is_constant=true`, `val`, `lower_bound`, `upper_bound` to `fix_to`,
+  and `dist_params` to a same-length tuple filled with `fix_to`.
+
+Columns absent from `spec` (e.g. domain-filtered fields) are silently skipped.
+"""
+function _fix_child!(spec::DataFrame, child::Symbol, fix_to::Real)::Nothing
+    physical_cols = get(_GROUP_MEMBERS, child, [child])
+    for col in physical_cols
+        row_mask = spec.fieldname .== col
+        any(row_mask) || continue
+        is_const = spec[row_mask, :is_constant][1]
+        cur_val = spec[row_mask, :val][1]
+        if is_const
+            if !isequal(cur_val, fix_to)
+                @debug "Column :$col is already fixed to $cur_val; leaving as-is " *
+                    "instead of overwriting with dependency sentinel $fix_to"
+            end
+            continue
+        end
+        existing_dp = spec[row_mask, :dist_params][1]
+        new_dp = Tuple(fill(Float64(fix_to), length(existing_dp)))
+        spec[row_mask, :val] .= Float64(fix_to)
+        spec[row_mask, :lower_bound] .= Float64(fix_to)
+        spec[row_mask, :upper_bound] .= Float64(fix_to)
+        spec[row_mask, :dist_params] .= [new_dp]
+        spec[row_mask, :is_constant] .= true
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# Fixed-point resolution loop (gate-free; only parent→child edges)
+# ---------------------------------------------------------------------------
+
+"""
+    _resolve_conditional_spec!(spec::DataFrame, fixed::NamedTuple)::DataFrame
+
+Pre-sampling conditional spec resolution.
+
+Fix spec columns/groups whose activation condition can be determined from `fixed`
+(typically `(guided=value,)` for one of CF/unguided/guided). Runs a fixed-point
+loop until no new rules fire. Rules whose parent is not in `fixed` are silently
+skipped — they belong to the post-sampling `_apply_transforms!` step.
+
+# Example
+Called once per scenario regime, before sampling, with the known top-level
+`guided` value; every parameter rendered inactive under that regime is fixed
+to a constant so it is never sampled.
+```julia
+_resolve_conditional_spec!(spec, (guided=-1.0,))  # counterfactual
+_resolve_conditional_spec!(spec, (guided=0.0,))   # unguided
+_resolve_conditional_spec!(spec, (guided=1.0,))   # guided (top-split only)
+```
+"""
+function _resolve_conditional_spec!(spec::DataFrame, fixed::NamedTuple)::DataFrame
+    known = Dict{Symbol,Any}(pairs(fixed))
+    changed = true
+    while changed
+        changed = false
+        for rule in _PARAM_DEPENDENCIES
+            haskey(known, rule.child) && continue
+            haskey(known, rule.parent) || continue
+            active = _CONDITIONS[rule.op](known[rule.parent], rule.value)
+            rule.negate && (active = !active)
+            if !active
+                _fix_child!(spec, rule.child, rule.fix_to)
+                known[rule.child] = rule.fix_to
+                changed = true
+            end
+        end
+    end
+    return spec
+end
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+"""
+    _check_dependency_acyclic(rules)::Nothing
+
+Check that the parent→child edges in `rules` form a DAG. Errors if a cycle is found.
+"""
+function _check_dependency_acyclic(rules)::Nothing
+    adj = Dict{Symbol,Vector{Symbol}}()
+    for rule in rules
+        push!(get!(adj, rule.parent, Symbol[]), rule.child)
+    end
+
+    colors = Dict{Symbol,Int}()  # 0=unvisited, 1=in-stack, 2=done
+
+    function dfs(node)
+        get(colors, node, 0) == 2 && return nothing
+        if get(colors, node, 0) == 1
+            throw(ArgumentError("Cycle detected in _PARAM_DEPENDENCIES involving :$node"))
+        end
+        colors[node] = 1
+        for child in get(adj, node, Symbol[])
+            dfs(child)
+        end
+        colors[node] = 2
+    end
+
+    all_nodes = unique(
+        vcat(Symbol[r.parent for r in rules], Symbol[r.child for r in rules])
+    )
+    for node in all_nodes
+        get(colors, node, 0) == 0 && dfs(node)
+    end
+    return nothing
+end
+
+"""
+    _validate_dependencies(spec::DataFrame)::Nothing
+
+Validate `_PARAM_DEPENDENCIES` and `_GROUP_MEMBERS` against `spec`.
+
+Checks:
+- Every rule's parent is a known spec column.
+- Every rule uses a registered op from `_CONDITIONS`.
+- Every rule's child is either a spec column or a defined group name.
+- The parent→child graph is acyclic.
+- No two rules fix the same physical column to *different* values; same-value
+  overlaps are permitted (no-op branch).
+"""
+function _validate_dependencies(spec::DataFrame)::Nothing
+    # spec_cols = set of parameter field names (rows of spec), not the DataFrame's column names
+    spec_cols = Set(spec.fieldname)
+
+    for rule in _PARAM_DEPENDENCIES
+        rule.parent in spec_cols ||
+            throw(
+                ArgumentError(
+                    "Dependency rule for :$(rule.child) references unknown parent " *
+                    ":$(rule.parent)"
+                )
+            )
+        haskey(_CONDITIONS, rule.op) ||
+            throw(
+                ArgumentError(
+                    "Dependency rule for :$(rule.child) uses unknown op :$(rule.op)"
+                )
+            )
+        rule.child in spec_cols || rule.child in keys(_GROUP_MEMBERS) ||
+            throw(
+                ArgumentError(
+                    "Dependency rule references unknown child :$(rule.child) " *
+                    "(not a spec column or a defined group name)"
+                )
+            )
+    end
+
+    _check_dependency_acyclic(_PARAM_DEPENDENCIES)
+
+    # Duplicate-child detection on expanded physical columns.
+    # Rows with the SAME child symbol are guarded by the `haskey(known, rule.child)`
+    # check in _resolve_conditional_spec! — only one can fire per call, so different
+    # fix_to values are permitted (they represent mutually-exclusive regimes, e.g. the
+    # two :strategy_group rows for CF and unguided).
+    # Only flag when DIFFERENT child symbols expand to the same physical column with
+    # disagreeing fix_to values — those lack the haskey guard and are genuine conflicts.
+    column_owners = Dict{Symbol,Vector{Any}}()
+    for rule in _PARAM_DEPENDENCIES
+        cols = get(_GROUP_MEMBERS, rule.child, [rule.child])
+        for c in cols
+            push!(get!(column_owners, c, []), (rule.child, rule.fix_to))
+        end
+    end
+    for (col, owners) in column_owners
+        length(owners) <= 1 && continue
+        # Group by child symbol; only check cross-child conflicts
+        by_child = Dict{Symbol,Set}()
+        for (child_sym, ft) in owners
+            push!(get!(by_child, child_sym, Set()), ft)
+        end
+        child_syms = collect(keys(by_child))
+        length(child_syms) <= 1 && continue   # all from the same child — guarded, skip
+        # Multiple different child symbols touch this column — check they agree
+        fix_tos = [only(fts) for fts in values(by_child) if length(fts) == 1]
+        length(fix_tos) == length(by_child) ||
+            throw(
+                ArgumentError(
+                    "Column :$col is fixed by multiple child symbols, " *
+                    "some of which have ambiguous fix_to values"
+                )
+            )
+        length(unique(isequal, fix_tos)) == 1 ||
+            throw(
+                ArgumentError(
+                    "Column :$col is targeted by rules with different child symbols " *
+                    "($(child_syms)) and disagreeing fix_to values: $(fix_tos)"
+                )
+            )
+    end
+
+    return nothing
+end

--- a/ADRIA/src/io/sampling/sampling_guided.jl
+++ b/ADRIA/src/io/sampling/sampling_guided.jl
@@ -24,5 +24,9 @@ function sample_guided(
         spec_df[!, :is_constant] .= spec_df[!, :lower_bound] .== spec_df[!, :upper_bound]
     end
 
+    # Pre-sampling resolution: top-level guided split only (within-guided
+    # dependencies remain in _apply_transforms! as they require sampled values)
+    _resolve_conditional_spec!(spec_df, (guided=1.0,))
+
     return sample(spec_df, n, sample_method)
 end

--- a/ADRIA/src/io/sampling/sampling_interface.jl
+++ b/ADRIA/src/io/sampling/sampling_interface.jl
@@ -9,9 +9,20 @@ function _adjust_guided_lower_bound!(spec_df::DataFrame, lower::Int64)::DataFram
     guided_col = spec_df.fieldname .== :guided
     g_upper = Float64(spec_df[guided_col, :upper_bound][1])
 
+    # `guided` is a CategoricalDistribution, so dist_params are explicit category
+    # values, not a continuous range -- CategoricalDistribution errors on duplicate
+    # category values. Since the guided/mcda_method split narrowed `guided` to
+    # {-1,0,1}, `lower` and `g_upper` now coincide when restricting to the
+    # guided-only regime (lower=1, g_upper=1). Mark the row constant in that case
+    # so `sample()` never constructs a CategoricalDistribution for it at all (constant
+    # rows are filtered out before `_build_dist_types` and use `:val` directly);
+    # the `dist_params` column still requires >=2 elements, so it's left as the
+    # (possibly-duplicate) 2-tuple, which is harmless once the row is constant.
+    is_const = lower == g_upper
+
     # Update entries, standardizing values for bounds as floats
-    spec_df[guided_col, [:val, :lower_bound, :dist_params]] .=
-        [lower Float64(lower) (Float64(lower), g_upper)]
+    spec_df[guided_col, [:val, :lower_bound, :dist_params, :is_constant]] .=
+        [lower Float64(lower) (Float64(lower), g_upper) is_const]
 
     return spec_df
 end
@@ -94,7 +105,7 @@ end
 """
     _update_decision_method!(dom, new_dist_params::Tuple)::Domain
 
-Update the model spec with the tuple of MCDA methods to use.
+Update the model spec `mcda_method` factor with the tuple of MCDA methods to use.
 
 Converts named MCDA methods to known IDs.
 The nominal default is set to the first MCDA method provided.
@@ -105,12 +116,14 @@ function _update_decision_method!(dom, new_dist_params::Tuple)::Domain
     new_method_idxs = decision.decision_method_encoding.(new_method_names)
 
     ms = model_spec(dom)
-    guided_row = findfirst(ms.fieldname .== :guided)
-    @assert !isnothing(guided_row) "Guided variable not found in model spec."
+    mcda_method_row = findfirst(ms.fieldname .== :mcda_method)
+    @assert !isnothing(mcda_method_row) "mcda_method variable not found in model spec."
 
-    ms[guided_row, :dist_params] = Tuple(new_method_idxs)
-    ms[guided_row, :val] = first(new_method_idxs)
-    ms[guided_row, :is_constant] = length(new_method_idxs) == 1
+    dp = Float64.(new_method_idxs)
+    length(dp) == 1 && (dp = [dp[1], dp[1]])
+    ms[mcda_method_row, :dist_params] = Tuple(dp)
+    ms[mcda_method_row, :val] = first(new_method_idxs)
+    ms[mcda_method_row, :is_constant] = length(new_method_idxs) == 1
     update!(dom, ms)
 
     return dom
@@ -164,13 +177,16 @@ Note: Changes are permanent. To reset, either specify the original value(s)
 fix_factor!(dom, :guided)
 
 # Fix `guided` to specified value
-fix_factor!(dom, :guided, 3)
+fix_factor!(dom, :guided, 1)
+
+# Fix `mcda_method` to a specific MCDA method (only relevant when `guided > 0`)
+fix_factor!(dom, :mcda_method, 3)
 
 # Fix a set of factors to their default values
 fix_factor!(dom, [:guided, :N_seed_TA])
 
 # Fix specified factors to provided values
-fix_factor!(dom; guided=3, N_seed_TA=1e6)
+fix_factor!(dom; guided=1, N_seed_TA=1e6)
 ```
 """
 function fix_factor!(d::Domain, factor::Symbol)::Nothing
@@ -216,7 +232,8 @@ function fix_factor!(d::Domain; factors...)::Nothing
 
     params = model_spec(d)
 
-    target_order = vcat([findall(x -> x == y, params.fieldname) for y in factor_names]...)
+    # target_order = vcat([findall(x -> x == y, params.fieldname) for y in factor_names]...)
+    target_order = indexin(collect(factor_names), params.fieldname)
     params[target_order, :val] .= factor_vals
 
     dist_params = params[target_order, :dist_params]
@@ -279,124 +296,12 @@ function get_bounds(param::Param)::NTuple{2,Float64}
     return param.dist_params[1:2]
 end
 
-"""
-    adjust_samples(dom::Domain, samples::DataFrame)::DataFrame
-    adjust_samples!(spec::DataFrame, samples::DataFrame)::DataFrame
-
-Adjust given samples to ensure parameter value combinations for unguided
-scenarios are plausible.
-"""
-function adjust_samples(dom::Domain, samples::DataFrame)::DataFrame
-    return adjust_samples(model_spec(dom), samples)
-end
-function adjust_samples(spec::DataFrame, samples::DataFrame)::DataFrame
-    samples[:, :a_adapt_ref] .= floor.(samples[:, :a_adapt_ref])
-
-    interv = component_params(spec, Intervention)
-    seed_weights = component_params(spec, SeedCriteriaWeights)
-    fog_weights = component_params(spec, FogCriteriaWeights)
-    mc_weights = component_params(spec, MCCriteriaWeights)
-    depth_offsets = component_params(spec, DepthThresholds)
-
-    counterfactual_mask = (samples.guided .== -1.0)
-    unguided_mask = (samples.guided .== 0.0)
-
-    # If counterfactual, set all intervention options to 0.0
-    samples[
-        counterfactual_mask, filter(x -> x ∉ [:guided, :heritability], interv.fieldname)
-    ] .=
-        0.0
-
-    # Treat weight parameters as Gamma quantiles and transform so they sum to 1
-    guided_mask = samples.guided .> 0
-    if any(guided_mask)
-        for wf in (seed_weights.fieldname, fog_weights.fieldname, mc_weights.fieldname)
-            samples[guided_mask, wf] .= gamma_to_dirichlet(Matrix(samples[guided_mask, wf]))
-        end
-    end
-
-    # Collect MCDA weight parameters
-    non_depth_names = vcat(
-        seed_weights.fieldname,
-        fog_weights.fieldname,
-        mc_weights.fieldname
-    )
-
-    # If unguided/counterfactual, set all preference criteria, except those related to depth, to 0.
-    samples[samples.guided .<= 0.0, non_depth_names] .= 0.0  # Turn off weights for unguided and cf
-    samples[counterfactual_mask, depth_offsets.fieldname] .= 0.0  # No depth offsets for cf
-
-    # Also deactivate strategy parameters for counterfactuals and unguided
-    (samples[unguided_mask, [:seed_strategy, :fog_strategy, :mc_strategy]]) .= DECISION_STRATEGY[:periodic]
-    samples[counterfactual_mask, [:seed_strategy, :fog_strategy, :mc_strategy]] .= -1.0
-
-    # If unguided, set planning horizon to 0.
-    samples[unguided_mask, :plan_horizon] .= 0.0
-
-    # If no seeding is to occur, set related variables to 0
-    not_seeded::BitVector = no_seeding(samples)
-    samples[not_seeded, contains.(names(samples), "seed_")] .= 0.0
-    samples[not_seeded, :a_adapt] .= 0.0
-
-    # Same for fogging/shading
-    not_fogged = (samples.fogging .== 0)
-    samples[not_fogged, contains.(names(samples), "fog_")] .= 0.0
-
-    # # Same for moving corals
-    not_moving_corals = (samples.N_mc_settlers .== 0)
-    samples[not_moving_corals, contains.(names(samples), "mc_")] .= 0.0
-
-    not_shaded = (samples.SRM .== 0)
-    samples[not_shaded, contains.(names(samples), "shade_")] .= 0.0
-
-    # Reactive
-    not_reactive =
-        .!is_reactive(samples.seed_strategy) .&
-        .!is_reactive(samples.fog_strategy) .&
-        .!is_reactive(samples.mc_strategy)
-    reactive_params = [
-        :reactive_absolute_threshold,
-        :reactive_loss_threshold,
-        :reactive_min_cover_remaining,
-        :reactive_response_delay,
-        :reactive_cooldown_period
-    ]
-    samples[not_reactive, reactive_params] .= 0.0
-
-    # Deactivate periodic parameters when reactive strategy is in place
-    samples[is_reactive(samples.seed_strategy), [:seed_deployment_freq]] .= 0.0
-    samples[is_reactive(samples.mc_strategy), [:mc_deployment_freq]] .= 0.0
-
-    not_periodic_fog = (samples.fog_strategy .!= 1)
-    samples[not_periodic_fog, [:fog_deployment_freq]] .= 0.0
-
-    # Normalize MCDA weights for fogging scenarios
-    guided_fogged = (samples.fogging .> 0.0) .& (samples.guided .> 0)
-    samples[guided_fogged, fog_weights.fieldname] .= mcda_normalize(
-        samples[guided_fogged, fog_weights.fieldname]
-    )
-    # Normalize MCDA weights for seeding scenarios
-    guided_seeded = .!(not_seeded) .& (samples.guided .> 0)
-    samples[guided_seeded, seed_weights.fieldname] .= mcda_normalize(
-        samples[guided_seeded, seed_weights.fieldname]
-    )
-    # Normalize MCDA weights for mc scenarios
-    guided_mc = .!(not_moving_corals) .& (samples.guided .> 0)
-    samples[guided_mc, mc_weights.fieldname] .= mcda_normalize(
-        samples[guided_mc, mc_weights.fieldname]
-    )
-
-    # Disable wave decisions if no wave stress is used
-    no_wave_scenario = samples.wave_scenario .== 0.0
-    samples[no_wave_scenario, :seed_wave_stress] .= 0.0
-
-    if size(unique(Matrix(samples); dims=1), 1) < nrow(samples)
-        perc = "$(@sprintf("%.3f", (1.0 - (nrow(unique(samples)) / nrow(samples))) * 100.0))%"
-        @warn "Non-unique samples created: $perc of the samples are duplicates."
-    end
-
-    return samples
-end
+@deprecate adjust_samples(dom::Domain, samples::DataFrame) _apply_transforms!(
+    model_spec(dom), samples
+)
+@deprecate adjust_samples(spec::DataFrame, samples::DataFrame) _apply_transforms!(
+    spec, samples
+)
 
 """
     get_default_bounds(dom::Domain, factor::Symbol)::NTuple{2,Float64}
@@ -451,7 +356,7 @@ function set_factor_bounds(dom::Domain, factor::Symbol, new_dist_params::Tuple):
     return dom
 end
 function set_factor_bounds!(dom::Domain, factor::Symbol, new_dist_params::Tuple)::Domain
-    if factor == :guided
+    if factor == :mcda_method
         return _update_decision_method!(dom, new_dist_params)
     end
 
@@ -483,11 +388,11 @@ function set_factor_bounds!(dom::Domain; factors...)::Domain
     factor_symbols = collect(keys(factors))
     new_params = collect(values(factors))
 
-    # Handle categorical guided factor separately
+    # Handle categorical mcda_method factor separately
     # Converts named MCDA methods to known IDs.
     # The nominal default is set to the first MCDA method provided.
-    if :guided in factor_symbols
-        factor_idx::Int64 = findfirst(factor_symbols .== :guided)
+    if :mcda_method in factor_symbols
+        factor_idx::Int64 = findfirst(factor_symbols .== :mcda_method)
         dom = _update_decision_method!(dom, new_params[factor_idx])
 
         keep_idx = 1:length(factor_symbols) .!= factor_idx
@@ -498,7 +403,7 @@ function set_factor_bounds!(dom::Domain; factors...)::Domain
     ms = model_spec(dom)
     for (i, fn) in enumerate(factor_symbols)
         idx = findfirst(ms.fieldname .== fn)
-        ms[idx, :dist_params] = new_params[i]
+        ms[idx, :dist_params] = Tuple(new_params[i])
 
         lb = new_params[i][1]
         ub = new_params[i][2]

--- a/ADRIA/src/io/sampling/sampling_interventions.jl
+++ b/ADRIA/src/io/sampling/sampling_interventions.jl
@@ -26,9 +26,11 @@ function sample_set(d::Domain, n::Int64, rcp::String)::DataFrame
 
     dhw_scens = [rand(findall(clusters .== c)) for c in unique(clusters)]
 
+    # `guided`'s default bounds already span -1..1 (counterfactual/unguided/guided),
+    # so only `mcda_method` needs constraining to a single method here.
     ADRIA.set_factor_bounds!(
         d;
-        guided=("counterfactual", "unguided", "COCOSO"),
+        mcda_method=("COCOSO",),
         dhw_scenario=Tuple(dhw_scens)
     )
 
@@ -66,4 +68,265 @@ function sample_set(d::Domain, n::Int64, rcp::String)::DataFrame
     scenarios = ADRIA.sample(d, n)
 
     return scenarios
+end
+
+"""
+    _derive_regime(samples::DataFrame, guided_value::Float64)::DataFrame
+
+Produce scenario rows paired to `samples` under a fixed `guided` regime, by setting
+`:guided` to `guided_value` and fixing every column that `_PARAM_DEPENDENCIES` renders
+inactive under that value.
+
+Non-intervention parameter columns (and any columns still active under the given regime)
+are left unchanged, enabling causal attribution by differencing outcomes between paired
+rows.
+
+Shared by `derive_cf` (`guided_value=-1.0`) and `derive_unguided` (`guided_value=0.0`) so
+both regimes stay consistent with the same dependency table used pre-sampling by
+`sample_guided`/`sample_unguided`/`sample_cf`.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `guided_value` : the `:guided` sentinel for the target regime (-1.0 CF, 0.0 unguided).
+
+# Returns
+Scenario rows for the target regime, paired 1:1 with `samples`.
+"""
+function _derive_regime(samples::DataFrame, guided_value::Float64)::DataFrame
+    regime = copy(samples)
+    regime[!, :guided] .= guided_value
+
+    # Mirrors the `haskey(known, rule.child)` guard in _resolve_conditional_spec!:
+    # the two :strategy_group rows both evaluate "inactive" under guided=-1.0, and
+    # without this guard the second (fix_to=PERIODIC) would overwrite the first
+    # (fix_to=-1.0 CF sentinel) applied to the same columns.
+    fixed_children = Set{Symbol}()
+    for dep in _PARAM_DEPENDENCIES
+        dep.child in fixed_children && continue
+
+        active = _CONDITIONS[dep.op](guided_value, dep.value)
+        dep.negate && (active = !active)
+        active && continue  # only fix rows where this dep is inactive under this regime
+
+        cols =
+            dep.child in propertynames(regime) ?
+            [dep.child] :
+            get(_GROUP_MEMBERS, dep.child, Symbol[])
+        for col in cols
+            col in propertynames(regime) && (regime[!, col] .= dep.fix_to)
+        end
+        push!(fixed_children, dep.child)
+    end
+
+    return regime
+end
+
+"""
+    derive_cf(samples::DataFrame, spec::DataFrame)::DataFrame
+
+Produce counterfactual-regime rows paired to `samples` by zeroing all columns
+that are inactive under guided = -1.0, using the pre-sampling dependency tables.
+
+Non-intervention parameter columns are left unchanged, enabling causal attribution
+by differencing outcomes between paired rows.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `spec` : model spec for the same domain (output of `model_spec(d)`).
+  Currently unused — the dependency tables are module-level constants — but retained
+  for forward-compatibility with domain-specific dependency overrides.
+
+# Returns
+Counterfactual-regime scenario rows paired 1:1 with `samples`.
+"""
+function derive_cf(samples::DataFrame, spec::DataFrame)::DataFrame
+    return _derive_regime(samples, -1.0)
+end
+
+"""
+    derive_unguided(samples::DataFrame, spec::DataFrame)::DataFrame
+
+Produce unguided-regime rows paired to `samples` by fixing all columns that are inactive
+under guided = 0.0, using the pre-sampling dependency tables.
+
+Unlike the counterfactual regime, intervention deployment amounts (`:intervention_group`)
+and `:depth_thresholds` remain **active** (unchanged) under guided = 0.0 — unguided
+scenarios still deploy interventions, just without MCDA-driven site selection. Only
+`:criteria_weights` and `:plan_horizon` are zeroed, and `:strategy_group` columns
+(`seed_strategy`/`fog_strategy`/`mc_strategy`) are fixed to `DECISION_STRATEGY[:periodic]`
+— mirroring what `sample_unguided`'s pre-sampling `_resolve_conditional_spec!(spec,
+(guided=0.0,))` does.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `spec` : model spec for the same domain (output of `model_spec(d)`).
+  Currently unused — the dependency tables are module-level constants — but retained
+  for forward-compatibility with domain-specific dependency overrides.
+
+# Returns
+Unguided-regime scenario rows paired 1:1 with `samples`.
+"""
+function derive_unguided(samples::DataFrame, spec::DataFrame)::DataFrame
+    return _derive_regime(samples, 0.0)
+end
+
+"""
+Maps a `regimes` symbol (as accepted by `sample_matched`) to the `:guided` sentinel
+value used to derive that regime from a guided draw via `_derive_regime`.
+"""
+const _REGIME_GUIDED_VALUE = Dict{Symbol,Float64}(
+    :counterfactual => -1.0,
+    :unguided => 0.0
+)
+
+"""
+    sample_matched(d::Domain, n::Int; ssp=nothing, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)), regimes=(:counterfactual, :unguided))::DataFrame
+
+Draw `n` guided intervention scenarios and produce paired rows for each regime in
+`regimes`. Returns a DataFrame with `(1 + length(regimes)) * n` rows and a `:run_type`
+column (`String`) with values in `("intervention", "counterfactual", "unguided")`
+(whichever were requested).
+
+All rows share identical non-intervention parameter values (and, for `:unguided`,
+identical intervention deployment amounts too — see `derive_unguided`), enabling causal
+attribution by differencing outcomes across regimes.
+
+This differs from `sample_balanced`, which draws each regime independently: those rows
+are NOT matched row-for-row and cannot be used for this kind of differencing.
+
+`n` should be a power of 2 for Sobol' sequences.
+
+# Arguments
+- `d` : Domain.
+- `n` : number of guided intervention scenarios to draw.
+- `ssp` : RCP/SSP scenario to switch the domain to before sampling, if given.
+- `sample_method` : type of sampler to use.
+- `regimes` : which regimes to derive alongside the guided draw. Must be a non-empty
+  subset of `(:counterfactual, :unguided)`.
+
+# Returns
+Scenario specification with paired intervention + regime rows.
+"""
+function sample_matched(
+    d::Domain, n::Int;
+    ssp::Union{String,Nothing}=nothing,
+    sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32)),
+    regimes::Tuple{Vararg{Symbol}}=(:counterfactual, :unguided)
+)::DataFrame
+    isempty(regimes) && throw(ArgumentError("`regimes` must be non-empty"))
+    unknown = filter(r -> !haskey(_REGIME_GUIDED_VALUE, r), regimes)
+    isempty(unknown) || throw(
+        ArgumentError(
+            "Unknown regime(s) $unknown; expected a subset of " *
+            "$(Tuple(keys(_REGIME_GUIDED_VALUE)))"
+        )
+    )
+
+    isnothing(ssp) || switch_RCPs!(d, ssp)
+
+    intervention_samples = sample_guided(d, n; sample_method)
+    intervention_samples[!, :run_type] .= "intervention"
+
+    regime_dfs = [
+        let df = _derive_regime(intervention_samples, _REGIME_GUIDED_VALUE[r])
+            df[!, :run_type] .= string(r)
+            df
+        end for r in regimes
+    ]
+
+    return vcat(intervention_samples, regime_dfs...)
+end
+
+"""
+    sample_paired(d::Domain, n::Int; ssp=nothing, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+
+Draw `n` guided intervention scenarios and produce paired counterfactual rows.
+Returns a DataFrame with `2n` rows and a `:run_type` column (`String`).
+
+The intervention and CF rows share identical non-intervention parameter values,
+enabling causal attribution by differencing outcomes.
+
+`n` should be a power of 2 for Sobol' sequences.
+
+A special case of `sample_matched` with `regimes=(:counterfactual,)`; see that function
+for a 3-way (guided/CF/unguided) matched comparison.
+
+# Arguments
+- `d` : Domain.
+- `n` : number of guided intervention scenarios to draw.
+- `ssp` : RCP/SSP scenario to switch the domain to before sampling, if given.
+- `sample_method` : type of sampler to use.
+
+# Returns
+Scenario specification with `2n` paired intervention/counterfactual rows.
+"""
+function sample_paired(
+    d::Domain, n::Int;
+    ssp::Union{String,Nothing}=nothing,
+    sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32))
+)::DataFrame
+    return sample_matched(d, n; ssp, sample_method, regimes=(:counterfactual,))
+end
+
+"""
+    sample_matched_stratified(d::Domain, n_per_stratum::Int, ssp_strata::AbstractVector{String}; regimes=(:counterfactual, :unguided))::DataFrame
+
+For each SSP in `ssp_strata`, draw `n_per_stratum` matched rows (see `sample_matched`)
+using an independent Owen scramble. Returns a DataFrame with `:ssp` and `:run_type`
+columns.
+
+`n_per_stratum` must be a power of 2.
+
+# Arguments
+- `d` : Domain.
+- `n_per_stratum` : number of guided intervention scenarios to draw per SSP stratum.
+- `ssp_strata` : RCP/SSP scenarios to stratify sampling over.
+- `regimes` : which regimes to derive alongside the guided draw; see `sample_matched`.
+
+# Returns
+Scenario specification with `(1 + length(regimes)) * n_per_stratum * length(ssp_strata)`
+matched rows.
+"""
+function sample_matched_stratified(
+    d::Domain,
+    n_per_stratum::Int,
+    ssp_strata::AbstractVector{String};
+    regimes::Tuple{Vararg{Symbol}}=(:counterfactual, :unguided)
+)::DataFrame
+    results = map(ssp_strata) do ssp
+        m = SobolSample(; R=OwenScramble(; base=2, pad=32))  # fresh scramble per stratum
+        df = sample_matched(d, n_per_stratum; ssp, sample_method=m, regimes)
+        df[!, :ssp] .= ssp
+        df
+    end
+    return vcat(results...)
+end
+
+"""
+    sample_paired_stratified(d::Domain, n_per_stratum::Int, ssp_strata::AbstractVector{String})::DataFrame
+
+For each SSP in `ssp_strata`, draw `n_per_stratum` paired rows (see `sample_paired`)
+using an independent Owen scramble. Returns a DataFrame with `:ssp` and `:run_type`
+columns.
+
+`n_per_stratum` must be a power of 2.
+
+A special case of `sample_matched_stratified` with `regimes=(:counterfactual,)`.
+
+# Arguments
+- `d` : Domain.
+- `n_per_stratum` : number of guided intervention scenarios to draw per SSP stratum.
+- `ssp_strata` : RCP/SSP scenarios to stratify sampling over.
+
+# Returns
+Scenario specification with `2 * n_per_stratum * length(ssp_strata)` paired rows.
+"""
+function sample_paired_stratified(
+    d::Domain,
+    n_per_stratum::Int,
+    ssp_strata::AbstractVector{String}
+)::DataFrame
+    return sample_matched_stratified(
+        d, n_per_stratum, ssp_strata; regimes=(:counterfactual,)
+    )
 end

--- a/ADRIA/src/io/sampling/sampling_stratified.jl
+++ b/ADRIA/src/io/sampling/sampling_stratified.jl
@@ -1,0 +1,95 @@
+"""
+    sample_stratified(d::Domain, n_env::Int64, n_lever::Int64;
+        regimes::Tuple{Vararg{Symbol}}=(:guided, :unguided, :counterfactual),
+        env_sample_method=SobolSample(R=OwenScramble(base=2, pad=32)),
+        lever_sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+
+Draw a nested Environment -> Intervention policy -> Deployment strategy sample.
+
+# Design
+
+Level 1 (blocking, identical across every regime): `EnvironmentalLayer` factors
+(`dhw_scenario`, `wave_scenario`, `cyclone_mortality_scenario`) and ecological/biological
+factors (`Coral`, `GrowthAcceleration`). `n_env` blocks are drawn once via a space-filling
+design and reused, unchanged, across every regime and every lever draw within that block.
+Biological parameters are blocked here rather than nested under deployment strategy
+because they interact multiplicatively with environment (thermal tolerance changes what
+"cooler refugia" means) -- they are a source of exogenous uncertainty, not a lever.
+
+Level 2/3 (independently sampled within each regime, per block): each regime's own active
+factors -- MCDA criteria weights/plan_horizon/mcda_method for `:guided`; seeding/fogging/
+moving-coral deployment amounts, depth thresholds and strategy timing for all regimes --
+are drawn independently via `sample_guided`/`sample_unguided`/`sample_cf`, so RSA/PRIM
+retains full independent, space-filling coverage of each regime's own lever space.
+
+This differs from `sample_matched`, which derives unguided/CF rows from a single guided
+draw by zeroing columns: that collapses unguided/CF lever coverage down to whatever the
+guided draw happened to produce, and is suited to causal differencing (validating a single
+candidate region), not open-ended scenario discovery. `sample_stratified` is suited to the
+latter: it controls for the environment/ecology confound via blocking while leaving each
+regime's own factor space free to vary for RSA/PRIM to search.
+
+Rows carry `:env_block` (integer id of which Level-1 block they belong to, `1:n_env`) so
+downstream analysis can facet by block for a 3-way, environment-controlled comparison, or
+run RSA per-regime using each block as a repeated observation. Regime is identified by
+`:guided` itself (`1` guided, `0` unguided, `-1` counterfactual) -- no separate `:run_type`
+column, since it would just duplicate `:guided`.
+
+# Arguments
+- `d` : Domain.
+- `n_env` : number of Level-1 environment/ecology blocks to draw (power of 2 for Sobol').
+- `n_lever` : number of Level-2/3 lever draws per (block, regime) cell (power of 2 for
+  Sobol').
+- `regimes` : which policy regimes to include; subset of `(:guided, :unguided,
+  :counterfactual)`.
+- `env_sample_method` : sampler used for the Level-1 block draw.
+- `lever_sample_method` : sampler used for each regime's Level-2/3 lever draw.
+
+# Returns
+Scenario specification with `n_env * length(regimes) * n_lever` rows.
+"""
+function sample_stratified(
+    d::Domain, n_env::Int64, n_lever::Int64;
+    regimes::Tuple{Vararg{Symbol}}=(:guided, :unguided, :counterfactual),
+    env_sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32)),
+    lever_sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32))
+)::DataFrame
+    regime_sampler = Dict(
+        :guided => sample_guided,
+        :unguided => sample_unguided,
+        :counterfactual => sample_cf
+    )
+    unknown = filter(r -> !haskey(regime_sampler, r), regimes)
+    isempty(unknown) || throw(
+        ArgumentError(
+            "Unknown regime(s) $unknown; expected a subset of " *
+            "$(Tuple(keys(regime_sampler)))"
+        )
+    )
+
+    # Level 1: environment + ecological/biological blocking factors, filtered
+    # consistently with how sample_guided/sample_unguided/sample_cf filter their spec.
+    cb_calib_groups::Vector{Int64} = d.loc_data.CB_CALIB_GROUPS
+    full_spec = _filtered_model_spec(model_spec(d), cb_calib_groups)
+    env_fieldnames = component_params(
+        d.model, [EnvironmentalLayer, Coral, GrowthAcceleration]
+    ).fieldname
+    env_spec = full_spec[in.(full_spec.fieldname, Ref(env_fieldnames)), :]
+
+    env_blocks = sample(env_spec, n_env, env_sample_method)
+    env_cols = names(env_blocks)
+
+    cells = DataFrame[]
+    for b = 1:n_env
+        for r in regimes
+            df = regime_sampler[r](d, n_lever; sample_method=lever_sample_method)
+            for col in env_cols
+                df[!, col] .= env_blocks[b, col]
+            end
+            df[!, :env_block] .= b
+            push!(cells, df)
+        end
+    end
+
+    return vcat(cells...)
+end

--- a/ADRIA/src/io/sampling/sampling_transforms.jl
+++ b/ADRIA/src/io/sampling/sampling_transforms.jl
@@ -1,0 +1,453 @@
+# sampling_transforms.jl
+#
+# Post-sampling zeroing and reparameterization transforms, applied to already-
+# drawn samples rather than to the pre-sampling spec (contrast with
+# sampling_dependencies.jl, which fixes spec columns before sampling). This is
+# needed for dependencies that can only be evaluated per-sample — e.g.
+# gating on a sampled parameter's value (`fogging > 0`) rather than a
+# top-level setting known in advance — and for reparameterizations
+# (gamma-to-Dirichlet, mcda_normalize) that only make sense on drawn values.
+#
+# Byte-for-byte fidelity to what `adjust_samples` previously did is maintained,
+# with one exception: seed_strategy/fog_strategy/mc_strategy are EXCLUDED from
+# the :seed_group/:fog_group/:mc_group substring matches (commit d5871840,
+# 2025-12-15, fixed a regression where including them here conflicted with
+# :strategy_group in sampling_dependencies.jl, which already owns them with
+# fix_to=-1.0 for CF).
+#
+# Reuses _CONDITIONS from sampling_dependencies.jl via broadcast; no re-import
+# needed since sampling_dependencies.jl is included first.
+#
+# ---------------------------------------------------------------------------
+# How to add a rule
+#
+# There are four mechanisms in this file. Pick the first one that fits,
+# ordered from simplest to most involved.
+#
+# 1. Single parent, single child/group -> _TRANSFORM_DEPENDENCIES
+#    Use when a child is zeroed based on ONE other sampled column, evaluated
+#    row-wise (e.g. "zero fog_group when fogging == 0"). Add a row:
+#      (parent=:col, child=:target, op=:eq, value=0.0, negate=true, fix_to=0.0)
+#    `child` can be a bare spec column (fixed directly) or a group name
+#    resolved via `_transform_group_columns` (prefix match / extras, see
+#    _TRANSFORM_GROUP_* below). See the negate-semantics note further down
+#    for how `op`+`negate` combine into the "active" check.
+#
+# 2. Multiple parents combined -> _TRANSFORM_GATE_DEFS + _TRANSFORM_GATE_RULES
+#    Use when "active" depends on MORE than one column at once (e.g. "any of
+#    the five N_seed_* columns is > 0"). Two steps:
+#      a. Add a combiner function to _TRANSFORM_GATE_COMBINERS if none of the
+#         existing ones (`:any_gt0`, `:any_reactive`) fit. It takes the
+#         parents' columns as a sub-DataFrame and returns a BitVector/Vector{Bool}
+#         of per-row "active".
+#      b. Add a row to _TRANSFORM_GATE_DEFS naming the parents and combiner,
+#         then a row to _TRANSFORM_GATE_RULES pointing a child at that gate
+#         name, with a fix_to. Gate masks are computed once per call in
+#         `_apply_transform_dependencies!` and reused by `_apply_transform_calls!`
+#         (see `masks` dict); don't recompute a gate you already defined here.
+#
+# 3. A child needs new group membership -> _TRANSFORM_GROUP_PREFIXES /
+#    _TRANSFORM_GROUP_EXTRA_MEMBERS / _TRANSFORM_GROUP_EXCLUDED_MEMBERS
+#    Only needed if your rule's `child` (in 1 or 2 above) is NOT a single spec
+#    column but should expand to several. Membership resolves as:
+#    (columns matching the group's prefix, if any) + (explicit extras, if
+#    any) - (explicit exclusions, if any). You rarely need all three; most
+#    groups use only one. See `_transform_group_columns` docstring.
+#
+# 4. A reparameterization/normalization call, gated by activity ->
+#    _TRANSFORM_CALLS
+#    Use when the rule isn't zeroing but instead re-deriving values in place
+#    (currently only `mcda_normalize`). Add a row with either a direct
+#    `parent`/`op`/`value`/`negate` condition, OR `gate=:some_gate_name` to
+#    reuse a mask already computed in step 2 above (mutually exclusive: set
+#    exactly one of {parent-based condition, gate}). `columns` must be a key
+#    into _CRITERIA_WEIGHT_GROUPS (add one if the target isn't already there).
+#
+# Before choosing 1-4: if the rule depends ONLY on `guided` and is knowable
+# BEFORE sampling (not on a value that only exists after a row is drawn), it
+# belongs in sampling_dependencies.jl instead, see that file's own "How to
+# add a rule" note. Everything in this file fires strictly AFTER sampling,
+# because the condition depends on the sampled value of another column
+# (`fogging > 0`) rather than a top-level setting fixed for the whole call.
+#
+# Whichever mechanism you use, double check `_apply_transforms!`'s docstring
+# below: the ordering between its numbered steps is load-bearing (e.g.
+# gamma_to_dirichlet must run before the zeroing rules that depend on it).
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Broadcast gate combiners and gate defs (post-sampling, vector masks)
+# ---------------------------------------------------------------------------
+
+const _TRANSFORM_GATE_COMBINERS = Dict{Symbol,Function}(
+    :any_gt0 => cols -> vec(any(Matrix(cols) .> 0; dims=2)),
+    :any_reactive =>
+        cols -> reduce(
+            .|, (is_reactive(cols[:, c]) for c in propertynames(cols))
+        )
+)
+
+const _TRANSFORM_GATE_DEFS = [
+    (name=:any_seeding,
+        parents=[:N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM],
+        combine=:any_gt0),
+    (name=:any_reactive, parents=[:seed_strategy, :fog_strategy, :mc_strategy],
+        combine=:any_reactive)
+]
+
+# ---------------------------------------------------------------------------
+# Single-parent deferred zeroing rules
+#
+# negate semantics follow the same convention as _PARAM_DEPENDENCIES: for each
+# row, `active = op(parent, value)`, then, if `negate=true`, inverted to
+# `active = !active`. `negate` exists because a rule's natural condition is
+# sometimes stated as the INACTIVE case rather than the active one, and
+# inverting it in-place is simpler than picking a different `op`. The child is
+# then zeroed on rows where `!active` (fix_mask = .!active), regardless of
+# whether that flip came from `op` or from `negate`.
+#
+# e.g. if fogging is disabled for a sample, every fog-related parameter for
+# that sample is meaningless and should be zeroed too. :fog_group encodes
+# this with op=:eq, value=0.0, negate=true:
+#   active = .!(fogging .== 0) = (fogging .!= 0)
+#   fix_mask = .!active = (fogging .== 0)
+# i.e. fog_group is zeroed on rows where fogging == 0.
+# ---------------------------------------------------------------------------
+
+const _TRANSFORM_DEPENDENCIES = [
+    (parent=:fogging, child=:fog_group, op=:eq, value=0.0, negate=true, fix_to=0.0),
+    (parent=:N_mc_settlers, child=:mc_group, op=:eq, value=0.0, negate=true, fix_to=0.0),
+    (parent=:SRM, child=:shade_group, op=:eq, value=0.0, negate=true, fix_to=0.0),
+    (
+        parent=:seed_strategy,
+        child=:seed_deployment_freq,
+        op=:is_reactive,
+        value=nothing,
+        negate=true,
+        fix_to=0.0
+    ),
+    (
+        parent=:mc_strategy,
+        child=:mc_deployment_freq,
+        op=:is_reactive,
+        value=nothing,
+        negate=true,
+        fix_to=0.0
+    ),
+    (
+        parent=:fog_strategy,
+        child=:fog_deployment_freq,
+        op=:is_periodic,
+        value=nothing,
+        negate=false,
+        fix_to=0.0
+    )
+]
+
+# ---------------------------------------------------------------------------
+# Gate rules for compound-parent rows
+# ---------------------------------------------------------------------------
+
+const _TRANSFORM_GATE_RULES = [
+    (child=:seed_group, gate=:any_seeding, fix_to=0.0),
+    (child=:a_adapt, gate=:any_seeding, fix_to=0.0),
+    (child=:reactive_group, gate=:any_reactive, fix_to=0.0)
+]
+
+# ---------------------------------------------------------------------------
+# Live substring-based group membership for post-sampling groups
+#
+# seed_strategy/fog_strategy/mc_strategy are EXCLUDED from
+# :seed_group/:fog_group/:mc_group. :strategy_group (pre-sampling,
+# sampling_dependencies.jl) already owns these with fix_to=-1.0 for CF;
+# re-touching them here with fix_to=0.0 would reproduce the d5871840
+# regression (see file header).
+#
+# Possible improvement: these groups are currently maintained by hand
+# (prefix/extras/exclusions) rather than derived from the model spec's own
+# component definitions (e.g. SeedCriteriaWeights, FogCriteriaWeights,
+# component_params groupings used elsewhere in this file/_apply_transforms!).
+# If the component definitions already encode which fields belong together,
+# deriving _TRANSFORM_GROUP_* from them instead of hand-maintaining prefixes
+# would remove a source of drift between the two representations.
+# ---------------------------------------------------------------------------
+
+const _TRANSFORM_GROUP_PREFIXES = Dict{Symbol,String}(
+    :seed_group => "seed_",
+    :fog_group => "fog_",
+    :mc_group => "mc_",
+    :shade_group => "shade_"
+)
+
+const _TRANSFORM_GROUP_EXTRA_MEMBERS = Dict{Symbol,Vector{Symbol}}(
+    :reactive_group => [
+        :reactive_absolute_threshold,
+        :reactive_loss_threshold,
+        :reactive_min_cover_remaining,
+        :reactive_response_delay,
+        :reactive_cooldown_period
+    ]
+)
+
+const _TRANSFORM_GROUP_EXCLUDED_MEMBERS = Dict{Symbol,Vector{Symbol}}(
+    :seed_group => [:seed_strategy],
+    :fog_group => [:fog_strategy],
+    :mc_group => [:mc_strategy]
+)
+
+"""
+    _transform_group_columns(samples::DataFrame, group::Symbol)::Vector{Symbol}
+
+Return the column names in `samples` that belong to `group` for post-sampling
+zeroing. Membership is derived by substring match plus explicit extras, minus
+the exclusions in `_TRANSFORM_GROUP_EXCLUDED_MEMBERS`.
+"""
+function _transform_group_columns(samples::DataFrame, group::Symbol)::Vector{Symbol}
+    cols = Symbol[]
+    if haskey(_TRANSFORM_GROUP_PREFIXES, group)
+        prefix = _TRANSFORM_GROUP_PREFIXES[group]
+        append!(cols, filter(n -> contains(String(n), prefix), propertynames(samples)))
+    end
+    if haskey(_TRANSFORM_GROUP_EXTRA_MEMBERS, group)
+        append!(cols, _TRANSFORM_GROUP_EXTRA_MEMBERS[group])
+    end
+    excluded = get(_TRANSFORM_GROUP_EXCLUDED_MEMBERS, group, Symbol[])
+    cols = setdiff(cols, excluded)
+    return unique(cols)
+end
+
+# ---------------------------------------------------------------------------
+# Post-sampling application of the pre-sampling guided dependency table
+#
+# `_resolve_conditional_spec!` (sampling_dependencies.jl) can only fix
+# `_PARAM_DEPENDENCIES` columns pre-sampling when `guided` is a single known
+# constant for the whole call (as in sample_cf/sample_unguided/sample_guided/
+# sample_selection). Plain `sample(dom, n)` samples `guided` as its own
+# dimension, so each row can realize a different regime and the pre-sampling
+# resolver structurally cannot apply. `_apply_guided_dependencies!` re-applies
+# the same table row-wise, after the fact, using each row's realized `guided`
+# value. For calls where `guided` was already fixed pre-sampling, this is a
+# no-op (every row is already at its `fix_to` value).
+#
+# Rule order matters for :strategy_group, which has two rows targeting the
+# same child (CF -> -1.0, then guided<=0 -> periodic). The second row's mask
+# (guided<=0) is a superset of the first's (guided==-1), so once a row is
+# fixed by an earlier rule for a given child, later rules for that same child
+# must not re-fix it — mirrored here via `fixed_rows`, analogous to the
+# `haskey(known, rule.child)` guard in `_resolve_conditional_spec!`.
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_guided_dependencies!(samples::DataFrame)::Nothing
+
+Zero/sentinel `_PARAM_DEPENDENCIES` columns row-wise based on each row's
+realized `guided` value. No-op if `samples` has no `:guided` column (e.g.
+component-scoped sampling that excludes Intervention).
+"""
+function _apply_guided_dependencies!(samples::DataFrame)::Nothing
+    :guided in propertynames(samples) || return nothing
+
+    guided = samples.guided
+    fixed_rows = Dict{Symbol,BitVector}()
+    for rule in _PARAM_DEPENDENCIES
+        already = get!(fixed_rows, rule.child, falses(length(guided)))
+        active = _CONDITIONS[rule.op].(guided, rule.value)
+        rule.negate && (active = .!active)
+        fix_mask = .!active .& .!already
+        fixed_rows[rule.child] = already .| fix_mask
+        any(fix_mask) || continue
+
+        cols = get(_GROUP_MEMBERS, rule.child, [rule.child])
+        cols = filter(c -> c in propertynames(samples), cols)
+        isempty(cols) && continue
+        samples[fix_mask, cols] .= rule.fix_to
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# mcda_normalize gating rules
+#
+# fog_weights deliberately recomputes fogging > 0 directly rather than
+# reusing the :fog_group fix_mask, preserving an asymmetry present in the
+# original implementation.
+# ---------------------------------------------------------------------------
+
+const _CRITERIA_WEIGHT_GROUPS = Dict{Symbol,Vector{Symbol}}(
+    :seed_weights => [
+        :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,
+        :seed_out_connectivity, :seed_depth, :seed_coral_cover,
+        :seed_cluster_diversity, :seed_geographic_separation
+    ],
+    :fog_weights => [
+        :fog_heat_stress, :fog_wave_stress, :fog_in_connectivity,
+        :fog_out_connectivity, :fog_depth, :fog_coral_cover,
+        :fog_cluster_diversity, :fog_geographic_separation
+    ],
+    :mc_weights => [
+        :mc_heat_stress, :mc_wave_stress, :mc_in_connectivity,
+        :mc_out_connectivity, :mc_depth, :mc_coral_cover,
+        :mc_cluster_diversity, :mc_geographic_separation
+    ]
+)
+
+const _TRANSFORM_CALLS = [
+    # fog_weights: deliberately NOT gate-based (see section header above).
+    (transform=:mcda_normalize, columns=:fog_weights,
+        parent=:fogging, op=:gt, value=0.0, negate=false, gate=nothing),
+    (transform=:mcda_normalize, columns=:seed_weights,
+        parent=nothing, op=nothing, value=nothing, negate=false, gate=:any_seeding),
+    (transform=:mcda_normalize, columns=:mc_weights,
+        parent=:N_mc_settlers, op=:eq, value=0.0, negate=true, gate=nothing)
+]
+
+# ---------------------------------------------------------------------------
+# _apply_transform_dependencies!
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_transform_dependencies!(samples::DataFrame)::Dict{Symbol,BitVector}
+
+Apply single-parent and gate-based post-sampling zeroing rules.
+Returns a dict of gate-name => fix_mask, reused by `_apply_transform_calls!`.
+"""
+function _apply_transform_dependencies!(samples::DataFrame)::Dict{Symbol,BitVector}
+    masks = Dict{Symbol,BitVector}()
+    sample_cols = propertynames(samples)
+
+    for rule in _TRANSFORM_DEPENDENCIES
+        rule.parent in sample_cols || continue
+        active = _CONDITIONS[rule.op].(samples[:, rule.parent], rule.value)
+        rule.negate && (active = .!active)
+        fix_mask = .!active
+        any(fix_mask) || continue
+        cols =
+            rule.child in sample_cols ?
+            [rule.child] :
+            _transform_group_columns(samples, rule.child)
+        isempty(cols) && continue
+        samples[fix_mask, cols] .= rule.fix_to
+    end
+
+    for rule in _TRANSFORM_GATE_RULES
+        gdef = only(filter(g -> g.name == rule.gate, _TRANSFORM_GATE_DEFS))
+        all(p -> p in sample_cols, gdef.parents) || continue
+        active = _TRANSFORM_GATE_COMBINERS[gdef.combine](samples[:, gdef.parents])
+        fix_mask = .!active
+        masks[rule.gate] = fix_mask
+        any(fix_mask) || continue
+        cols =
+            rule.child in sample_cols ?
+            [rule.child] :
+            _transform_group_columns(samples, rule.child)
+        isempty(cols) && continue
+        samples[fix_mask, cols] .= rule.fix_to
+    end
+
+    return masks
+end
+
+# ---------------------------------------------------------------------------
+# _apply_transform_calls!
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_transform_calls!(samples::DataFrame, masks::Dict{Symbol,BitVector})::Nothing
+
+Apply mcda_normalize to criteria weight columns, gated per-intervention-type.
+`masks` is the gate-name => fix_mask dict returned by `_apply_transform_dependencies!`.
+"""
+function _apply_transform_calls!(
+    samples::DataFrame, masks::Dict{Symbol,BitVector}
+)::Nothing
+    :guided in propertynames(samples) || return nothing
+    guided_active = samples.guided .> 0
+    sample_cols = propertynames(samples)
+    for rule in _TRANSFORM_CALLS
+        rule.gate === nothing && !(rule.parent in sample_cols) && continue
+        cols = _CRITERIA_WEIGHT_GROUPS[rule.columns]
+        all(c -> c in sample_cols, cols) || continue
+        parent_active = if rule.gate !== nothing
+            .!masks[rule.gate]
+        else
+            active = _CONDITIONS[rule.op].(samples[:, rule.parent], rule.value)
+            rule.negate ? .!active : active
+        end
+        mask = parent_active .& guided_active
+        any(mask) || continue
+        samples[mask, cols] .= mcda_normalize(samples[mask, cols])
+    end
+    return nothing
+end
+
+# ---------------------------------------------------------------------------
+# _apply_transforms! — assembled post-sampling transform function
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_transforms!(spec::DataFrame, samples::DataFrame)::DataFrame
+
+Post-sampling transforms: reparameterization + conditional zeroing.
+Replaces the body of `adjust_samples`.
+
+Ordering is load-bearing:
+1. `_apply_guided_dependencies!` — row-wise re-application of the pre-sampling
+   guided dependency table, needed for callers (plain `sample(dom, n)`) where
+   `guided` was sampled rather than fixed. Runs first so later steps see
+   already-zeroed intervention/criteria/strategy columns for inactive rows.
+2. `floor.(a_adapt_ref)` — no ordering dependency vs step 1 (zeroed rows floor
+   to 0.0 either way).
+3. `gamma_to_dirichlet` on weight columns — must precede the zeroing rules
+   below, which depend on the reparameterized values.
+4. `_apply_transform_dependencies!` — single-parent + gate zeroing rules.
+5. `_apply_transform_calls!` — mcda_normalize gates.
+6. `seed_wave_stress` zeroing — must run LAST: mcda_normalize normalizes seed
+   weights (including seed_wave_stress) to sum=1 first; zeroing
+   seed_wave_stress afterward deliberately leaves the remaining 7 weights
+   summing to <1 for wave_scenario==0 rows, matching production behaviour.
+"""
+function _apply_transforms!(spec::DataFrame, samples::DataFrame)::DataFrame
+    _apply_guided_dependencies!(samples)
+
+    sample_cols = propertynames(samples)
+
+    if :a_adapt_ref in sample_cols
+        samples[:, :a_adapt_ref] .= floor.(samples[:, :a_adapt_ref])
+    end
+
+    # Must precede the zeroing rules below (see docstring above, point 2).
+    if :guided in sample_cols
+        guided_mask = samples.guided .> 0
+        if any(guided_mask)
+            seed_weights = component_params(spec, SeedCriteriaWeights)
+            fog_weights = component_params(spec, FogCriteriaWeights)
+            mc_weights = component_params(spec, MCCriteriaWeights)
+            for wf in (seed_weights.fieldname, fog_weights.fieldname, mc_weights.fieldname)
+                wf = filter(c -> c in sample_cols, wf)
+                isempty(wf) && continue
+                samples[guided_mask, wf] .= gamma_to_dirichlet(
+                    Matrix(samples[guided_mask, wf])
+                )
+            end
+        end
+    end
+
+    masks = _apply_transform_dependencies!(samples)
+    _apply_transform_calls!(samples, masks)
+
+    # Must run LAST (see docstring above, point 5). seed_wave_stress is a
+    # SeedCriteriaWeights member already normalised by mcda_normalize above;
+    # zeroing it here deliberately does NOT renormalise the remaining 7 seed
+    # weights back to sum=1, matching production behaviour.
+    if :wave_scenario in sample_cols && :seed_wave_stress in sample_cols
+        no_wave = _CONDITIONS[:eq].(samples.wave_scenario, 0.0)
+        samples[no_wave, :seed_wave_stress] .= 0.0
+    end
+
+    if size(unique(Matrix(samples); dims=1), 1) < nrow(samples)
+        perc = "$(@sprintf("%.3f", (1.0 - (nrow(unique(samples)) / nrow(samples))) * 100.0))%"
+        @warn "Non-unique samples created: $perc of the samples are duplicates."
+    end
+
+    return samples
+end

--- a/ADRIA/src/io/sampling/sampling_transforms.jl
+++ b/ADRIA/src/io/sampling/sampling_transforms.jl
@@ -13,7 +13,13 @@
 # the :seed_group/:fog_group/:mc_group substring matches (commit d5871840,
 # 2025-12-15, fixed a regression where including them here conflicted with
 # :strategy_group in sampling_dependencies.jl, which already owns them with
-# fix_to=-1.0 for CF).
+# fix_to=-1.0 for CF). fog_strategy/mc_strategy are instead gated on their own
+# intervention's activity via the dedicated :fog_strategy_gate/:mc_strategy_gate
+# rules below (fix_to=periodic when fogging/N_mc_settlers == 0), which check
+# the CF sentinel before touching the column so they don't reintroduce that
+# regression. seed_strategy is deliberately left out of this: it isn't gated
+# on :any_seeding here, so a seeding-inactive scenario can still draw
+# seed_strategy=reactive independently.
 #
 # Reuses _CONDITIONS from sampling_dependencies.jl via broadcast; no re-import
 # needed since sampling_dependencies.jl is included first.
@@ -37,7 +43,7 @@
 #    Use when "active" depends on MORE than one column at once (e.g. "any of
 #    the five N_seed_* columns is > 0"). Two steps:
 #      a. Add a combiner function to _TRANSFORM_GATE_COMBINERS if none of the
-#         existing ones (`:any_gt0`, `:any_reactive`) fit. It takes the
+#         existing ones (`:any_gt0`, `:any_reactive`, `:strategy_gate`) fit. It takes the
 #         parents' columns as a sub-DataFrame and returns a BitVector/Vector{Bool}
 #         of per-row "active".
 #      b. Add a row to _TRANSFORM_GATE_DEFS naming the parents and combiner,
@@ -84,7 +90,14 @@ const _TRANSFORM_GATE_COMBINERS = Dict{Symbol,Function}(
     :any_reactive =>
         cols -> reduce(
             .|, (is_reactive(cols[:, c]) for c in propertynames(cols))
-        )
+        ),
+    # cols[:,1] is the intervention-activity column (e.g. fogging,
+    # N_mc_settlers), cols[:,2] is the *_strategy column itself. "active"
+    # (i.e. leave alone) when the intervention is on, OR when the strategy
+    # column already holds the CF sentinel (-1.0, set pre-sampling by
+    # :strategy_group / re-applied by _apply_guided_dependencies!); this
+    # gate must never overwrite that sentinel.
+    :strategy_gate => cols -> (cols[:, 1] .!= 0) .| (cols[:, 2] .== -1.0)
 )
 
 const _TRANSFORM_GATE_DEFS = [
@@ -92,7 +105,10 @@ const _TRANSFORM_GATE_DEFS = [
         parents=[:N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM],
         combine=:any_gt0),
     (name=:any_reactive, parents=[:seed_strategy, :fog_strategy, :mc_strategy],
-        combine=:any_reactive)
+        combine=:any_reactive),
+    (name=:fog_strategy_gate, parents=[:fogging, :fog_strategy], combine=:strategy_gate),
+    (name=:mc_strategy_gate, parents=[:N_mc_settlers, :mc_strategy],
+        combine=:strategy_gate)
 ]
 
 # ---------------------------------------------------------------------------
@@ -151,6 +167,13 @@ const _TRANSFORM_DEPENDENCIES = [
 const _TRANSFORM_GATE_RULES = [
     (child=:seed_group, gate=:any_seeding, fix_to=0.0),
     (child=:a_adapt, gate=:any_seeding, fix_to=0.0),
+    # Must run BEFORE :reactive_group's :any_reactive rule below: that rule
+    # reads :fog_strategy/:mc_strategy, and needs to see them already fixed
+    # to periodic here for fogging/N_mc_settlers-inactive rows, otherwise an
+    # orphaned reactive draw on an inactive intervention keeps reactive_group
+    # alive as pure sampling noise (see file header).
+    (child=:fog_strategy, gate=:fog_strategy_gate, fix_to=DECISION_STRATEGY[:periodic]),
+    (child=:mc_strategy, gate=:mc_strategy_gate, fix_to=DECISION_STRATEGY[:periodic]),
     (child=:reactive_group, gate=:any_reactive, fix_to=0.0)
 ]
 

--- a/ADRIA/src/io/sampling/sampling_unguided.jl
+++ b/ADRIA/src/io/sampling/sampling_unguided.jl
@@ -22,5 +22,8 @@ function sample_unguided(
     cols = [:val, :lower_bound, :upper_bound, :dist_params, :is_constant]
     spec_df[guided_col, cols] .= [0 0 0 (0.0, 0.0) true]
 
+    # Pre-sampling resolution: fix criteria weights, plan_horizon and strategy columns
+    _resolve_conditional_spec!(spec_df, (guided=0.0,))
+
     return sample(spec_df, n, sample_method)
 end

--- a/ADRIA/src/scenario.jl
+++ b/ADRIA/src/scenario.jl
@@ -874,7 +874,7 @@ function run_model(
     # Intervention strategy: < 0 is no intervention, 0 is random location selection, > 0 is guided
     is_guided = param_set[At("guided")] > 0
     if is_guided
-        MCDA_approach = mcda_methods()[Int64(param_set[At("guided")])]
+        MCDA_approach = mcda_methods()[Int64(param_set[At("mcda_method")])]
     end
 
     # Number of time steps in environmental layers to look ahead when making decisions

--- a/ADRIA/test/analysis.jl
+++ b/ADRIA/test/analysis.jl
@@ -40,6 +40,7 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame; seed=1)
             :dhw_scenario,
             :wave_scenario,
             :guided,
+            :mcda_method,
             :N_seed_TA,
             :N_seed_CA,
             :fogging,
@@ -131,7 +132,7 @@ function test_rs_w_fig(rs::ADRIA.ResultSet, scens::ADRIA.DataFrame; seed=1)
     # Bands represent the 95% confidence interval derived from the number of conditioning
     # points, the default for which is ten (i.e., 10 samples).
     # Due to the limited sample size, care should be taken when interpreting the figure.
-    foi = [:dhw_scenario, :wave_scenario, :guided]
+    foi = [:dhw_scenario, :wave_scenario, :guided, :mcda_method]
     Si_conv = ADRIA.sensitivity.convergence(scens, outcome, foi)
     ADRIA.viz.convergence(Si_conv, foi)
 

--- a/ADRIA/test/sampling.jl
+++ b/ADRIA/test/sampling.jl
@@ -79,6 +79,51 @@ end
             # sampling test below
         end
     end
+
+    @testset "guided-dependent params are resolved for plain sample()" begin
+        cf_rows = scens.guided .== -1
+        unguided_rows = scens.guided .== 0
+        non_guided_rows = .!(scens.guided .> 0)
+
+        interv_params = string.(
+            ADRIA.component_params(ADRIA.model_spec(dom), Intervention).fieldname
+        )
+        strategy_params = ["seed_strategy", "fog_strategy", "mc_strategy"]
+        non_strategy_interv_params = String[
+            ip for ip in interv_params if ip ∉ vcat(["guided"], strategy_params)
+        ]
+        strategy_interv_params = String[ip for ip in strategy_params if ip ∈ interv_params]
+
+        # CF (guided == -1): all intervention params zeroed, strategies sentineled to -1
+        if any(cf_rows)
+            @test all(
+                all.(==(0), eachrow(scens[cf_rows, non_strategy_interv_params]))
+            ) || "CF rows in plain sample() have non-zero intervention params"
+            @test all(
+                all.(.==(-1), eachrow(scens[cf_rows, strategy_interv_params]))
+            ) || "CF rows in plain sample() do not have strategy sentinel -1"
+            @test all(scens[cf_rows, :depth_min] .== 0) &&
+                  all(scens[cf_rows, :depth_offset] .== 0) ||
+                "CF rows in plain sample() have non-zero depth thresholds"
+        end
+
+        # Criteria weights only matter when guided > 0
+        seed_w = ADRIA.component_params(ms, ADRIA.SeedCriteriaWeights).fieldname
+        fog_w = ADRIA.component_params(ms, ADRIA.FogCriteriaWeights).fieldname
+        mc_w = ADRIA.component_params(ms, ADRIA.MCCriteriaWeights).fieldname
+        criteria_cols = string.(vcat(seed_w, fog_w, mc_w))
+        if any(non_guided_rows)
+            @test all(
+                all.(==(0), eachrow(scens[non_guided_rows, criteria_cols]))
+            ) || "Non-guided rows in plain sample() have non-zero criteria weights"
+        end
+
+        # plan_horizon only matters when guided != 0
+        if any(unguided_rows)
+            @test all(scens[unguided_rows, :plan_horizon] .== 0) ||
+                "Unguided rows in plain sample() have non-zero plan_horizon"
+        end
+    end
 end
 
 @testset "Targeted sampling" begin
@@ -94,10 +139,21 @@ end
             ADRIA.component_params(ADRIA.model_spec(dom), ADRIA.Intervention).fieldname
         )
 
-        # Ensure all interventions are deactivated (ignoring the "guided" factor)
-        interv_params = String[ip for ip in interv_params if ip != "guided"]
-        @test all(all.(==(0), eachrow(scens[:, interv_params]))) ||
-            "Intervention factors with values > 0 found"
+        # Ensure all interventions are deactivated (ignoring "guided").
+        # Strategy params (seed_strategy/fog_strategy/mc_strategy) are set to -1.0
+        # as a CF sentinel (see §2.3 change 2 in component_dependency_dag_v3.md);
+        # all other intervention params are 0.
+        strategy_params = ["seed_strategy", "fog_strategy", "mc_strategy"]
+        non_strategy_params = String[
+            ip for ip in interv_params
+                   if ip != "guided" && ip ∉ strategy_params
+        ]
+        strategy_interv_params = String[ip for ip in strategy_params if ip ∈ interv_params]
+
+        @test all(all.(==(0), eachrow(scens[:, non_strategy_params]))) ||
+            "Non-strategy intervention factors with values != 0 found"
+        @test all(all.(.==(-1), eachrow(scens[:, strategy_interv_params]))) ||
+            "Strategy params not set to -1 sentinel in CF scenarios"
     end
 
     @testset "Guided sampling" begin
@@ -132,24 +188,64 @@ end
 
     @testset "Specific Intervention strategy" begin
         dom = deepcopy(ADRIA_DOM_45)
-        num_samples = 32
 
-        test_inputs = [
-            ("Cocoso",), ("Mairca",), ("counterfactual", "unguided"),
-            ("counterfactual", "unguided", "Piv"),
-            ("counterfactual", "unguided", "Cocoso", "Moora", "Piv", "Vikor"),
-            ("Cocoso", "Mairca", "Moora", "Piv", "Vikor")
-        ]
-        test_output = [
-            [1], [2], [-1, 0], [-1, 0, 4], [-1, 0, 1, 3, 4, 5]
-        ]
+        # :guided is now a strict ordinal {-1, 0, 1} (CF / unguided / guided);
+        # `set_factor_bounds!` restricts sampling to plain numeric bounds.
+        test_bounds = [(-1.0, -1.0), (0.0, 0.0), (1.0, 1.0), (0.0, 1.0), (-1.0, 1.0)]
 
-        for (inp, out) in zip(test_inputs, test_output)
-            ADRIA.set_factor_bounds!(dom, :guided, inp)
+        for bounds in test_bounds
+            ADRIA.set_factor_bounds!(dom, :guided, bounds)
             scens = ADRIA.sample(dom, 32)
 
-            @test all(scens.guided .∈ [out])
+            @test all(bounds[1] .<= scens.guided .<= bounds[2])
         end
+    end
+
+    @testset "Specific MCDA method" begin
+        dom = deepcopy(ADRIA_DOM_45)
+
+        test_inputs = [
+            ("Cocoso",), ("Mairca",),
+            ("Cocoso", "Moora", "Piv", "Vikor"),
+            ("Cocoso", "Mairca", "Moora", "Piv", "Vikor")
+        ]
+
+        for inp in test_inputs
+            ADRIA.set_factor_bounds!(dom, :mcda_method, inp)
+            # Ensure guided is in the "guided" regime so mcda_method isn't
+            # sentineled to 0 by the guided<=0 dependency rule.
+            ADRIA.set_factor_bounds!(dom, :guided, (1.0, 1.0))
+            scens = ADRIA.sample(dom, 32)
+
+            expected = sort(ADRIA.decision.decision_method_encoding.(collect(inp)))
+            @test all(scens.mcda_method .∈ [expected])
+        end
+    end
+
+    @testset "mcda_method sentineled when not guided" begin
+        dom = deepcopy(ADRIA_DOM_45)
+        ADRIA.set_factor_bounds!(dom, :guided, (-1.0, 0.0))  # CF + unguided only
+        scens = ADRIA.sample(dom, 32)
+
+        @test all(scens.mcda_method .== 0.0)
+    end
+
+    @testset "guided/mcda_method split" begin
+        dom = deepcopy(ADRIA_DOM_45)
+        scens = ADRIA.sample(dom, 32)
+
+        @test :guided in propertynames(scens)
+        @test :mcda_method in propertynames(scens)
+        @test all(scens.guided .∈ [[-1.0, 0.0, 1.0]])
+
+        # mcda_method must be 0 (sentinel) on every row where guided <= 0,
+        # and a valid 1..N index on every row where guided == 1.
+        not_guided = scens.guided .<= 0
+        is_guided = scens.guided .== 1
+        @test all(scens.mcda_method[not_guided] .== 0.0)
+        n_methods = length(ADRIA.decision.mcda_methods())
+        @test !any(is_guided) ||
+            all(1.0 .<= scens.mcda_method[is_guided] .<= n_methods)
     end
 
     @testset "Unguided sampling" begin
@@ -446,5 +542,148 @@ end
                 end
             end
         end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests for component_dependency_dag_v3 implementation
+# (sampling_dependencies.jl + sampling_transforms.jl)
+# Ref: .claude/plans/components/component_dependency_dag_v3.md §4 Steps 5,6,8,9
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "Dependency DAG — _validate_dependencies" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    spec = ADRIA.model_spec(dom)
+    @test_nowarn ADRIA._validate_dependencies(spec)
+end
+
+@testset "Dependency DAG — _resolve_conditional_spec!" begin
+    PERIODIC = ADRIA.DECISION_STRATEGY[:periodic]
+
+    @testset "CF regime (guided=-1)" begin
+        dom = deepcopy(ADRIA_DOM_45)
+        spec = ADRIA.model_spec(dom)
+        ADRIA._resolve_conditional_spec!(spec, (guided=-1.0,))
+
+        for col in ADRIA._GROUP_MEMBERS[:intervention_group]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], 0.0) ||
+                "CF: :$col should be fixed to 0.0, got val=$(row.val[1])"
+        end
+
+        # PINNED REGRESSION (§2.3 changes 1 & 2): strategy cols must be -1.0 for CF.
+        # Previously had negate-sign inversion AND wrong fix_to (0.0 not -1.0).
+        for col in ADRIA._GROUP_MEMBERS[:strategy_group]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], -1.0) ||
+                "CF: :$col should be -1.0 sentinel (§2.3 change 2). " *
+                  "Got val=$(row.val[1]). Check negate-sign or fix_to."
+        end
+
+        for col in ADRIA._GROUP_MEMBERS[:criteria_weights]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], 0.0) ||
+                "CF: criteria weight :$col should be 0.0"
+        end
+
+        for col in ADRIA._GROUP_MEMBERS[:depth_thresholds]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], 0.0) ||
+                "CF: depth threshold :$col should be 0.0"
+        end
+    end
+
+    @testset "Unguided regime (guided=0)" begin
+        dom = deepcopy(ADRIA_DOM_45)
+        spec = ADRIA.model_spec(dom)
+        ADRIA._resolve_conditional_spec!(spec, (guided=0.0,))
+
+        ph_row = spec[spec.fieldname .== :plan_horizon, :]
+        if !isempty(ph_row)
+            @test ph_row.is_constant[1] && isequal(ph_row.val[1], 0.0) ||
+                "Unguided: :plan_horizon should be 0.0"
+        end
+
+        for col in ADRIA._GROUP_MEMBERS[:criteria_weights]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], 0.0) ||
+                "Unguided: criteria weight :$col should be 0.0"
+        end
+
+        # PINNED REGRESSION (§2.3 change 1): strategy cols must be PERIODIC for unguided.
+        for col in ADRIA._GROUP_MEMBERS[:strategy_group]
+            row = spec[spec.fieldname .== col, :]
+            isempty(row) && continue
+            @test row.is_constant[1] && isequal(row.val[1], Float64(PERIODIC)) ||
+                "Unguided: :$col should be PERIODIC ($PERIODIC). " *
+                  "Got val=$(row.val[1]). Check negate-sign (§2.3 change 1)."
+        end
+    end
+
+    @testset "Guided regime (guided=1)" begin
+        dom = deepcopy(ADRIA_DOM_45)
+        spec = ADRIA.model_spec(dom)
+        already_constant = Set(spec[spec.is_constant, :fieldname])
+        ADRIA._resolve_conditional_spec!(spec, (guided=1.0,))
+
+        newly_fixed = setdiff(Set(spec[spec.is_constant, :fieldname]), already_constant)
+        @test isempty(newly_fixed) ||
+            "Guided: unexpected columns newly fixed: $newly_fixed"
+    end
+end
+
+@testset "Dependency DAG — _transform_group_columns snapshot (E4)" begin
+    # Pinned snapshot: strategy cols must NOT appear in prefix-based groups.
+    # Their inclusion was the d5871840 regression (overwrites -1.0 CF sentinel).
+    dom = deepcopy(ADRIA_DOM_45)
+    scens = ADRIA.sample(dom, 8)
+
+    seed_cols = ADRIA._transform_group_columns(scens, :seed_group)
+    fog_cols = ADRIA._transform_group_columns(scens, :fog_group)
+    mc_cols = ADRIA._transform_group_columns(scens, :mc_group)
+
+    @test :seed_strategy ∉ seed_cols ||
+        ":seed_strategy in :seed_group reproduces d5871840 regression"
+    @test :fog_strategy ∉ fog_cols ||
+        ":fog_strategy in :fog_group reproduces d5871840 regression"
+    @test :mc_strategy ∉ mc_cols ||
+        ":mc_strategy in :mc_group reproduces d5871840 regression"
+
+    @test !isempty(seed_cols) || ":seed_group resolved empty — prefix filter broken"
+    @test !isempty(fog_cols) || ":fog_group resolved empty — prefix filter broken"
+    @test !isempty(mc_cols) || ":mc_group resolved empty — prefix filter broken"
+end
+
+@testset "Dependency DAG — seed_wave_stress ordering (§2.12 pt 1)" begin
+    # seed_wave_stress is zeroed AFTER mcda_normalize. For wave_scenario==0
+    # guided+seeded rows, remaining 7 seed weights must sum to <1 (not renormalised).
+    dom = deepcopy(ADRIA_DOM_45)
+    num_samples = 128
+    scens = ADRIA.sample_guided(dom, num_samples)
+    ms = ADRIA.model_spec(dom)
+    seed_weights = ADRIA.component_params(ms, ADRIA.SeedCriteriaWeights).fieldname
+
+    not_seeded = ADRIA.no_seeding(scens)
+    guided_seeded_mask = .!not_seeded .& (scens.guided .> 0)
+    wave_zero_mask = (scens.wave_scenario .== 0.0)
+    target_mask = guided_seeded_mask .& wave_zero_mask
+
+    if any(target_mask)
+        @test all(scens[target_mask, :seed_wave_stress] .== 0.0) ||
+            "seed_wave_stress should be 0 for wave_scenario==0 guided+seeded rows"
+
+        other_seed_weights = filter(w -> w != :seed_wave_stress, seed_weights)
+        row_sums = vec(sum(Matrix(scens[target_mask, other_seed_weights]); dims=2))
+        @test all(row_sums .< 1.0) ||
+            "Remaining seed weights sum to 1 — ordering wrong: mcda_normalize ran " *
+              "AFTER zeroing seed_wave_stress (§2.12 pt 1)"
+    else
+        @info "No wave_scenario==0 guided+seeded rows in $num_samples samples; " *
+            "seed_wave_stress ordering test inconclusive"
     end
 end

--- a/ADRIA/test/sampling.jl
+++ b/ADRIA/test/sampling.jl
@@ -659,6 +659,48 @@ end
     @test !isempty(mc_cols) || ":mc_group resolved empty — prefix filter broken"
 end
 
+@testset "Dependency DAG — fog_strategy/mc_strategy gated on intervention activity (Issue #1132)" begin
+    # fog_strategy/mc_strategy used to be free to draw reactive even when their
+    # own intervention (fogging/N_mc_settlers) was fixed inactive across all
+    # rows, keeping reactive_group alive as sampling noise. They should now be
+    # fixed to PERIODIC whenever their intervention is inactive.
+    PERIODIC = ADRIA.DECISION_STRATEGY[:periodic]
+
+    dom = deepcopy(ADRIA_DOM_45)
+    ADRIA.fix_factor!(dom; fogging=0.0, N_mc_settlers=0.0)
+    scens = ADRIA.sample(dom, 64)
+
+    @testset "fog_strategy fixed when fogging inactive" begin
+        if :fog_strategy in propertynames(scens) && :fogging in propertynames(scens)
+            not_cf = scens.fog_strategy .!= -1.0
+            @test all(scens[not_cf, :fog_strategy] .== Float64(PERIODIC)) ||
+                "fog_strategy should be PERIODIC ($PERIODIC) for all non-CF rows once " *
+                  "fogging is fixed inactive"
+        end
+    end
+
+    @testset "mc_strategy fixed when N_mc_settlers inactive" begin
+        if :mc_strategy in propertynames(scens) && :N_mc_settlers in propertynames(scens)
+            not_cf = scens.mc_strategy .!= -1.0
+            @test all(scens[not_cf, :mc_strategy] .== Float64(PERIODIC)) ||
+                "mc_strategy should be PERIODIC ($PERIODIC) for all non-CF rows once " *
+                  "N_mc_settlers is fixed inactive"
+        end
+    end
+
+    @testset "reactive_group dropped when seed is the only reactive-capable lever" begin
+        if all(
+            c -> c in propertynames(scens),
+            [:seed_strategy, :fog_strategy, :mc_strategy, :reactive_response_delay]
+        )
+            periodic_seed = scens.seed_strategy .== Float64(PERIODIC)
+            @test all(scens[periodic_seed, :reactive_response_delay] .== 0.0) ||
+                "reactive_group should be 0.0 when seed_strategy is periodic and " *
+                  "fog/mc are fixed inactive (no reactive-capable lever remains)"
+        end
+    end
+end
+
 @testset "Dependency DAG — seed_wave_stress ordering (§2.12 pt 1)" begin
     # seed_wave_stress is zeroed AFTER mcda_normalize. For wave_scenario==0
     # guided+seeded rows, remaining 7 seed weights must sum to <1 (not renormalised).

--- a/ADRIA/test/sampling.jl
+++ b/ADRIA/test/sampling.jl
@@ -729,3 +729,237 @@ end
             "seed_wave_stress ordering test inconclusive"
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests for paired counterfactual sampling (sampling_design_plan_v4.md §5 Step 3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "derive_cf" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    num_samples = 32
+    spec = ADRIA.model_spec(dom)
+    intervention_samples = ADRIA.sample_guided(dom, num_samples)
+    cf_samples = ADRIA.derive_cf(intervention_samples, spec)
+
+    zeroed_cols = [
+        :N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM,
+        :fogging, :SRM, :N_mc_settlers
+    ]
+    zeroed_cols = filter(c -> c in propertynames(cf_samples), zeroed_cols)
+    strategy_cols = filter(
+        c -> c in propertynames(cf_samples), [:seed_strategy, :fog_strategy, :mc_strategy]
+    )
+
+    @testset "CF zeroing" begin
+        @test all(all(cf_samples[:, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected all of $zeroed_cols to be 0.0 in CF rows"
+    end
+
+    @testset "strategy sentinel" begin
+        @test all(all(cf_samples[:, c] .== -1.0) for c in strategy_cols) ||
+            "Expected all of $strategy_cols to be -1.0 (CF sentinel) in CF rows"
+    end
+
+    @testset "env params unchanged" begin
+        # Columns derive_cf may fix (per _PARAM_DEPENDENCIES/_GROUP_MEMBERS) are not
+        # "non-intervention" even though some (criteria weights, depth thresholds)
+        # fall outside the Intervention component.
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(intervention_samples) if c ∉ cf_affected_cols
+        ]
+        @test intervention_samples[:, env_cols] == cf_samples[:, env_cols] ||
+            "Non-intervention parameter columns differ between paired rows"
+    end
+
+    @testset "parent params zeroed" begin
+        nonzero_mask = vec(
+            any(Matrix(intervention_samples[:, zeroed_cols]) .> 0; dims=2)
+        )
+        @test any(nonzero_mask) ||
+            "No sampled guided rows had non-zero intervention parent values to test against"
+        @test all(all(cf_samples[nonzero_mask, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected $zeroed_cols to be 0.0 in CF rows paired to non-zero intervention rows"
+    end
+end
+
+@testset "sample_paired" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n = 16
+    scens = ADRIA.sample_paired(dom, n)
+
+    @testset "shape" begin
+        @test nrow(scens) == 2n || "Expected 2n rows, got $(nrow(scens))"
+        @test count(==("intervention"), scens.run_type) == n
+        @test count(==("counterfactual"), scens.run_type) == n
+    end
+
+    @testset "pairing" begin
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(scens) if c ∉ cf_affected_cols && c != :run_type
+        ]
+
+        interv_rows = scens[scens.run_type .== "intervention", env_cols]
+        cf_rows = scens[scens.run_type .== "counterfactual", env_cols]
+        @test interv_rows == cf_rows ||
+            "Non-intervention parameters do not match between paired rows"
+    end
+
+    @testset "run_type type" begin
+        @test eltype(scens.run_type) == String
+    end
+end
+
+@testset "sample_paired_stratified" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n_per_stratum = 8
+    # Test_domain only ships RCP45 DHW/wave data; repeat the same RCP as two
+    # independently-scrambled strata to validate shape/labelling without
+    # requiring additional RCP datasets.
+    ssp_strata = ["45", "45"]
+    scens = ADRIA.sample_paired_stratified(dom, n_per_stratum, ssp_strata)
+
+    @testset "shape" begin
+        @test nrow(scens) == 2 * n_per_stratum * length(ssp_strata) ||
+            "Expected $(2 * n_per_stratum * length(ssp_strata)) rows, got $(nrow(scens))"
+        @test count(==("45"), scens.ssp) == 2 * n_per_stratum * length(ssp_strata)
+    end
+end
+
+@testset "derive_unguided" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    num_samples = 32
+    spec = ADRIA.model_spec(dom)
+    intervention_samples = ADRIA.sample_guided(dom, num_samples)
+    ug_samples = ADRIA.derive_unguided(intervention_samples, spec)
+
+    # Unlike CF, unguided rows keep intervention deployment amounts and depth
+    # thresholds unchanged (:intervention_group / :depth_thresholds stay active
+    # at guided=0.0) — only criteria weights / plan_horizon are zeroed.
+    zeroed_cols = filter(
+        c -> c in propertynames(ug_samples),
+        [
+            :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,
+            :fog_heat_stress, :mc_heat_stress, :plan_horizon
+        ]
+    )
+    unchanged_cols = filter(
+        c -> c in propertynames(ug_samples),
+        [:N_seed_TA, :N_seed_CA, :fogging, :SRM, :N_mc_settlers, :depth_min]
+    )
+    strategy_cols = filter(
+        c -> c in propertynames(ug_samples), [:seed_strategy, :fog_strategy, :mc_strategy]
+    )
+
+    @testset "criteria weights/plan_horizon zeroed" begin
+        @test all(all(ug_samples[:, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected all of $zeroed_cols to be 0.0 in unguided rows"
+    end
+
+    @testset "strategy fixed to periodic" begin
+        periodic = ADRIA.decision.DECISION_STRATEGY[:periodic]
+        @test all(all(ug_samples[:, c] .== periodic) for c in strategy_cols) ||
+            "Expected all of $strategy_cols to be $periodic (periodic) in unguided rows"
+    end
+
+    @testset "intervention deployment amounts unchanged" begin
+        @test intervention_samples[:, unchanged_cols] == ug_samples[:, unchanged_cols] ||
+            "Expected intervention deployment amounts to be unchanged in unguided rows"
+    end
+
+    @testset "guided column set to 0.0" begin
+        @test all(ug_samples.guided .== 0.0)
+    end
+end
+
+@testset "sample_matched" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n = 16
+
+    @testset "default regimes (3-way)" begin
+        scens = ADRIA.sample_matched(dom, n)
+
+        @test nrow(scens) == 3n || "Expected 3n rows, got $(nrow(scens))"
+        @test count(==("intervention"), scens.run_type) == n
+        @test count(==("counterfactual"), scens.run_type) == n
+        @test count(==("unguided"), scens.run_type) == n
+        @test eltype(scens.run_type) == String
+
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(scens) if c ∉ cf_affected_cols && c != :run_type
+        ]
+
+        interv_rows = scens[scens.run_type .== "intervention", env_cols]
+        cf_rows = scens[scens.run_type .== "counterfactual", env_cols]
+        ug_rows = scens[scens.run_type .== "unguided", env_cols]
+        @test interv_rows == cf_rows ||
+            "Non-intervention parameters do not match between guided/CF rows"
+        @test interv_rows == ug_rows ||
+            "Non-intervention parameters do not match between guided/unguided rows"
+    end
+
+    @testset "regimes subsetting" begin
+        ug_only = ADRIA.sample_matched(dom, n; regimes=(:unguided,))
+        @test nrow(ug_only) == 2n
+        @test count(==("counterfactual"), ug_only.run_type) == 0
+        @test count(==("unguided"), ug_only.run_type) == n
+
+        cf_only = ADRIA.sample_matched(dom, n; regimes=(:counterfactual,))
+        @test nrow(cf_only) == 2n
+        @test count(==("unguided"), cf_only.run_type) == 0
+        @test count(==("counterfactual"), cf_only.run_type) == n
+    end
+
+    @testset "invalid regimes" begin
+        @test_throws ArgumentError ADRIA.sample_matched(dom, n; regimes=())
+        @test_throws ArgumentError ADRIA.sample_matched(dom, n; regimes=(:bogus,))
+    end
+end
+
+@testset "sample_matched_stratified" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n_per_stratum = 8
+    ssp_strata = ["45", "45"]
+    scens = ADRIA.sample_matched_stratified(dom, n_per_stratum, ssp_strata)
+
+    @testset "shape" begin
+        @test nrow(scens) == 3 * n_per_stratum * length(ssp_strata) ||
+            "Expected $(3 * n_per_stratum * length(ssp_strata)) rows, got $(nrow(scens))"
+        @test count(==("45"), scens.ssp) == 3 * n_per_stratum * length(ssp_strata)
+    end
+end


### PR DESCRIPTION
## Summary
- Splits the overloaded `guided` factor into `guided` (intervention regime: -1 counterfactual, 0 unguided, 1 guided) and a separate `mcda_method` factor, so regime and MCDA-method choice can be sampled/fixed independently.
- Introduces a declarative dependency table (`sampling_dependencies.jl`: `_PARAM_DEPENDENCIES`, `_GROUP_MEMBERS`) describing which factors are only meaningful under which regimes, plus two resolution passes:
  - `_resolve_conditional_spec!` (`sampling_dependencies.jl`) fixes inactive factors to sentinel constants *before* sampling, when the regime is known for the whole call (`sample_cf`/`sample_guided`/`sample_unguided`/`sample_selection`).
  - `_apply_transforms!` (`sampling_transforms.jl`) resolves dependencies row-by-row *after* sampling, for plain `sample(dom, n)` (where `guided` is itself sampled) and for dependencies only evaluable from a drawn value (e.g. gating on `fogging > 0`). Replaces the old monolithic `adjust_samples` (now `@deprecate`'d).
- Includes a follow-up fix: `fog_strategy`/`mc_strategy` are now gated on their own intervention's activity (`fogging`/`N_mc_settlers`), fixing to `PERIODIC` when inactive rather than staying free to draw `reactive` as sampling noise.
- Updates the two call sites that read `guided` as an MCDA index (`location_selection.jl`, `scenario.jl`) to use `mcda_method` instead.
- Documents the dependency graph in `architecture.md` and `generating_scenarios.md`.

Relates to Issue #1132 — foundational infrastructure for the "split scenarios, rank features" example assessment workflow described in the issue, and a prerequisite for the paired/matched sampling PR (#TBD, stacked on this one).

## Test plan
- [x] Extensive new coverage in `test/sampling.jl`: dependency resolution (pre- and post-sampling), guided/mcda_method split, dependency DAG validation, ordering regressions (e.g. seed_wave_stress must zero after mcda_normalize)