### PR TITLE
feat(decision): add projection_confidence factor and decision.build_decay

### DIFF
--- a/ADRIA/docs/scripts/viz_check_common.jl
+++ b/ADRIA/docs/scripts/viz_check_common.jl
@@ -518,7 +518,8 @@ check("criteria_spatial_plots") do
     sum_cover = vec(sum(example_dom.init_coral_cover; dims=1).data)
     dhw_scens = example_dom.dhw_scens[:, :, Int64(scen["dhw_scenario"])]
     plan_horizon = Int64(scen["plan_horizon"])
-    decay = 0.99 .^ (1:(plan_horizon + 1)) .^ 2
+    projection_confidence = scen["projection_confidence"]
+    decay = ADRIA.decision.build_decay(plan_horizon, projection_confidence)
     dhw_projection = ADRIA.decision.weighted_projection(
         dhw_scens, 1, plan_horizon, decay, 75
     )

--- a/ADRIA/docs/src/usage/analysis.jl
+++ b/ADRIA/docs/src/usage/analysis.jl
@@ -166,7 +166,8 @@
 # sum_cover = vec(sum(dom.init_coral_cover; dims=1).data)
 # dhw_scens = dom.dhw_scens[:, :, Int64(scen["dhw_scenario"])]
 # plan_horizon = Int64(scen["plan_horizon"])
-# decay = 0.99 .^ (1:(plan_horizon + 1)) .^ 2
+# projection_confidence = scen["projection_confidence"]
+# decay = ADRIA.decision.build_decay(plan_horizon, projection_confidence)
 # dhw_projection = ADRIA.decision.weighted_projection(dhw_scens, 1, plan_horizon, decay, 75)
 # area_weighted_conn = dom.conn.data .* ADRIA.loc_k_area(dom)
 # conn_cache = similar(area_weighted_conn)

--- a/ADRIA/docs/src/usage/generating_scenarios.md
+++ b/ADRIA/docs/src/usage/generating_scenarios.md
@@ -289,8 +289,8 @@ requested via `regimes` (any non-empty subset of `(:counterfactual, :unguided)`,
 both), all sharing the same non-intervention factor draws — `sample_paired` is just
 `sample_matched` with `regimes=(:counterfactual,)`. Note that unguided rows keep the same
 intervention deployment amounts as their guided counterpart (only the MCDA criteria
-weights/`plan_horizon` are zeroed and the strategy is fixed to periodic) — unlike
-counterfactual rows, where deployment amounts are zeroed too:
+weights/`plan_horizon`/`projection_confidence` are zeroed and the strategy is fixed to
+periodic) — unlike counterfactual rows, where deployment amounts are zeroed too:
 
 ```julia
 # 128 guided/counterfactual/unguided triples (384 rows), tagged by `:run_type`

--- a/ADRIA/src/decision/Decision.jl
+++ b/ADRIA/src/decision/Decision.jl
@@ -41,6 +41,7 @@ export
     unguided_selection,
     decision_frequency,
     weighted_projection,
+    build_decay,
     identify_within_depth_bounds,
     summary_stat_env,
     mcda_methods,

--- a/ADRIA/src/decision/dMCDA.jl
+++ b/ADRIA/src/decision/dMCDA.jl
@@ -128,6 +128,23 @@ function identify_within_depth_bounds(
 end
 
 """
+    build_decay(plan_horizon::Int64, projection_confidence::Float64; α::Float64=0.99)::Vector{Float64}
+
+Per-timestep decay vector weighting environmental projections by lead time, for
+use with `weighted_projection`. `α` is the per-step base decay rate (unchanged
+default). `projection_confidence` (0.0-1.0) sets `exponent = 2.0 -
+projection_confidence`: 0.0 gives exponent 2.0 (steep decay, historical
+default), 1.0 gives exponent 1.0 (mild decay). `plan_horizon` controls the
+window length (vector length), not decay shape.
+"""
+function build_decay(
+    plan_horizon::Int64, projection_confidence::Float64; α::Float64=0.99
+)::Vector{Float64}
+    exponent = 2.0 - projection_confidence
+    return α .^ (1:(plan_horizon + 1)) .^ exponent
+end
+
+"""
     weighted_projection(
         env_data::AbstractMatrix{Float64}, tstep::Int64, planning_horizon::Int64,
         decay::AbstractVector{Float64}, timeframe::Int64

--- a/ADRIA/src/decision/location_selection.jl
+++ b/ADRIA/src/decision/location_selection.jl
@@ -113,15 +113,15 @@ function rank_locations(
     fog_pref = FogPreferences(dom, scens[1, :])
     mc_pref = MCPreferences(dom, scens[1, :])
 
-    α = 0.99
-
     loc_data = dom.loc_data
     coral_habitable_locs = loc_data.k .> 0.0
     for (scen_idx, scen) in enumerate(eachrow(scens))
         # Decisions should place more weight on environmental conditions
-        # closer to the decision point
+        # closer to the decision point. `projection_confidence` shapes how
+        # aggressively that weighting decays with lead time.
         plan_horizon = Int64(scen[At("plan_horizon")])
-        decay = α .^ (1:(plan_horizon + 1)) .^ 2
+        projection_confidence = scen[At("projection_confidence")]
+        decay = build_decay(plan_horizon, projection_confidence)
 
         min_depth = scen[factors = At("depth_min")].data[1]
         depth_offset = scen[factors = At("depth_offset")].data[1]

--- a/ADRIA/src/interventions/Interventions.jl
+++ b/ADRIA/src/interventions/Interventions.jl
@@ -153,6 +153,14 @@ Base.@kwdef struct Intervention <: EcoModel
         name="Planning Horizon",
         description="How many years of projected data to take into account when selecting intervention locations (0 only accounts for current deployment year)."
     )
+    projection_confidence::Param = Factor(
+        0.0;
+        ptype="continuous",
+        dist=Uniform,
+        dist_params=(0.0, 1.0),
+        name="Projection Confidence",
+        description="Confidence in far-future environmental projections when weighting them for site selection (only active when `guided` > 0)."
+    )
     seed_deployment_freq::Param = Factor(
         5;
         ptype="ordered categorical",

--- a/ADRIA/src/io/sampling/sampling_dependencies.jl
+++ b/ADRIA/src/io/sampling/sampling_dependencies.jl
@@ -95,6 +95,23 @@ const _PARAM_DEPENDENCIES = [
     # since decision.mcda_methods() is indexed from 1.
     (parent=:guided, child=:mcda_method, op=:gt, value=0.0, negate=false, fix_to=0.0),
     (parent=:guided, child=:plan_horizon, op=:neq, value=0.0, negate=false, fix_to=0.0),
+    # fix_to must match :intervention_group's fix_to=0.0 above, since
+    # `projection_confidence` is also a member of that group (see
+    # _GROUP_MEMBERS) and _validate_dependencies rejects two child symbols
+    # disagreeing on a fix_to for the same physical column. The value is
+    # cosmetic either way, not correctness-affecting: `plan_horizon`'s own row
+    # above already collapses the decay window to a single element whenever
+    # this row fires, and `1^exponent == 1` for any exponent -- so this
+    # factor's fixed value has no effect on `build_decay`'s output once
+    # `plan_horizon` is inactive.
+    (
+        parent=:guided,
+        child=:projection_confidence,
+        op=:neq,
+        value=0.0,
+        negate=false,
+        fix_to=0.0
+    ),
     (
         parent=:guided,
         child=:depth_thresholds,
@@ -136,7 +153,7 @@ const _GROUP_MEMBERS = Dict{Symbol,Vector{Symbol}}(
         :N_seed_TA, :N_seed_CA, :N_seed_CNA, :N_seed_SM, :N_seed_LM,
         :N_mc_settlers, :seeding_devices_per_m2, :min_iv_locations,
         :mc_min_iv_locations, :fogging, :SRM, :a_adapt, :a_adapt_ref,
-        :seed_years, :shade_years, :fog_years, :plan_horizon,
+        :seed_years, :shade_years, :fog_years, :plan_horizon, :projection_confidence,
         :seed_deployment_freq, :fog_deployment_freq, :shade_deployment_freq,
         :mc_deployment_freq, :seed_year_start, :shade_year_start,
         :fog_year_start, :mc_year_start, :mc_years,

--- a/ADRIA/src/io/sampling/sampling_interventions.jl
+++ b/ADRIA/src/io/sampling/sampling_interventions.jl
@@ -152,7 +152,8 @@ under guided = 0.0, using the pre-sampling dependency tables.
 Unlike the counterfactual regime, intervention deployment amounts (`:intervention_group`)
 and `:depth_thresholds` remain **active** (unchanged) under guided = 0.0 — unguided
 scenarios still deploy interventions, just without MCDA-driven site selection. Only
-`:criteria_weights` and `:plan_horizon` are zeroed, and `:strategy_group` columns
+`:criteria_weights`, `:plan_horizon`, and `:projection_confidence` are zeroed, and
+`:strategy_group` columns
 (`seed_strategy`/`fog_strategy`/`mc_strategy`) are fixed to `DECISION_STRATEGY[:periodic]`
 — mirroring what `sample_unguided`'s pre-sampling `_resolve_conditional_spec!(spec,
 (guided=0.0,))` does.

--- a/ADRIA/src/io/sampling/sampling_stratified.jl
+++ b/ADRIA/src/io/sampling/sampling_stratified.jl
@@ -17,8 +17,9 @@ because they interact multiplicatively with environment (thermal tolerance chang
 "cooler refugia" means) -- they are a source of exogenous uncertainty, not a lever.
 
 Level 2/3 (independently sampled within each regime, per block): each regime's own active
-factors -- MCDA criteria weights/plan_horizon/mcda_method for `:guided`; seeding/fogging/
-moving-coral deployment amounts, depth thresholds and strategy timing for all regimes --
+factors -- MCDA criteria weights/plan_horizon/projection_confidence/mcda_method for
+`:guided`; seeding/fogging/moving-coral deployment amounts, depth thresholds and strategy
+timing for all regimes --
 are drawn independently via `sample_guided`/`sample_unguided`/`sample_cf`, so RSA/PRIM
 retains full independent, space-filling coverage of each regime's own lever space.
 

--- a/ADRIA/src/io/sampling/sampling_unguided.jl
+++ b/ADRIA/src/io/sampling/sampling_unguided.jl
@@ -22,7 +22,8 @@ function sample_unguided(
     cols = [:val, :lower_bound, :upper_bound, :dist_params, :is_constant]
     spec_df[guided_col, cols] .= [0 0 0 (0.0, 0.0) true]
 
-    # Pre-sampling resolution: fix criteria weights, plan_horizon and strategy columns
+    # Pre-sampling resolution: fix criteria weights, plan_horizon,
+    # projection_confidence, and strategy columns
     _resolve_conditional_spec!(spec_df, (guided=0.0,))
 
     return sample(spec_df, n, sample_method)

--- a/ADRIA/src/scenario.jl
+++ b/ADRIA/src/scenario.jl
@@ -880,10 +880,11 @@ function run_model(
     # Number of time steps in environmental layers to look ahead when making decisions
     plan_horizon::Int64 = Int64(param_set[At("plan_horizon")])
 
-    # Decisions should place more weight on environmental conditions
-    # closer to the decision point
-    α = 0.99
-    decay = α .^ (1:(plan_horizon + 1)) .^ 2
+    # Decisions should place more weight on environmental conditions closer to
+    # the decision point. `projection_confidence` shapes how aggressively that
+    # weighting decays with lead time (see decision.build_decay).
+    projection_confidence::Float64 = param_set[At("projection_confidence")]
+    decay = build_decay(plan_horizon, projection_confidence)
 
     # Years at which intervention locations are re-evaluated and deployed
     # seed_decision_years = decision_frequency(

--- a/ADRIA/test/decisions/mcda.jl
+++ b/ADRIA/test/decisions/mcda.jl
@@ -190,7 +190,8 @@ if hasmethod(
         # DHWS
         dhw_scens = ADRIA_DOM_45.dhw_scens[:, :, Int64(scen["dhw_scenario"])]
         plan_horizon = Int64(scen["plan_horizon"])
-        decay = 0.99 .^ (1:(plan_horizon + 1)) .^ 2
+        projection_confidence = scen["projection_confidence"]
+        decay = ADRIA.decision.build_decay(plan_horizon, projection_confidence)
         dhw_projection = ADRIA.decision.weighted_projection(
             dhw_scens, 1, plan_horizon, decay, 75
         )

--- a/ADRIA/test/sampling.jl
+++ b/ADRIA/test/sampling.jl
@@ -123,6 +123,12 @@ end
             @test all(scens[unguided_rows, :plan_horizon] .== 0) ||
                 "Unguided rows in plain sample() have non-zero plan_horizon"
         end
+
+        # projection_confidence only matters when guided != 0
+        if any(unguided_rows)
+            @test all(scens[unguided_rows, :projection_confidence] .== 0) ||
+                "Unguided rows in plain sample() have non-zero projection_confidence"
+        end
     end
 end
 
@@ -260,10 +266,12 @@ end
             ADRIA.component_params(ADRIA.model_spec(dom), ADRIA.Intervention).fieldname
         )
 
-        # Ignore guided, planning horizon, and reactive params (which are conditionally zeroed)
+        # Ignore guided, planning horizon, projection confidence, and reactive
+        # params (which are conditionally zeroed)
         interv_params = String[
             ip for ip in interv_params if
-            ip ∉ ["plan_horizon", "guided"] && !contains(ip, "reactive")
+            ip ∉ ["plan_horizon", "projection_confidence", "guided"] &&
+            !contains(ip, "reactive")
         ]
 
         # Ensure at least one intervention is active
@@ -608,6 +616,12 @@ end
                 "Unguided: :plan_horizon should be 0.0"
         end
 
+        pc_row = spec[spec.fieldname .== :projection_confidence, :]
+        if !isempty(pc_row)
+            @test pc_row.is_constant[1] && isequal(pc_row.val[1], 0.0) ||
+                "Unguided: :projection_confidence should be 0.0"
+        end
+
         for col in ADRIA._GROUP_MEMBERS[:criteria_weights]
             row = spec[spec.fieldname .== col, :]
             isempty(row) && continue
@@ -863,7 +877,7 @@ end
         c -> c in propertynames(ug_samples),
         [
             :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,
-            :fog_heat_stress, :mc_heat_stress, :plan_horizon
+            :fog_heat_stress, :mc_heat_stress, :plan_horizon, :projection_confidence
         ]
     )
     unchanged_cols = filter(


### PR DESCRIPTION
## Summary
- Replaces the hardcoded quadratic lead-time decay used when weighting environmental projections for site selection with a tunable curve: `decision.build_decay(plan_horizon, projection_confidence)` computes `alpha^(1:plan_horizon+1)^(2 - projection_confidence)`.
- New `projection_confidence` factor (0.0-1.0, continuous): 0 reproduces the historical steep (exponent=2) decay, 1 gives a mild (exponent=1) decay.
- Only active when `guided > 0` — resolved via the existing dependency-graph machinery (`sampling_dependencies.jl`) alongside `plan_horizon`, so counterfactual/unguided scenarios sentinel it to 0.0 the same way.
- Updates `scenario.jl` and `location_selection.jl` to call `build_decay` instead of inlining the old fixed-exponent formula, and refreshes the docs/scripts viz-check example and doc comments that mirrored the same calculation.

Relates to Issue #1132 — extends the site-selection decision logic with a tunable confidence parameter, building on the conditional-dependency infrastructure merged via #1149.

## Test plan
- [x] `test/decisions/mcda.jl` updated to call `build_decay` directly
- [x] `test/sampling.jl`: projection_confidence sentineled to 0.0 for unguided/CF regimes (both pre- and post-sampling resolution), excluded from the "at least one intervention active" guided-sampling check, included in `derive_unguided`'s zeroed-columns check