### PR TITLE
feat(interventions): widen mc_min_iv_locations sampling range

### DIFF
--- a/ADRIA/src/interventions/Interventions.jl
+++ b/ADRIA/src/interventions/Interventions.jl
@@ -85,7 +85,7 @@ Base.@kwdef struct Intervention <: EcoModel
         5;
         ptype="ordered discrete",
         dist=DiscreteUniform,
-        dist_params=(5.0, 100.0),
+        dist_params=(1.0, 400.0),
         name="Moving corals minimum intervention locations",
         description="Minimum number of locations to perform moving corals intervention"
     )


### PR DESCRIPTION
## Summary
- Widens the lower/upper bounds of `mc_min_iv_locations` (moving-corals minimum intervention locations factor) from `(5, 100)` to `(1, 400)`, to explore a broader range of minimum-location thresholds.

Same flavor as #1145 (reactive_absolute_threshold widening) — a factor-definition exploration tweak, unrelated to Issue #1132 directly.

## Test plan
- [ ] Existing intervention/sampling tests pass with the new bound