### PR TITLE
feat(sampling): stratified/matched/paired sampling for causal comparisons

### DIFF
--- a/ADRIA/docs/src/usage/generating_scenarios.md
+++ b/ADRIA/docs/src/usage/generating_scenarios.md
@@ -229,13 +229,86 @@ ADRIA.fix_factor!(dom, :mcb_albedo, 0.3)
 scens = ADRIA.sample(dom, 128)
 ```
 
-## Sampling counterfactuals only
+## Sampling by intervention regime
 
-A convenience function to create scenarios with no interventions (counterfactuals).
+Alongside plain `ADRIA.sample(dom, n)` (which samples the `guided` factor together with
+everything else, so each row may land in a different intervention regime), ADRIA provides
+a family of convenience functions that fix the intervention regime for the whole call
+up-front. This avoids wasting samples on factor combinations that are meaningless for the
+regime under study (e.g. seeding-related factors when only counterfactual scenarios are
+wanted), and lets the conditional factor dependencies described above be resolved *before*
+sampling rather than row-by-row afterwards (see
+[Conditional factor dependencies](@ref)).
+
+| Function | Regime sampled | `n` refers to |
+|----------|-----------------|---------------|
+| `ADRIA.sample(dom, n)` | All regimes (`guided` itself is sampled) | total scenarios |
+| `ADRIA.sample_cf(dom, n)` | Counterfactual only (no interventions) | total scenarios |
+| `ADRIA.sample_unguided(dom, n)` | Unguided interventions only | total scenarios |
+| `ADRIA.sample_guided(dom, n)` | Guided (MCDA-driven) interventions only | total scenarios |
+| `ADRIA.sample_balanced(dom, n)` | Equal parts counterfactual, unguided and guided | scenarios *per regime* (returns `3n` rows) |
+| `ADRIA.sample_selection(dom, n)` | Guided location-selection factors only; coral factors held at their defaults | total scenarios |
+| `ADRIA.sample_paired(dom, n)` | Guided scenarios paired 1:1 with a derived counterfactual row sharing the same non-intervention factor values | guided scenarios drawn (returns `2n` rows) |
+| `ADRIA.sample_paired_stratified(dom, n, ssps)` | As `sample_paired`, repeated independently for each RCP/SSP in `ssps` | guided scenarios drawn *per SSP stratum* |
+| `ADRIA.sample_matched(dom, n)` | Guided scenarios paired 1:1 with derived rows for each regime in `regimes` (default: counterfactual **and** unguided) | guided scenarios drawn (returns `(1 + length(regimes)) * n` rows) |
+| `ADRIA.sample_matched_stratified(dom, n, ssps)` | As `sample_matched`, repeated independently for each RCP/SSP in `ssps` | guided scenarios drawn *per SSP stratum* |
 
 ```julia
+# Counterfactual scenarios only (no interventions)
 cf_scens = ADRIA.sample_cf(dom, 1024)
+
+# Unguided intervention scenarios only
+ug_scens = ADRIA.sample_unguided(dom, 1024)
+
+# Guided (MCDA-driven) intervention scenarios only
+gd_scens = ADRIA.sample_guided(dom, 1024)
+
+# 1024 scenarios of each regime (3072 rows total)
+balanced_scens = ADRIA.sample_balanced(dom, 1024)
 ```
+
+For causal comparisons between an intervention and "no intervention", `sample_paired`
+draws guided scenarios and derives a matching counterfactual row for each one, holding all
+non-intervention factors (environmental layers, etc.) fixed between the pair so that
+outcome differences can be attributed to the intervention itself. `sample_paired_stratified`
+extends this across multiple RCP/SSP scenarios, using an independent Owen scramble per
+stratum:
+
+```julia
+# 128 guided/counterfactual pairs (256 rows), tagged by `:run_type`
+paired_scens = ADRIA.sample_paired(dom, 128)
+
+# As above, repeated for each listed RCP/SSP, tagged by `:ssp` and `:run_type`
+strat_scens = ADRIA.sample_paired_stratified(dom, 128, ["45", "60", "85"])
+```
+
+`sample_paired` only pairs guided scenarios against a derived counterfactual row, so it
+cannot support a 3-way cross-comparison against unguided scenarios. `sample_matched`
+generalises this: it draws guided scenarios and derives a matched row for each regime
+requested via `regimes` (any non-empty subset of `(:counterfactual, :unguided)`, default
+both), all sharing the same non-intervention factor draws — `sample_paired` is just
+`sample_matched` with `regimes=(:counterfactual,)`. Note that unguided rows keep the same
+intervention deployment amounts as their guided counterpart (only the MCDA criteria
+weights/`plan_horizon` are zeroed and the strategy is fixed to periodic) — unlike
+counterfactual rows, where deployment amounts are zeroed too:
+
+```julia
+# 128 guided/counterfactual/unguided triples (384 rows), tagged by `:run_type`
+matched_scens = ADRIA.sample_matched(dom, 128)
+
+# Only guided + unguided (256 rows)
+matched_ug_scens = ADRIA.sample_matched(dom, 128; regimes=(:unguided,))
+
+# As `sample_matched`, repeated for each listed RCP/SSP
+strat_matched_scens = ADRIA.sample_matched_stratified(dom, 128, ["45", "60", "85"])
+```
+
+This differs from `sample_balanced`, which draws each regime *independently* — those rows
+are not matched row-for-row and cannot be used for this kind of differencing.
+
+!!! note "Sobol' samples"
+    As with plain `ADRIA.sample`, `n` (or `n_per_stratum`) should be a power of 2 when
+    using the default Sobol' sampler.
 
 ## References
 

--- a/ADRIA/src/io/sampling/sampling.jl
+++ b/ADRIA/src/io/sampling/sampling.jl
@@ -20,6 +20,7 @@ include("sampling_unguided.jl")
 include("sampling_guided.jl")
 include("sampling_interventions.jl")
 include("sampling_balanced.jl")
+include("sampling_stratified.jl")
 
 const DISCRETE_FACTOR_TYPES = [
     "ordered categorical", "unordered categorical", "ordered discrete"

--- a/ADRIA/src/io/sampling/sampling_interventions.jl
+++ b/ADRIA/src/io/sampling/sampling_interventions.jl
@@ -26,9 +26,11 @@ function sample_set(d::Domain, n::Int64, rcp::String)::DataFrame
 
     dhw_scens = [rand(findall(clusters .== c)) for c in unique(clusters)]
 
+    # `guided`'s default bounds already span -1..1 (counterfactual/unguided/guided),
+    # so only `mcda_method` needs constraining to a single method here.
     ADRIA.set_factor_bounds!(
         d;
-        guided=("counterfactual", "unguided", "COCOSO"),
+        mcda_method=("COCOSO",),
         dhw_scenario=Tuple(dhw_scens)
     )
 
@@ -66,4 +68,265 @@ function sample_set(d::Domain, n::Int64, rcp::String)::DataFrame
     scenarios = ADRIA.sample(d, n)
 
     return scenarios
+end
+
+"""
+    _derive_regime(samples::DataFrame, guided_value::Float64)::DataFrame
+
+Produce scenario rows paired to `samples` under a fixed `guided` regime, by setting
+`:guided` to `guided_value` and fixing every column that `_PARAM_DEPENDENCIES` renders
+inactive under that value.
+
+Non-intervention parameter columns (and any columns still active under the given regime)
+are left unchanged, enabling causal attribution by differencing outcomes between paired
+rows.
+
+Shared by `derive_cf` (`guided_value=-1.0`) and `derive_unguided` (`guided_value=0.0`) so
+both regimes stay consistent with the same dependency table used pre-sampling by
+`sample_guided`/`sample_unguided`/`sample_cf`.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `guided_value` : the `:guided` sentinel for the target regime (-1.0 CF, 0.0 unguided).
+
+# Returns
+Scenario rows for the target regime, paired 1:1 with `samples`.
+"""
+function _derive_regime(samples::DataFrame, guided_value::Float64)::DataFrame
+    regime = copy(samples)
+    regime[!, :guided] .= guided_value
+
+    # Mirrors the `haskey(known, rule.child)` guard in _resolve_conditional_spec!:
+    # the two :strategy_group rows both evaluate "inactive" under guided=-1.0, and
+    # without this guard the second (fix_to=PERIODIC) would overwrite the first
+    # (fix_to=-1.0 CF sentinel) applied to the same columns.
+    fixed_children = Set{Symbol}()
+    for dep in _PARAM_DEPENDENCIES
+        dep.child in fixed_children && continue
+
+        active = _CONDITIONS[dep.op](guided_value, dep.value)
+        dep.negate && (active = !active)
+        active && continue  # only fix rows where this dep is inactive under this regime
+
+        cols =
+            dep.child in propertynames(regime) ?
+            [dep.child] :
+            get(_GROUP_MEMBERS, dep.child, Symbol[])
+        for col in cols
+            col in propertynames(regime) && (regime[!, col] .= dep.fix_to)
+        end
+        push!(fixed_children, dep.child)
+    end
+
+    return regime
+end
+
+"""
+    derive_cf(samples::DataFrame, spec::DataFrame)::DataFrame
+
+Produce counterfactual-regime rows paired to `samples` by zeroing all columns
+that are inactive under guided = -1.0, using the pre-sampling dependency tables.
+
+Non-intervention parameter columns are left unchanged, enabling causal attribution
+by differencing outcomes between paired rows.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `spec` : model spec for the same domain (output of `model_spec(d)`).
+  Currently unused — the dependency tables are module-level constants — but retained
+  for forward-compatibility with domain-specific dependency overrides.
+
+# Returns
+Counterfactual-regime scenario rows paired 1:1 with `samples`.
+"""
+function derive_cf(samples::DataFrame, spec::DataFrame)::DataFrame
+    return _derive_regime(samples, -1.0)
+end
+
+"""
+    derive_unguided(samples::DataFrame, spec::DataFrame)::DataFrame
+
+Produce unguided-regime rows paired to `samples` by fixing all columns that are inactive
+under guided = 0.0, using the pre-sampling dependency tables.
+
+Unlike the counterfactual regime, intervention deployment amounts (`:intervention_group`)
+and `:depth_thresholds` remain **active** (unchanged) under guided = 0.0 — unguided
+scenarios still deploy interventions, just without MCDA-driven site selection. Only
+`:criteria_weights` and `:plan_horizon` are zeroed, and `:strategy_group` columns
+(`seed_strategy`/`fog_strategy`/`mc_strategy`) are fixed to `DECISION_STRATEGY[:periodic]`
+— mirroring what `sample_unguided`'s pre-sampling `_resolve_conditional_spec!(spec,
+(guided=0.0,))` does.
+
+# Arguments
+- `samples` : intervention scenario rows (output of `sample_guided` or `sample_paired`).
+- `spec` : model spec for the same domain (output of `model_spec(d)`).
+  Currently unused — the dependency tables are module-level constants — but retained
+  for forward-compatibility with domain-specific dependency overrides.
+
+# Returns
+Unguided-regime scenario rows paired 1:1 with `samples`.
+"""
+function derive_unguided(samples::DataFrame, spec::DataFrame)::DataFrame
+    return _derive_regime(samples, 0.0)
+end
+
+"""
+Maps a `regimes` symbol (as accepted by `sample_matched`) to the `:guided` sentinel
+value used to derive that regime from a guided draw via `_derive_regime`.
+"""
+const _REGIME_GUIDED_VALUE = Dict{Symbol,Float64}(
+    :counterfactual => -1.0,
+    :unguided => 0.0
+)
+
+"""
+    sample_matched(d::Domain, n::Int; ssp=nothing, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)), regimes=(:counterfactual, :unguided))::DataFrame
+
+Draw `n` guided intervention scenarios and produce paired rows for each regime in
+`regimes`. Returns a DataFrame with `(1 + length(regimes)) * n` rows and a `:run_type`
+column (`String`) with values in `("intervention", "counterfactual", "unguided")`
+(whichever were requested).
+
+All rows share identical non-intervention parameter values (and, for `:unguided`,
+identical intervention deployment amounts too — see `derive_unguided`), enabling causal
+attribution by differencing outcomes across regimes.
+
+This differs from `sample_balanced`, which draws each regime independently: those rows
+are NOT matched row-for-row and cannot be used for this kind of differencing.
+
+`n` should be a power of 2 for Sobol' sequences.
+
+# Arguments
+- `d` : Domain.
+- `n` : number of guided intervention scenarios to draw.
+- `ssp` : RCP/SSP scenario to switch the domain to before sampling, if given.
+- `sample_method` : type of sampler to use.
+- `regimes` : which regimes to derive alongside the guided draw. Must be a non-empty
+  subset of `(:counterfactual, :unguided)`.
+
+# Returns
+Scenario specification with paired intervention + regime rows.
+"""
+function sample_matched(
+    d::Domain, n::Int;
+    ssp::Union{String,Nothing}=nothing,
+    sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32)),
+    regimes::Tuple{Vararg{Symbol}}=(:counterfactual, :unguided)
+)::DataFrame
+    isempty(regimes) && throw(ArgumentError("`regimes` must be non-empty"))
+    unknown = filter(r -> !haskey(_REGIME_GUIDED_VALUE, r), regimes)
+    isempty(unknown) || throw(
+        ArgumentError(
+            "Unknown regime(s) $unknown; expected a subset of " *
+            "$(Tuple(keys(_REGIME_GUIDED_VALUE)))"
+        )
+    )
+
+    isnothing(ssp) || switch_RCPs!(d, ssp)
+
+    intervention_samples = sample_guided(d, n; sample_method)
+    intervention_samples[!, :run_type] .= "intervention"
+
+    regime_dfs = [
+        let df = _derive_regime(intervention_samples, _REGIME_GUIDED_VALUE[r])
+            df[!, :run_type] .= string(r)
+            df
+        end for r in regimes
+    ]
+
+    return vcat(intervention_samples, regime_dfs...)
+end
+
+"""
+    sample_paired(d::Domain, n::Int; ssp=nothing, sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+
+Draw `n` guided intervention scenarios and produce paired counterfactual rows.
+Returns a DataFrame with `2n` rows and a `:run_type` column (`String`).
+
+The intervention and CF rows share identical non-intervention parameter values,
+enabling causal attribution by differencing outcomes.
+
+`n` should be a power of 2 for Sobol' sequences.
+
+A special case of `sample_matched` with `regimes=(:counterfactual,)`; see that function
+for a 3-way (guided/CF/unguided) matched comparison.
+
+# Arguments
+- `d` : Domain.
+- `n` : number of guided intervention scenarios to draw.
+- `ssp` : RCP/SSP scenario to switch the domain to before sampling, if given.
+- `sample_method` : type of sampler to use.
+
+# Returns
+Scenario specification with `2n` paired intervention/counterfactual rows.
+"""
+function sample_paired(
+    d::Domain, n::Int;
+    ssp::Union{String,Nothing}=nothing,
+    sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32))
+)::DataFrame
+    return sample_matched(d, n; ssp, sample_method, regimes=(:counterfactual,))
+end
+
+"""
+    sample_matched_stratified(d::Domain, n_per_stratum::Int, ssp_strata::AbstractVector{String}; regimes=(:counterfactual, :unguided))::DataFrame
+
+For each SSP in `ssp_strata`, draw `n_per_stratum` matched rows (see `sample_matched`)
+using an independent Owen scramble. Returns a DataFrame with `:ssp` and `:run_type`
+columns.
+
+`n_per_stratum` must be a power of 2.
+
+# Arguments
+- `d` : Domain.
+- `n_per_stratum` : number of guided intervention scenarios to draw per SSP stratum.
+- `ssp_strata` : RCP/SSP scenarios to stratify sampling over.
+- `regimes` : which regimes to derive alongside the guided draw; see `sample_matched`.
+
+# Returns
+Scenario specification with `(1 + length(regimes)) * n_per_stratum * length(ssp_strata)`
+matched rows.
+"""
+function sample_matched_stratified(
+    d::Domain,
+    n_per_stratum::Int,
+    ssp_strata::AbstractVector{String};
+    regimes::Tuple{Vararg{Symbol}}=(:counterfactual, :unguided)
+)::DataFrame
+    results = map(ssp_strata) do ssp
+        m = SobolSample(; R=OwenScramble(; base=2, pad=32))  # fresh scramble per stratum
+        df = sample_matched(d, n_per_stratum; ssp, sample_method=m, regimes)
+        df[!, :ssp] .= ssp
+        df
+    end
+    return vcat(results...)
+end
+
+"""
+    sample_paired_stratified(d::Domain, n_per_stratum::Int, ssp_strata::AbstractVector{String})::DataFrame
+
+For each SSP in `ssp_strata`, draw `n_per_stratum` paired rows (see `sample_paired`)
+using an independent Owen scramble. Returns a DataFrame with `:ssp` and `:run_type`
+columns.
+
+`n_per_stratum` must be a power of 2.
+
+A special case of `sample_matched_stratified` with `regimes=(:counterfactual,)`.
+
+# Arguments
+- `d` : Domain.
+- `n_per_stratum` : number of guided intervention scenarios to draw per SSP stratum.
+- `ssp_strata` : RCP/SSP scenarios to stratify sampling over.
+
+# Returns
+Scenario specification with `2 * n_per_stratum * length(ssp_strata)` paired rows.
+"""
+function sample_paired_stratified(
+    d::Domain,
+    n_per_stratum::Int,
+    ssp_strata::AbstractVector{String}
+)::DataFrame
+    return sample_matched_stratified(
+        d, n_per_stratum, ssp_strata; regimes=(:counterfactual,)
+    )
 end

--- a/ADRIA/src/io/sampling/sampling_stratified.jl
+++ b/ADRIA/src/io/sampling/sampling_stratified.jl
@@ -1,0 +1,95 @@
+"""
+    sample_stratified(d::Domain, n_env::Int64, n_lever::Int64;
+        regimes::Tuple{Vararg{Symbol}}=(:guided, :unguided, :counterfactual),
+        env_sample_method=SobolSample(R=OwenScramble(base=2, pad=32)),
+        lever_sample_method=SobolSample(R=OwenScramble(base=2, pad=32)))::DataFrame
+
+Draw a nested Environment -> Intervention policy -> Deployment strategy sample.
+
+# Design
+
+Level 1 (blocking, identical across every regime): `EnvironmentalLayer` factors
+(`dhw_scenario`, `wave_scenario`, `cyclone_mortality_scenario`) and ecological/biological
+factors (`Coral`, `GrowthAcceleration`). `n_env` blocks are drawn once via a space-filling
+design and reused, unchanged, across every regime and every lever draw within that block.
+Biological parameters are blocked here rather than nested under deployment strategy
+because they interact multiplicatively with environment (thermal tolerance changes what
+"cooler refugia" means) -- they are a source of exogenous uncertainty, not a lever.
+
+Level 2/3 (independently sampled within each regime, per block): each regime's own active
+factors -- MCDA criteria weights/plan_horizon/mcda_method for `:guided`; seeding/fogging/
+moving-coral deployment amounts, depth thresholds and strategy timing for all regimes --
+are drawn independently via `sample_guided`/`sample_unguided`/`sample_cf`, so RSA/PRIM
+retains full independent, space-filling coverage of each regime's own lever space.
+
+This differs from `sample_matched`, which derives unguided/CF rows from a single guided
+draw by zeroing columns: that collapses unguided/CF lever coverage down to whatever the
+guided draw happened to produce, and is suited to causal differencing (validating a single
+candidate region), not open-ended scenario discovery. `sample_stratified` is suited to the
+latter: it controls for the environment/ecology confound via blocking while leaving each
+regime's own factor space free to vary for RSA/PRIM to search.
+
+Rows carry `:env_block` (integer id of which Level-1 block they belong to, `1:n_env`) so
+downstream analysis can facet by block for a 3-way, environment-controlled comparison, or
+run RSA per-regime using each block as a repeated observation. Regime is identified by
+`:guided` itself (`1` guided, `0` unguided, `-1` counterfactual) -- no separate `:run_type`
+column, since it would just duplicate `:guided`.
+
+# Arguments
+- `d` : Domain.
+- `n_env` : number of Level-1 environment/ecology blocks to draw (power of 2 for Sobol').
+- `n_lever` : number of Level-2/3 lever draws per (block, regime) cell (power of 2 for
+  Sobol').
+- `regimes` : which policy regimes to include; subset of `(:guided, :unguided,
+  :counterfactual)`.
+- `env_sample_method` : sampler used for the Level-1 block draw.
+- `lever_sample_method` : sampler used for each regime's Level-2/3 lever draw.
+
+# Returns
+Scenario specification with `n_env * length(regimes) * n_lever` rows.
+"""
+function sample_stratified(
+    d::Domain, n_env::Int64, n_lever::Int64;
+    regimes::Tuple{Vararg{Symbol}}=(:guided, :unguided, :counterfactual),
+    env_sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32)),
+    lever_sample_method=SobolSample(; R=OwenScramble(; base=2, pad=32))
+)::DataFrame
+    regime_sampler = Dict(
+        :guided => sample_guided,
+        :unguided => sample_unguided,
+        :counterfactual => sample_cf
+    )
+    unknown = filter(r -> !haskey(regime_sampler, r), regimes)
+    isempty(unknown) || throw(
+        ArgumentError(
+            "Unknown regime(s) $unknown; expected a subset of " *
+            "$(Tuple(keys(regime_sampler)))"
+        )
+    )
+
+    # Level 1: environment + ecological/biological blocking factors, filtered
+    # consistently with how sample_guided/sample_unguided/sample_cf filter their spec.
+    cb_calib_groups::Vector{Int64} = d.loc_data.CB_CALIB_GROUPS
+    full_spec = _filtered_model_spec(model_spec(d), cb_calib_groups)
+    env_fieldnames = component_params(
+        d.model, [EnvironmentalLayer, Coral, GrowthAcceleration]
+    ).fieldname
+    env_spec = full_spec[in.(full_spec.fieldname, Ref(env_fieldnames)), :]
+
+    env_blocks = sample(env_spec, n_env, env_sample_method)
+    env_cols = names(env_blocks)
+
+    cells = DataFrame[]
+    for b = 1:n_env
+        for r in regimes
+            df = regime_sampler[r](d, n_lever; sample_method=lever_sample_method)
+            for col in env_cols
+                df[!, col] .= env_blocks[b, col]
+            end
+            df[!, :env_block] .= b
+            push!(cells, df)
+        end
+    end
+
+    return vcat(cells...)
+end

--- a/ADRIA/test/sampling.jl
+++ b/ADRIA/test/sampling.jl
@@ -729,3 +729,237 @@ end
             "seed_wave_stress ordering test inconclusive"
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests for paired counterfactual sampling (sampling_design_plan_v4.md §5 Step 3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "derive_cf" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    num_samples = 32
+    spec = ADRIA.model_spec(dom)
+    intervention_samples = ADRIA.sample_guided(dom, num_samples)
+    cf_samples = ADRIA.derive_cf(intervention_samples, spec)
+
+    zeroed_cols = [
+        :N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM,
+        :fogging, :SRM, :N_mc_settlers
+    ]
+    zeroed_cols = filter(c -> c in propertynames(cf_samples), zeroed_cols)
+    strategy_cols = filter(
+        c -> c in propertynames(cf_samples), [:seed_strategy, :fog_strategy, :mc_strategy]
+    )
+
+    @testset "CF zeroing" begin
+        @test all(all(cf_samples[:, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected all of $zeroed_cols to be 0.0 in CF rows"
+    end
+
+    @testset "strategy sentinel" begin
+        @test all(all(cf_samples[:, c] .== -1.0) for c in strategy_cols) ||
+            "Expected all of $strategy_cols to be -1.0 (CF sentinel) in CF rows"
+    end
+
+    @testset "env params unchanged" begin
+        # Columns derive_cf may fix (per _PARAM_DEPENDENCIES/_GROUP_MEMBERS) are not
+        # "non-intervention" even though some (criteria weights, depth thresholds)
+        # fall outside the Intervention component.
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(intervention_samples) if c ∉ cf_affected_cols
+        ]
+        @test intervention_samples[:, env_cols] == cf_samples[:, env_cols] ||
+            "Non-intervention parameter columns differ between paired rows"
+    end
+
+    @testset "parent params zeroed" begin
+        nonzero_mask = vec(
+            any(Matrix(intervention_samples[:, zeroed_cols]) .> 0; dims=2)
+        )
+        @test any(nonzero_mask) ||
+            "No sampled guided rows had non-zero intervention parent values to test against"
+        @test all(all(cf_samples[nonzero_mask, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected $zeroed_cols to be 0.0 in CF rows paired to non-zero intervention rows"
+    end
+end
+
+@testset "sample_paired" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n = 16
+    scens = ADRIA.sample_paired(dom, n)
+
+    @testset "shape" begin
+        @test nrow(scens) == 2n || "Expected 2n rows, got $(nrow(scens))"
+        @test count(==("intervention"), scens.run_type) == n
+        @test count(==("counterfactual"), scens.run_type) == n
+    end
+
+    @testset "pairing" begin
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(scens) if c ∉ cf_affected_cols && c != :run_type
+        ]
+
+        interv_rows = scens[scens.run_type .== "intervention", env_cols]
+        cf_rows = scens[scens.run_type .== "counterfactual", env_cols]
+        @test interv_rows == cf_rows ||
+            "Non-intervention parameters do not match between paired rows"
+    end
+
+    @testset "run_type type" begin
+        @test eltype(scens.run_type) == String
+    end
+end
+
+@testset "sample_paired_stratified" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n_per_stratum = 8
+    # Test_domain only ships RCP45 DHW/wave data; repeat the same RCP as two
+    # independently-scrambled strata to validate shape/labelling without
+    # requiring additional RCP datasets.
+    ssp_strata = ["45", "45"]
+    scens = ADRIA.sample_paired_stratified(dom, n_per_stratum, ssp_strata)
+
+    @testset "shape" begin
+        @test nrow(scens) == 2 * n_per_stratum * length(ssp_strata) ||
+            "Expected $(2 * n_per_stratum * length(ssp_strata)) rows, got $(nrow(scens))"
+        @test count(==("45"), scens.ssp) == 2 * n_per_stratum * length(ssp_strata)
+    end
+end
+
+@testset "derive_unguided" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    num_samples = 32
+    spec = ADRIA.model_spec(dom)
+    intervention_samples = ADRIA.sample_guided(dom, num_samples)
+    ug_samples = ADRIA.derive_unguided(intervention_samples, spec)
+
+    # Unlike CF, unguided rows keep intervention deployment amounts and depth
+    # thresholds unchanged (:intervention_group / :depth_thresholds stay active
+    # at guided=0.0) — only criteria weights / plan_horizon are zeroed.
+    zeroed_cols = filter(
+        c -> c in propertynames(ug_samples),
+        [
+            :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,
+            :fog_heat_stress, :mc_heat_stress, :plan_horizon
+        ]
+    )
+    unchanged_cols = filter(
+        c -> c in propertynames(ug_samples),
+        [:N_seed_TA, :N_seed_CA, :fogging, :SRM, :N_mc_settlers, :depth_min]
+    )
+    strategy_cols = filter(
+        c -> c in propertynames(ug_samples), [:seed_strategy, :fog_strategy, :mc_strategy]
+    )
+
+    @testset "criteria weights/plan_horizon zeroed" begin
+        @test all(all(ug_samples[:, c] .== 0.0) for c in zeroed_cols) ||
+            "Expected all of $zeroed_cols to be 0.0 in unguided rows"
+    end
+
+    @testset "strategy fixed to periodic" begin
+        periodic = ADRIA.decision.DECISION_STRATEGY[:periodic]
+        @test all(all(ug_samples[:, c] .== periodic) for c in strategy_cols) ||
+            "Expected all of $strategy_cols to be $periodic (periodic) in unguided rows"
+    end
+
+    @testset "intervention deployment amounts unchanged" begin
+        @test intervention_samples[:, unchanged_cols] == ug_samples[:, unchanged_cols] ||
+            "Expected intervention deployment amounts to be unchanged in unguided rows"
+    end
+
+    @testset "guided column set to 0.0" begin
+        @test all(ug_samples.guided .== 0.0)
+    end
+end
+
+@testset "sample_matched" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n = 16
+
+    @testset "default regimes (3-way)" begin
+        scens = ADRIA.sample_matched(dom, n)
+
+        @test nrow(scens) == 3n || "Expected 3n rows, got $(nrow(scens))"
+        @test count(==("intervention"), scens.run_type) == n
+        @test count(==("counterfactual"), scens.run_type) == n
+        @test count(==("unguided"), scens.run_type) == n
+        @test eltype(scens.run_type) == String
+
+        cf_affected_cols = Set(
+            vcat(
+                [:guided],
+                reduce(
+                    vcat,
+                    [
+                        get(ADRIA._GROUP_MEMBERS, dep.child, [dep.child])
+                        for dep in ADRIA._PARAM_DEPENDENCIES
+                    ]
+                )
+            )
+        )
+        env_cols = [
+            c for c in propertynames(scens) if c ∉ cf_affected_cols && c != :run_type
+        ]
+
+        interv_rows = scens[scens.run_type .== "intervention", env_cols]
+        cf_rows = scens[scens.run_type .== "counterfactual", env_cols]
+        ug_rows = scens[scens.run_type .== "unguided", env_cols]
+        @test interv_rows == cf_rows ||
+            "Non-intervention parameters do not match between guided/CF rows"
+        @test interv_rows == ug_rows ||
+            "Non-intervention parameters do not match between guided/unguided rows"
+    end
+
+    @testset "regimes subsetting" begin
+        ug_only = ADRIA.sample_matched(dom, n; regimes=(:unguided,))
+        @test nrow(ug_only) == 2n
+        @test count(==("counterfactual"), ug_only.run_type) == 0
+        @test count(==("unguided"), ug_only.run_type) == n
+
+        cf_only = ADRIA.sample_matched(dom, n; regimes=(:counterfactual,))
+        @test nrow(cf_only) == 2n
+        @test count(==("unguided"), cf_only.run_type) == 0
+        @test count(==("counterfactual"), cf_only.run_type) == n
+    end
+
+    @testset "invalid regimes" begin
+        @test_throws ArgumentError ADRIA.sample_matched(dom, n; regimes=())
+        @test_throws ArgumentError ADRIA.sample_matched(dom, n; regimes=(:bogus,))
+    end
+end
+
+@testset "sample_matched_stratified" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    n_per_stratum = 8
+    ssp_strata = ["45", "45"]
+    scens = ADRIA.sample_matched_stratified(dom, n_per_stratum, ssp_strata)
+
+    @testset "shape" begin
+        @test nrow(scens) == 3 * n_per_stratum * length(ssp_strata) ||
+            "Expected $(3 * n_per_stratum * length(ssp_strata)) rows, got $(nrow(scens))"
+        @test count(==("45"), scens.ssp) == 3 * n_per_stratum * length(ssp_strata)
+    end
+end


### PR DESCRIPTION
## Summary
Stacked on #1149 (graph-based conditional dependency resolution) — the first consumer of that dependency graph:

- `derive_cf` / `derive_unguided` (`sampling_interventions.jl`): derive a paired counterfactual/unguided row from a guided sample, holding non-intervention factors fixed via `_derive_regime`.
- `sample_paired` / `sample_matched` (+ `_stratified` variants): draw guided scenarios together with 1:1 paired rows for one or more regimes (counterfactual, unguided), tagged by `:run_type` (and `:ssp` for the stratified variants using independent Owen scrambles per RCP/SSP).
- `sampling_stratified.jl`: `sample_stratified` nests Level-1 environment/ecology blocks (shared across regimes) with independent Level-2/3 lever draws per (block, regime) cell, for RSA/PRIM-style scenario discovery workflows that need matched environmental conditions across regimes.
- Documents the full family of regime-scoped sampling functions in `generating_scenarios.md`.

Relates to Issue #1132 — directly implements the "split scenarios by outcome, rank features by distribution comparison" example assessment workflow described in the issue, and pairs naturally with a future Wilcoxon signed-rank comparison (paired-sample analog of the already-added Mann-Whitney U, #1141) given the 1:1 paired output here.

## Test plan
- [x] Tests for `derive_cf`/`derive_unguided` (correct columns zeroed/sentineled/unchanged), `sample_paired`/`sample_matched`/stratified variants (row counts, pairing integrity, regime subsetting, invalid-regime errors)