### PR TITLE
feat(ADRIAanalysis): RSA auto-dispatch, stratified/counterfactual RSA, feature-set metadata

### DIFF
--- a/ADRIAanalysis/Project.toml
+++ b/ADRIAanalysis/Project.toml
@@ -1,7 +1,7 @@
 name = "ADRIAanalysis"
 uuid = "bc4d0ea8-6565-4397-854d-28474bf8c6b3"
 authors = ["Takuya Iwanaga"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 ADRIA = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"

--- a/ADRIAanalysis/ext/ADRIAanalysisRulesExt.jl
+++ b/ADRIAanalysis/ext/ADRIAanalysisRulesExt.jl
@@ -101,8 +101,12 @@ function ADRIAanalysis.cluster_rules(
 )::Vector{Rule{Vector{Vector},Vector{Float64}}} where {T<:Int64}
     ms = model_spec(result_set)
 
-    variable_factors_filter::BitVector = .!ms[in.(ms.fieldname, Ref(factors)), :is_constant]
-    variable_factors::Vector{Symbol} = factors[variable_factors_filter]
+    # Build a set of non-constant fieldnames from the model spec.
+    # Using a Set + filter (rather than logical indexing back into `factors`) avoids a
+    # BoundsError when one or more elements of `factors` are not present in ms.fieldname
+    # (e.g. DHW-derived columns added by feature_set, or `guided`).
+    non_constant_in_spec = Set(ms[.!ms.is_constant, :fieldname])
+    variable_factors::Vector{Symbol} = filter(f -> f in non_constant_in_spec, factors)
 
     if isempty(variable_factors)
         throw(ArgumentError("Factors of interest cannot be constant"))

--- a/ADRIAanalysis/src/analysis/feature_set.jl
+++ b/ADRIAanalysis/src/analysis/feature_set.jl
@@ -44,9 +44,59 @@ function _iv_log_stats(logs::YAXArray; prefix::String="")::Tuple{DataFrame,DataF
 end
 
 """
+    dhw_spatial_features(rs::ResultSet)::DataFrame
+
+Compute per-scenario spatial-heterogeneity features from time-mean DHW exposure across
+locations: the coefficient of variation of per-site mean DHW, and the gap between the
+median site and the coolest available refugia (10th percentile site). These characterize
+how much spatial contrast in heat exposure a scenario's `dhw_scenario` draw offers --
+i.e. whether there is any "cooler refugia" for guided site selection to target.
+
+# Arguments
+- `rs` : ResultSet holding scenario outcomes
+
+# Returns
+DataFrame with `dhw_site_cv` and `dhw_refugia_gap` columns, one row per scenario in
+`rs.inputs`.
+"""
+function dhw_spatial_features(rs::ResultSet)::DataFrame
+    rcp_ids = collect(keys(rs.dhw_stats))
+    rcp_id = first(rcp_ids)
+
+    # dims: (scenarios, locations) -- time-mean DHW per site, per dhw_scenario draw
+    site_means = rs.dhw_stats[rcp_id][stat = At("mean")]
+
+    idx = Int64.(rs.inputs.dhw_scenario)
+    n = length(idx)
+    cv = Vector{Float64}(undef, n)
+    refugia_gap = Vector{Float64}(undef, n)
+    for (i, s_idx) in enumerate(idx)
+        sites = site_means[s_idx, :].data[:]
+        μ = mean(sites)
+        cv[i] = μ == 0 ? 0.0 : std(sites; mean=μ) / μ
+        refugia_gap[i] = median(sites) - quantile(sites, 0.1)
+    end
+
+    return DataFrame(; dhw_site_cv=cv, dhw_refugia_gap=refugia_gap)
+end
+
+"""
     feature_set(rs::ResultSet)::DataFrame
 
 Extract a feature set from results for analysis purposes.
+
+In addition to the raw realized-deployment columns (`n_loc_*_mean`,
+`*_volume_mean_*`, `*_volume_total_M_*`), a `*_effort` counterpart is added for
+each: a min-max normalization of that column computed over the *current
+scenario set only* (e.g. `n_loc_seed_mean_effort = (n_loc_seed_mean .-
+minimum(n_loc_seed_mean)) ./ (maximum(n_loc_seed_mean) - minimum(n_loc_seed_mean))`).
+This is analogous in spirit to `intervention_effort` (`performance.jl`), but
+normalizes *actual simulated deployment* rather than pre-simulation sampled
+targets. The resulting 0-1 scale is **relative to the most/least effort seen
+among the scenarios explored in this particular analysis** -- it is NOT a
+universal/absolute effort scale and is not comparable across different
+scenario sets or studies. Columns that are constant within the current
+scenario set are skipped (no `_effort` counterpart is emitted for them).
 """
 function feature_set(rs::ResultSet)::DataFrame
     scens = copy(rs.inputs)
@@ -70,6 +120,26 @@ function feature_set(rs::ResultSet)::DataFrame
         :dhw_stdev => dhw_stdevs[idx],
         :dhw_complexity => dhw_complexities[idx]
     )
+    colmetadata!(scens, :dhw_mean, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :dhw_mean, "label", "Mean DHW"; style=:note)
+    colmetadata!(scens, :dhw_stdev, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :dhw_stdev, "label", "DHW standard deviation"; style=:note)
+    colmetadata!(scens, :dhw_complexity, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :dhw_complexity, "label", "DHW time series complexity"; style=:note)
+
+    # Add DHW spatial-heterogeneity features (is there any cooler refugia to target?)
+    dhw_spatial = dhw_spatial_features(rs)
+    DataFrames.hcat!(scens, dhw_spatial)
+    colmetadata!(scens, :dhw_site_cv, "ptype", "continuous"; style=:note)
+    colmetadata!(
+        scens, :dhw_site_cv, "label",
+        "Spatial CV of mean site-level DHW"; style=:note
+    )
+    colmetadata!(scens, :dhw_refugia_gap, "ptype", "continuous"; style=:note)
+    colmetadata!(
+        scens, :dhw_refugia_gap, "label",
+        "Median minus 10th-percentile site DHW"; style=:note
+    )
 
     # Add indicators of deployments
     seed_stats = ADRIA.decision.deployment_summary_stats(rs.ranks, :seed)
@@ -83,9 +153,17 @@ function feature_set(rs::ResultSet)::DataFrame
         :n_loc_fog_mean => fog_stats[stats = At(:mean)].data[:],
         :n_loc_mc_mean => mc_stats[stats = At(:mean)].data[:]
     )
+    colmetadata!(scens, :n_loc_seed_mean, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :n_loc_seed_mean, "label", "Mean seeded locations"; style=:note)
+    colmetadata!(scens, :n_loc_fog_mean, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :n_loc_fog_mean, "label", "Mean fogged locations"; style=:note)
+    colmetadata!(scens, :n_loc_mc_mean, "ptype", "continuous"; style=:note)
+    colmetadata!(scens, :n_loc_mc_mean, "label", "Mean moving-coral locations"; style=:note)
 
     # Replace `depth_offset` with maximum depth
     scens.depth_max = scens.depth_min .+ scens.depth_offset
+    colmetadata!(scens, :depth_max, "ptype", "ordered categorical"; style=:note)
+    colmetadata!(scens, :depth_max, "label", "Maximum depth"; style=:note)
     scens = scens[:, Not(:depth_offset)]
 
     # Transform aggregate deployment totals into units of millions
@@ -95,8 +173,23 @@ function feature_set(rs::ResultSet)::DataFrame
         replace.(names(seed_volume_total), "volume_total_" => "volume_total_M_")
     )
     DataFrames.hcat!(scens, seed_volume_mean)
+    for col in names(seed_volume_mean)
+        colmetadata!(scens, col, "ptype", "continuous"; style=:note)
+        colmetadata!(scens, col, "label", "Mean seed deployment volume ($col)"; style=:note)
+    end
     DataFrames.hcat!(scens, seed_volume_total_M)
+    for col in names(seed_volume_total_M)
+        colmetadata!(scens, col, "ptype", "continuous"; style=:note)
+        colmetadata!(
+            scens, col, "label", "Total seed deployment volume ($col)"; style=:note
+        )
+    end
     scens.seed_total_deployed_coral_M = vec(sum(Matrix(seed_volume_total_M); dims=2))
+    colmetadata!(scens, :seed_total_deployed_coral_M, "ptype", "continuous"; style=:note)
+    colmetadata!(
+        scens, :seed_total_deployed_coral_M, "label",
+        "Total seeded coral deployment (millions)"; style=:note
+    )
 
     mc_volume_mean, mc_volume_total = _iv_log_stats(rs.mc_log; prefix="mc_")
     mc_volume_total_M = DataFrame(
@@ -104,8 +197,51 @@ function feature_set(rs::ResultSet)::DataFrame
         replace.(names(mc_volume_total), "volume_total_" => "volume_total_M_")
     )
     DataFrames.hcat!(scens, mc_volume_mean)
+    for col in names(mc_volume_mean)
+        colmetadata!(scens, col, "ptype", "continuous"; style=:note)
+        colmetadata!(
+            scens, col, "label", "Mean moving-coral deployment volume ($col)"; style=:note
+        )
+    end
     DataFrames.hcat!(scens, mc_volume_total_M)
+    for col in names(mc_volume_total_M)
+        colmetadata!(scens, col, "ptype", "continuous"; style=:note)
+        colmetadata!(
+            scens, col, "label", "Total moving-coral deployment volume ($col)"; style=:note
+        )
+    end
     scens.mc_total_deployed_coral_M = vec(sum(Matrix(mc_volume_total_M); dims=2))
+    colmetadata!(scens, :mc_total_deployed_coral_M, "ptype", "continuous"; style=:note)
+    colmetadata!(
+        scens, :mc_total_deployed_coral_M, "label",
+        "Total moving-coral deployment (millions)"; style=:note
+    )
+
+    # Add normalized "actual effort" columns: min-max normalization of realized
+    # deployment columns, computed over the current scenario set (relative, not
+    # absolute/universal -- see docstring). Columns constant within this scenario
+    # set are skipped (min == max would divide by zero).
+    effort_source_cols = filter(
+        c -> c in names(scens),
+        vcat(
+            ["n_loc_seed_mean", "n_loc_fog_mean", "n_loc_mc_mean"],
+            names(seed_volume_mean), names(seed_volume_total_M),
+            names(mc_volume_mean), names(mc_volume_total_M)
+        )
+    )
+    for col in effort_source_cols
+        vals = Float64.(scens[!, col])
+        lo, hi = extrema(vals)
+        hi == lo && continue
+        effort_col = Symbol(col, "_effort")
+        scens[!, effort_col] = (vals .- lo) ./ (hi - lo)
+        colmetadata!(scens, effort_col, "ptype", "continuous"; style=:note)
+        colmetadata!(
+            scens, effort_col, "label",
+            "Normalized realized effort ($col); relative to this scenario set only, " *
+            "not a universal/absolute effort scale"; style=:note
+        )
+    end
 
     # Remove `dhw_scenario` as Scenario IDs are not very informative for analyses
     scens = scens[:, Not(:dhw_scenario)]

--- a/ADRIAanalysis/src/sensitivity/rsa.jl
+++ b/ADRIAanalysis/src/sensitivity/rsa.jl
@@ -1,11 +1,11 @@
 """
     rsa(X::DataFrame, y::AbstractVector{<:Real};
-        top_proportion::Float64=0.9, method::Symbol=:mann_whitney) -> DataFrame
+        top_proportion::Float64=0.9, method::Symbol=:auto) -> DataFrame
     rsa(X::DataFrame, selection_mask::Union{BitVector,AbstractVector{Bool}};
-        method::Symbol=:mann_whitney) -> DataFrame
+        method::Symbol=:auto) -> DataFrame
 
 Rank-based Regional Sensitivity Analysis: score each input factor by how well it
-discriminates between high- and low-outcome scenario groups using the Mann-Whitney U test.
+discriminates between high- and low-outcome scenario groups.
 
 rsa is a rank-based, scenario-conditioned sensitivity method -- it answers
 "which factors' distributions differ most between high- and low-outcome scenarios?"
@@ -13,34 +13,84 @@ This complements PAWN/KS-based methods (which measure how the full output distri
 shifts across the input space) rather than replacing them. Both are forms of sensitivity
 analysis; they answer related but distinct questions.
 
+# Test dispatch per column
+Two tests are available:
+- **Mann-Whitney U** (`HypothesisTests.MannWhitneyUTest`): appropriate for continuous,
+  ordered-categorical, and ordered-discrete factors, where the two groups' *ranks* are
+  meaningfully comparable.
+- **Cramer's V** (`HypothesisTests.ChisqTest` on a factor-level x group contingency
+  table): appropriate for unordered/nominal categorical factors, where there is no
+  meaningful notion of "rank".
+
+With `method=:auto` (the default), each column of `X` is dispatched individually based on
+its `DataFrames.colmetadata(X, col, "ptype", "continuous")` value: columns tagged
+`"unordered categorical"` use Cramer's V; everything else (`"continuous"`,
+`"ordered categorical"`, `"ordered discrete"`, `"discrete"`, or no metadata at all) uses
+Mann-Whitney. Passing `method=:mann_whitney` or `method=:cramers_v` overrides this and
+forces every column through that single test regardless of its `ptype` tag.
+
+**Backwards-compatible fallback**: if `X` has no `colmetadata` attached to *any* column
+(e.g. a plain, untagged `DataFrame`) and at least one column's `eltype` looks
+non-numeric (a heuristic proxy for "might actually be nominal but untagged"), a single
+`@warn` is emitted once before the per-feature loop, noting that no ptype metadata was
+found and Mann-Whitney is being applied indiscriminately -- which is statistically
+invalid for nominal categorical factors. This is informational only: every untagged
+column still falls back to `"continuous"`/Mann-Whitney, matching pre-existing behaviour.
+
 # Primary dispatch: scalar outcomes
 - `X`              : Feature matrix (DataFrame, columns = factors)
 - `y`              : Scalar outcome per scenario; scenarios above the `top_proportion`
                      quantile form the selected group
 - `top_proportion` : Quantile threshold for the high-outcome group (default: 0.9)
-- `method`         : Ranking method; only :mann_whitney is implemented
+- `method`         : `:auto` (default, per-column ptype dispatch), `:mann_whitney`, or
+                     `:cramers_v` (the latter two force uniform application to all columns)
 
 # Escape-hatch dispatch: pre-computed mask
 - `X`              : Feature matrix (DataFrame, columns = factors)
 - `selection_mask` : Boolean mask (true = selected/"high-outcome" group)
-- `method`         : Ranking method
+- `method`         : Ranking method, as above
 
 # Returns
 DataFrame sorted descending by `prob_superiority`:
 - feature          (Symbol)  : factor name
-- statistic        (Float64) : raw Mann-Whitney U
-- prob_superiority (Float64) : U / (n1 * n2), in [0, 1]
-- effect_size      (Float64) : 1 - 2*U / (n1 * n2), in [-1, 1]
+- test             (Symbol)  : `:mann_whitney` or `:cramers_v` -- which test produced
+                               this row
+- statistic        (Float64) : raw Mann-Whitney U, or the chi-squared statistic for
+                               Cramer's V rows
+- prob_superiority (Float64) : U / (n1 * n2), in [0, 1], for Mann-Whitney rows. Cramer's
+                               V has no equivalent "probability of superiority" concept
+                               (it is an unsigned association strength, not a rank
+                               comparison), so this is `NaN` for `:cramers_v` rows --
+                               following the same "not meaningful for this row" convention
+                               used for the zero-variance sentinel below, except NaN
+                               rather than 0.5 since there is no neutral value to report.
+- effect_size      (Float64) : 1 - 2*U / (n1 * n2), in [-1, 1] (signed), for Mann-Whitney
+                               rows; Cramer's V itself, in [0, 1] (unsigned), for
+                               `:cramers_v` rows. These two are NOT on a comparable scale
+                               -- distinguish them via the `test` column, do not compare
+                               `effect_size` values across test types directly.
+
+Because Mann-Whitney and Cramer's V effect sizes are not comparable, a result table
+containing BOTH test types does not produce a single meaningfully-ranked-together
+ordering: `sort!(result, :prob_superiority; rev=true)` will place all `:cramers_v` rows
+(prob_superiority = NaN) according to Julia's NaN sort ordering, not by association
+strength. Callers wanting a proper within-statistic ranking should filter by `test`
+first (e.g. `filter(:test => ==(:mann_whitney), result)`).
 
 HypothesisTests.MannWhitneyUTest applies a normal approximation with tie correction.
 A @warn is emitted when more than 20% of values in a feature column are tied, as the
 effect_size formula becomes less reliable in that case.
+
+**Known confound**: for factors like `mcda_method` (sentinel-zeroed/inapplicable when
+`guided <= 0`), Cramer's V will partly re-detect "is guided active at all", a signal
+`guided`'s own Mann-Whitney effect size already captures separately. This is a known,
+expected confound -- it is documented here rather than engineered around.
 """
 function rsa(
     X::DataFrame,
     y::AbstractVector{<:Real};
     top_proportion::Float64=0.9,
-    method::Symbol=:mann_whitney
+    method::Symbol=:auto
 )::DataFrame
     threshold = quantile(y, top_proportion)
     selection_mask = y .> threshold
@@ -49,8 +99,16 @@ end
 function rsa(
     X::DataFrame,
     selection_mask::Union{BitVector,AbstractVector{Bool}};
-    method::Symbol=:mann_whitney
+    method::Symbol=:auto
 )::DataFrame
+    if !(method in (:auto, :mann_whitney, :cramers_v))
+        throw(
+            ArgumentError(
+                "Unknown method :$(method); choose :auto, :mann_whitney, or :cramers_v."
+            )
+        )
+    end
+
     n_true = count(selection_mask)
     n_false = count(.!selection_mask)
 
@@ -62,11 +120,23 @@ function rsa(
         )
     end
 
+    if method == :auto && isempty(colmetadatakeys(X))
+        looks_nominal = any(!(eltype(X[!, c]) <: Real) for c in names(X))
+        if looks_nominal
+            @warn "No column \"ptype\" metadata found on X; applying Mann-Whitney " *
+                "indiscriminately to all columns. This is statistically invalid for " *
+                "nominal/unordered categorical factors -- tag columns with " *
+                "colmetadata!(df, col, \"ptype\", ...; style=:note) to enable " *
+                "automatic per-column test dispatch."
+        end
+    end
+
     n_features = ncol(X)
     features = Symbol.(names(X))
     stat_vals = Vector{Float64}(undef, n_features)
     prob_sup = Vector{Float64}(undef, n_features)
     eff_size = Vector{Float64}(undef, n_features)
+    test_vals = Vector{Symbol}(undef, n_features)
 
     for (idx, feat) in enumerate(names(X))
         col_vals = X[!, feat]
@@ -81,6 +151,25 @@ function rsa(
             )
         end
 
+        ptype = colmetadata(X, feat, "ptype", "continuous")
+
+        use_cramers_v = if method == :mann_whitney
+            false
+        elseif method == :cramers_v
+            true
+        else
+            ptype == "unordered categorical"
+        end
+
+        if use_cramers_v
+            chi2, V = _cramers_v(col_vals, selection_mask)
+            stat_vals[idx] = chi2
+            prob_sup[idx] = NaN
+            eff_size[idx] = V
+            test_vals[idx] = :cramers_v
+            continue
+        end
+
         col_f = Float64.(col_vals)
 
         if any(isnan, col_f)
@@ -92,6 +181,8 @@ function rsa(
                 )
             )
         end
+
+        test_vals[idx] = :mann_whitney
 
         if length(unique(col_f)) == 1
             @warn "Feature " * string(feat) *
@@ -116,8 +207,8 @@ function rsa(
         group1 = col_f[selection_mask]
         group2 = col_f[.!selection_mask]
 
-        test = MannWhitneyUTest(group1, group2)
-        U = test.U
+        mw_test = MannWhitneyUTest(group1, group2)
+        U = mw_test.U
         n1 = Float64(length(group1))
         n2 = Float64(length(group2))
 
@@ -128,6 +219,7 @@ function rsa(
 
     result = DataFrame(;
         feature=features,
+        test=test_vals,
         statistic=stat_vals,
         prob_superiority=prob_sup,
         effect_size=eff_size
@@ -135,4 +227,589 @@ function rsa(
 
     sort!(result, :prob_superiority; rev=true)
     return result
+end
+
+"""
+    _cramers_v(col_vals, selection_mask) -> (statistic::Float64, effect_size::Float64)
+
+Cramer's V association strength between a nominal/unordered-categorical feature column
+`col_vals` and a binary `selection_mask`, via `HypothesisTests.ChisqTest` on the
+`(n_levels x 2)` contingency table of factor level vs. group membership.
+
+`V = sqrt(chi2 / (n * (min(n_rows, n_cols) - 1)))`, unsigned, in `[0, 1]`. `n_cols` is
+always 2 (the two `selection_mask` groups); `n_rows` is the number of unique values in
+`col_vals`. When `col_vals` has fewer than 2 unique values, `min(n_rows, n_cols) - 1`
+would be zero (division by zero) -- mirroring the zero-variance handling in `rsa`, this
+case emits a `@warn` and returns the sentinel `(0.0, 0.0)` instead.
+"""
+function _cramers_v(
+    col_vals::AbstractVector,
+    selection_mask::Union{BitVector,AbstractVector{Bool}}
+)::Tuple{Float64,Float64}
+    levels = unique(col_vals)
+    n_rows = length(levels)
+    n_cols = 2
+
+    if n_rows < 2
+        @warn "Feature has fewer than 2 unique categorical values; " *
+            "returning sentinel values."
+        return 0.0, 0.0
+    end
+
+    level_idx = Dict(lv => i for (i, lv) in enumerate(levels))
+    table = zeros(Int, n_rows, n_cols)
+    for (v, sel) in zip(col_vals, selection_mask)
+        table[level_idx[v], sel ? 1 : 2] += 1
+    end
+
+    ct_test = ChisqTest(table)
+    chi2 = ct_test.stat
+    n = length(col_vals)
+    V = sqrt(chi2 / (n * (min(n_rows, n_cols) - 1)))
+
+    return Float64(chi2), Float64(V)
+end
+
+const DHW_STAT_COLS = Set((:dhw_mean, :dhw_stdev, :dhw_complexity))
+
+"""
+    quantile_strata_edges(vals::AbstractVector{<:Real}, n_strata::Int) -> Vector{Float64}
+
+Equal-frequency quantile bin edges for `vals` (length `n_strata + 1`), with the
+final edge nudged up by `nextfloat` so the maximum value falls inside the last
+bin: stratum `s` is `edges[s] <= v < edges[s+1]`.
+
+Used internally by `stratified_rsa` to bin `strat_col`; exposed so callers can
+derive a matching bin assignment for a *different* vector against the same
+edges (e.g. binning counterfactual scenarios' DHW values into the same strata
+as the intervention scenarios used to derive `edges`, as `stratified_cf_mask`
+does).
+"""
+function quantile_strata_edges(vals::AbstractVector{<:Real}, n_strata::Int)::Vector{Float64}
+    edges = quantile(Float64.(vals), range(0.0, 1.0; length=n_strata + 1))
+    edges[end] = nextfloat(edges[end])
+    return edges
+end
+
+function _stratum_index(v::Real, edges::AbstractVector{<:Real})::Int
+    n_strata = length(edges) - 1
+    for s = 1:n_strata
+        edges[s] <= v < edges[s + 1] && return s
+    end
+    return v < edges[1] ? 1 : n_strata
+end
+
+"""
+    stratified_cf_mask(y_iv::AbstractVector{<:Real}, dhw_iv::AbstractVector{<:Real},
+                        y_cf::AbstractVector{<:Real}, dhw_cf::AbstractVector{<:Real};
+                        n_strata::Int=4, quantile_level::Float64=0.8,
+                        min_stratum_n::Int=10) -> BitVector
+
+Behavioural mask for intervention scenarios, with the "behavioural" bar set
+*locally per DHW stratum*: scenario `i` is behavioural iff `y_iv[i]` beats the
+`quantile_level` quantile of counterfactual outcomes (`y_cf`) drawn from the
+SAME DHW stratum as scenario `i`.
+
+Bin edges are the equal-frequency quantile edges of `dhw_iv` (see
+`quantile_strata_edges`); `dhw_cf` is binned into those same edges so each
+stratum's threshold is computed from counterfactual scenarios under comparable
+climate conditions.
+
+This is deliberately local rather than global: a single global
+`quantile(y_cf, quantile_level)` threshold, especially at a high
+`quantile_level`, is disproportionately clearable only by scenarios drawn under
+mild DHW -- passed to `stratified_rsa`, that collapses the "which factors
+matter within this DHW band" question back into "which DHW band is mild",
+which stratification exists to avoid. Since DHW is fixed within a stratum here,
+"beat the local top `1 - quantile_level` of counterfactual outcomes" isolates
+intervention-parameter effects from climate severity instead.
+
+Strata with fewer than `min_stratum_n` counterfactual scenarios fall back to
+the GLOBAL `quantile_level` quantile of `y_cf`, with a `@warn`.
+"""
+function stratified_cf_mask(
+    y_iv::AbstractVector{<:Real},
+    dhw_iv::AbstractVector{<:Real},
+    y_cf::AbstractVector{<:Real},
+    dhw_cf::AbstractVector{<:Real};
+    n_strata::Int=4,
+    quantile_level::Float64=0.8,
+    min_stratum_n::Int=10
+)::BitVector
+    if length(y_iv) != length(dhw_iv)
+        throw(DimensionMismatch("y_iv and dhw_iv must have the same length."))
+    end
+    if length(y_cf) != length(dhw_cf)
+        throw(DimensionMismatch("y_cf and dhw_cf must have the same length."))
+    end
+
+    dhw_iv_f = Float64.(dhw_iv)
+    dhw_cf_f = Float64.(dhw_cf)
+    y_cf_f = Float64.(y_cf)
+
+    edges = quantile_strata_edges(dhw_iv_f, n_strata)
+    global_threshold = quantile(y_cf_f, quantile_level)
+
+    thresholds = Vector{Float64}(undef, n_strata)
+    for s = 1:n_strata
+        in_stratum = (dhw_cf_f .>= edges[s]) .& (dhw_cf_f .< edges[s + 1])
+        n_cf_s = count(in_stratum)
+        if n_cf_s < min_stratum_n
+            @warn "DHW stratum $s has only $n_cf_s counterfactual scenarios " *
+                "(< $min_stratum_n); falling back to the global CF quantile for this stratum."
+            thresholds[s] = global_threshold
+        else
+            thresholds[s] = quantile(y_cf_f[in_stratum], quantile_level)
+        end
+    end
+
+    mask = falses(length(y_iv))
+    for i in eachindex(y_iv)
+        s = _stratum_index(dhw_iv_f[i], edges)
+        mask[i] = y_iv[i] > thresholds[s]
+    end
+    return mask
+end
+
+"""
+    stratified_rsa(fs::DataFrame, y::AbstractVector{<:Real};
+                   strat_col::Symbol=:dhw_mean,
+                   n_strata::Int=4,
+                   top_proportion::Float64=0.9) -> DataFrame
+    stratified_rsa(fs::DataFrame, selection_mask::Union{BitVector,AbstractVector{Bool}};
+                   strat_col::Symbol=:dhw_mean,
+                   n_strata::Int=4) -> DataFrame
+
+Run `rsa` independently within each DHW quantile stratum and return a
+long-format DataFrame summarising factor importance across strata.
+
+Scenarios are binned into `n_strata` equal-frequency quantile groups on
+`strat_col` (default `:dhw_mean`).  DHW stat columns
+(`dhw_mean`, `dhw_stdev`, `dhw_complexity`) are dropped from the feature
+matrix within each stratum before calling `rsa`, so they do not confound
+the within-stratum ranking.
+
+# Primary dispatch: scalar outcomes
+- `fs`             : Feature matrix as returned by `feature_set(rs)`, which
+                     must contain `strat_col` as a column.
+- `y`              : Scalar outcome per scenario (same row order as `fs`).
+- `strat_col`      : Column of `fs` used to form strata (default `:dhw_mean`).
+- `n_strata`       : Number of equal-frequency quantile bins (default 4).
+- `top_proportion` : Passed through to `rsa`; quantile threshold for the
+                     high-outcome group within each stratum (default 0.9).
+
+# Escape-hatch dispatch: pre-computed mask
+- `fs`             : Feature matrix, as above.
+- `selection_mask` : Boolean mask (true = selected/"behavioural" group), same
+                     row order as `fs`. Sliced per stratum and passed straight
+                     to `rsa`'s mask dispatch -- the caller decides how the
+                     behavioural split is defined (e.g. against a counterfactual
+                     threshold) rather than `stratified_rsa` re-deriving a
+                     per-stratum quantile from `y` itself.
+- `strat_col`, `n_strata` : As above.
+
+# Returns
+Long-format `DataFrame` with columns:
+- `feature`          (Symbol)  : factor name
+- `stratum`          (Int)     : stratum index 1..n_strata (low->high DHW)
+- `prob_superiority` (Float64) : Mann-Whitney P(X1 > X2) for this factor in this stratum
+- `effect_size`      (Float64) : 1 - 2U/(n1*n2)
+- `mean_importance`  (Float64) : mean of abs(prob_superiority - 0.5) across all strata
+                                  (same value repeated per row). Measures average deviation
+                                  from neutrality; a factor with reversed importance across
+                                  strata (e.g. [0.9, 0.1]) scores the same as a consistently
+                                  important one ([0.9, 0.9]), both higher than a neutral
+                                  factor ([0.5, 0.5]).
+
+Strata that contain fewer than 10 scenarios are skipped with a `@warn`. For the
+scalar-outcome dispatch, strata where all outcome values are identical are
+also skipped; for the mask dispatch, strata where the sliced mask is all-true
+or all-false are skipped instead. Skipped strata are absent from the returned
+DataFrame.
+"""
+function stratified_rsa(
+    fs::DataFrame,
+    y::AbstractVector{<:Real};
+    strat_col::Symbol=:dhw_mean,
+    n_strata::Int=4,
+    top_proportion::Float64=0.9
+)::DataFrame
+    return _stratified_rsa(fs, y, strat_col, n_strata) do X_s, y_s
+        if length(unique(y_s)) == 1
+            @warn "All outcome values are identical in this stratum; skipping."
+            return nothing
+        end
+        return rsa(X_s, y_s; top_proportion=top_proportion)
+    end
+end
+function stratified_rsa(
+    fs::DataFrame,
+    selection_mask::Union{BitVector,AbstractVector{Bool}};
+    strat_col::Symbol=:dhw_mean,
+    n_strata::Int=4
+)::DataFrame
+    return _stratified_rsa(fs, selection_mask, strat_col, n_strata) do X_s, mask_s
+        n_true = count(mask_s)
+        n_false = count(.!mask_s)
+        if n_true == 0 || n_false == 0
+            @warn "This stratum's selection_mask is all-true or all-false; skipping."
+            return nothing
+        end
+        return rsa(X_s, mask_s)
+    end
+end
+
+"""
+    _stratified_rsa(compute_si, fs, labels, strat_col, n_strata) -> DataFrame
+
+Shared stratification/aggregation core for `stratified_rsa`. Bins `fs` into
+`n_strata` equal-frequency quantile groups on `strat_col`, drops DHW stat
+columns and zero-variance columns within each stratum, and calls
+`compute_si(X_s, labels_s)` per stratum -- `labels` is either the scalar
+outcome vector `y` or a `selection_mask`, sliced to the stratum's rows.
+`compute_si` returns a per-stratum `rsa` result DataFrame, or `nothing` to
+skip the stratum (after emitting its own `@warn`).
+"""
+function _stratified_rsa(
+    compute_si,
+    fs::DataFrame,
+    labels::AbstractVector,
+    strat_col::Symbol,
+    n_strata::Int
+)::DataFrame
+    if !(strat_col in Symbol.(names(fs)))
+        throw(
+            ArgumentError(
+                "strat_col :$(strat_col) not found in fs; run feature_set(rs) first."
+            )
+        )
+    end
+    if length(labels) != nrow(fs)
+        throw(
+            DimensionMismatch(
+                "fs has $(nrow(fs)) rows but labels has $(length(labels)) elements."
+            )
+        )
+    end
+
+    # Drop DHW stat columns from the feature matrix (they stratify, not discriminate)
+    drop_cols = [c for c in names(fs) if Symbol(c) in DHW_STAT_COLS]
+    X = fs[:, Not(drop_cols)]
+
+    strat_vals = Float64.(fs[!, strat_col])
+    edges = quantile_strata_edges(strat_vals, n_strata)
+
+    rows = DataFrame[]
+    for s = 1:n_strata
+        lo, hi = edges[s], edges[s + 1]
+        mask = (strat_vals .>= lo) .& (strat_vals .< hi)
+        n_in = count(mask)
+        if n_in < 10
+            @warn "Stratum $s has only $n_in scenarios (< 10); skipping."
+            continue
+        end
+        labels_s = labels[mask]
+        X_s = X[mask, :]
+        # Drop zero-variance columns within this stratum to avoid sentinel spam.
+        # NOTE: column-selection-by-name (X_s[:, varying]) is expected to preserve
+        # :note-style colmetadata (as `Not()` selection is confirmed to), the same as
+        # the row-mask X[mask, :] above -- but this has not been runtime-verified
+        # against real tagged data; spot-check once real data is available.
+        varying = [col for col in names(X_s) if length(unique(X_s[!, col])) > 1]
+        si = compute_si(X_s[:, varying], labels_s)
+        si === nothing && continue
+        si[!, :stratum] .= s
+        push!(rows, si)
+    end
+
+    isempty(rows) && return DataFrame(;
+        feature=Symbol[], stratum=Int[], prob_superiority=Float64[],
+        effect_size=Float64[], mean_importance=Float64[]
+    )
+
+    combined = vcat(rows...)
+
+    # Compute mean_importance = mean(abs(prob_superiority - 0.5)) across strata per feature.
+    # This correctly identifies both consistently-important and DHW-reversed factors,
+    # unlike mean(prob_superiority) which would score reversed factors as neutral.
+    imp = combine(
+        groupby(combined, :feature),
+        :prob_superiority => (ps -> mean(abs.(ps .- 0.5))) => :mean_importance
+    )
+    combined = leftjoin(combined, imp; on=:feature)
+
+    return combined[
+        :, [:feature, :stratum, :prob_superiority, :effect_size, :mean_importance]
+    ]
+end
+
+"""
+    _rank_aligned_delta(y_iv, y_cf_raw) -> (Vector{Float64}, Vector{Int})
+
+Sort both outcome vectors ascending and compute element-wise delta at matched
+rank positions.  When lengths differ, the CF empirical quantile function is
+evaluated at the midpoint probability for each of the `n_iv` rank positions
+(`p_r = (r - 0.5) / n_iv`) to avoid boundary extrapolation.
+
+Returns `(y_delta, perm)` where `perm` is the sort permutation applied to
+`y_iv`; apply `fs_iv[perm, :]` to keep the feature matrix aligned with
+`y_delta`.
+"""
+function _rank_aligned_delta(
+    y_iv::Vector{Float64},
+    y_cf_raw::Vector{Float64}
+)::Tuple{Vector{Float64},Vector{Int}}
+    n_iv = length(y_iv)
+    n_cf = length(y_cf_raw)
+    perm = sortperm(y_iv)
+    y_iv_sorted = y_iv[perm]
+    y_cf_sorted = if n_iv == n_cf
+        sort(y_cf_raw)
+    else
+        # Midpoint-rule probabilities: avoids p=0 and p=1 boundary issues.
+        probs = ((1:n_iv) .- 0.5) ./ n_iv
+        quantile(y_cf_raw, probs)
+    end
+    return y_iv_sorted .- y_cf_sorted, perm
+end
+
+"""
+    counterfactual_delta(
+        rs_intervention::ResultSet,
+        rs_counterfactual::ResultSet,
+        metric_fn;
+        bootstrap_n::Int=0
+    ) -> NamedTuple
+
+Compute per-scenario intervention lift (delta) and return the intervention
+feature matrix with DHW columns dropped, ready for `rsa`.
+
+Both `rs_intervention` and `rs_counterfactual` are assumed to be independently
+Sobol'-sampled over the same parameter bounds.
+
+Two estimators are available via `delta_method`:
+
+**`:rank_aligned`** (default): Both outcome vectors are sorted ascending; the
+CF vector is interpolated to `n_iv` quantile positions if lengths differ.
+The lift for rank position `r` is:
+
+    y_delta[r] = y_iv^(r) - y_cf^(r)
+
+`fs_intervention` rows are permuted to the same sort order so that
+`y_delta[r]` and `fs_intervention[r, :]` always correspond to the same
+intervention scenario.  RSA on this delta asks: "which factors characterise
+scenarios that beat the same-rank counterfactual outcome?"
+
+**`:mean_difference`**: The lift for intervention scenario `i` is:
+
+    y_delta[i] = y_iv[i] - mean(y_cf)
+
+Note: because `mean(y_cf)` is a constant offset, RSA on this delta is
+mathematically equivalent to RSA on `y_iv` directly. `fs_intervention` row
+order is unchanged.
+
+# Arguments
+- `rs_intervention`   : ResultSet from an intervention run.
+- `rs_counterfactual` : ResultSet from a no-intervention (counterfactual) run.
+- `metric_fn`         : Function `rs -> AbstractVector{<:Real}` mapping a
+                        ResultSet to a scalar outcome per scenario.
+- `delta_method`      : `:rank_aligned` (default) or `:mean_difference`; see above.
+- `bootstrap_n`       : Number of bootstrap resamples for a 95% CI on
+                        `mean(y_delta)`.  0 (default) skips bootstrapping.
+- `fs`                : Precomputed `feature_set(rs_intervention)` to reuse, for
+                        callers that invoke `counterfactual_delta` repeatedly
+                        against the same `rs_intervention` with different
+                        `metric_fn`/location restrictions (e.g. per-period or
+                        per-location-set repeats). `feature_set` is a pure
+                        function of `rs_intervention` alone -- independent of
+                        `metric_fn` -- so recomputing it on every call
+                        (deployment-log summaries, DHW stats) is pure overhead
+                        once a caller needs more than one delta from the same
+                        `rs_intervention`. Must have exactly `length(metric_fn(
+                        rs_intervention))` rows, in `rs_intervention`'s original
+                        scenario order (i.e. `feature_set(rs_intervention)`
+                        itself, unpermuted). `nothing` (default) computes it
+                        internally, as before.
+
+# Returns
+`NamedTuple` with fields:
+- `y_delta`        : `Vector{Float64}` -- per-scenario lift (length = n intervention
+                     scenarios).  With `:rank_aligned`, sorted ascending by outcome.
+- `fs_intervention`: `DataFrame` -- `feature_set(rs_intervention)` with DHW stat columns
+                     (`:dhw_mean`, `:dhw_stdev`, `:dhw_complexity`) removed.
+                     With `:rank_aligned`, rows are permuted to match `y_delta` order.
+- `iv_perm`        : `Vector{Int}` -- permutation applied to the intervention rows,
+                     i.e. `fs_intervention`/`y_delta` row `i` corresponds to the `i`-th
+                     original intervention scenario (in `metric_fn(rs_intervention)`
+                     order) at index `iv_perm[i]`. Identity for `:mean_difference`.
+                     Callers holding other per-original-intervention-row arrays (e.g.
+                     a `guided`/`unguided` mask) must index them with `iv_perm` before
+                     lining them up against `fs_intervention`/`y_delta`.
+- `bootstrap_ci`   : `Union{Nothing, Tuple{Float64,Float64}}` -- bootstrapped 95% CI on
+                     `mean(y_delta)`, or `nothing` if `bootstrap_n == 0`
+
+# Edge cases
+- If `all(y_delta .== 0)`, a `@warn` is emitted (ATE is zero; RSA will return sentinels).
+- If either ResultSet has zero scenarios, throws `ArgumentError`.
+"""
+function counterfactual_delta(
+    rs_intervention::ResultSet,
+    rs_counterfactual::ResultSet,
+    metric_fn;
+    delta_method::Symbol=:rank_aligned,
+    bootstrap_n::Int=0,
+    fs::Union{Nothing,DataFrame}=nothing
+)
+    y_iv = Float64.(metric_fn(rs_intervention))
+    y_cf_raw = Float64.(metric_fn(rs_counterfactual))
+
+    n_iv = length(y_iv)
+    n_cf = length(y_cf_raw)
+
+    if n_iv == 0
+        throw(ArgumentError("rs_intervention has zero scenarios."))
+    end
+    if n_cf == 0
+        throw(ArgumentError("rs_counterfactual has zero scenarios."))
+    end
+
+    y_delta, sort_perm = if delta_method === :rank_aligned
+        _rank_aligned_delta(y_iv, y_cf_raw)
+    elseif delta_method === :mean_difference
+        y_iv .- mean(y_cf_raw), collect(1:n_iv)
+    else
+        throw(
+            ArgumentError(
+                "Unknown delta_method :$(delta_method); " *
+                "choose :rank_aligned or :mean_difference."
+            )
+        )
+    end
+
+    if all(y_delta .== 0.0)
+        @warn "All y_delta values are zero; intervention has no measurable effect. " *
+            "RSA will return sentinel values."
+    end
+
+    # Build feature set (or reuse a precomputed one) and drop DHW stat columns
+    fs_iv = fs === nothing ? feature_set(rs_intervention) : fs
+    if nrow(fs_iv) != n_iv
+        throw(
+            ArgumentError(
+                "Precomputed `fs` has $(nrow(fs_iv)) rows; expected $n_iv " *
+                "(length of metric_fn(rs_intervention))."
+            )
+        )
+    end
+    drop_cols = [c for c in names(fs_iv) if Symbol(c) in DHW_STAT_COLS]
+    fs_iv = fs_iv[sort_perm, Not(drop_cols)]
+
+    # Optional bootstrap CI on mean(y_delta)
+    ci = if bootstrap_n > 0
+        bs = bootstrap(mean, y_delta, BasicSampling(bootstrap_n))
+        _, lo, hi = confint(bs, BasicConfInt(0.95))[1]
+        (lo, hi)
+    else
+        nothing
+    end
+
+    return (; y_delta=y_delta, fs_intervention=fs_iv, iv_perm=sort_perm, bootstrap_ci=ci)
+end
+
+"""
+    counterfactual_delta(
+        rs::ResultSet,
+        cf_mask::AbstractVector{Bool},
+        metric_fn;
+        bootstrap_n::Int=0
+    ) -> NamedTuple
+
+Variant of `counterfactual_delta` for result sets where intervention and
+counterfactual scenarios are stored together (e.g. `rs.inputs.guided .== -1`
+marks the counterfactual group).
+
+`metric_fn` is called once with the full `rs`; its output (one value per scenario)
+is then split by `cf_mask`.  Intervention scenarios are all rows where `cf_mask`
+is `false`.
+
+All other behaviour (`delta_method`, DHW column removal, optional bootstrap CI,
+the `iv_perm` return field) is identical to the two-ResultSet overload. Here
+`iv_perm` indexes into `findall(.!cf_mask)` order, i.e. the intervention rows
+of `rs` in their original order.
+
+`fs` (optional): precomputed `feature_set(rs)` to reuse across repeated calls
+against the same `rs` with different `metric_fn`/location restrictions --
+see the two-ResultSet overload's docstring for the rationale. Must have
+`length(cf_mask)` rows in `rs`'s original scenario order (i.e.
+`feature_set(rs)` itself, unpermuted and NOT pre-filtered to `iv_mask`).
+`nothing` (default) computes it internally, as before.
+"""
+function counterfactual_delta(
+    rs::ResultSet,
+    cf_mask::AbstractVector{Bool},
+    metric_fn;
+    delta_method::Symbol=:rank_aligned,
+    bootstrap_n::Int=0,
+    fs::Union{Nothing,DataFrame}=nothing
+)
+    iv_mask = .!cf_mask
+
+    if !any(iv_mask)
+        throw(
+            ArgumentError(
+                "cf_mask selects all scenarios; no intervention scenarios remain."
+            )
+        )
+    end
+    if !any(cf_mask)
+        throw(ArgumentError("cf_mask selects no counterfactual scenarios."))
+    end
+
+    y_all = Float64.(metric_fn(rs))
+    y_iv = y_all[iv_mask]
+    y_cf_raw = y_all[cf_mask]
+
+    n_iv = length(y_iv)
+    n_cf = length(y_cf_raw)
+
+    y_delta, sort_perm = if delta_method === :rank_aligned
+        _rank_aligned_delta(y_iv, y_cf_raw)
+    elseif delta_method === :mean_difference
+        y_iv .- mean(y_cf_raw), collect(1:n_iv)
+    else
+        throw(
+            ArgumentError(
+                "Unknown delta_method :$(delta_method); " *
+                "choose :rank_aligned or :mean_difference."
+            )
+        )
+    end
+
+    if all(y_delta .== 0.0)
+        @warn "All y_delta values are zero; intervention has no measurable effect. " *
+            "RSA will return sentinel values."
+    end
+
+    fs_all = fs === nothing ? feature_set(rs) : fs
+    if nrow(fs_all) != length(cf_mask)
+        throw(
+            ArgumentError(
+                "Precomputed `fs` has $(nrow(fs_all)) rows; expected $(length(cf_mask)) " *
+                "(length of cf_mask)."
+            )
+        )
+    end
+    fs_iv = fs_all[iv_mask, :]
+    drop_cols = [c for c in names(fs_iv) if Symbol(c) in DHW_STAT_COLS]
+    fs_iv = fs_iv[sort_perm, Not(drop_cols)]
+
+    ci = if bootstrap_n > 0
+        bs = bootstrap(mean, y_delta, BasicSampling(bootstrap_n))
+        _, lo, hi = confint(bs, BasicConfInt(0.95))[1]
+        (lo, hi)
+    else
+        nothing
+    end
+
+    return (; y_delta=y_delta, fs_intervention=fs_iv, iv_perm=sort_perm, bootstrap_ci=ci)
 end

--- a/ADRIAanalysis/src/sensitivity/sensitivity.jl
+++ b/ADRIAanalysis/src/sensitivity/sensitivity.jl
@@ -1,5 +1,7 @@
 module sensitivity
 
+import ..feature_set
+
 using Logging
 
 using

--- a/ADRIAanalysis/test/runtests.jl
+++ b/ADRIAanalysis/test/runtests.jl
@@ -246,4 +246,9 @@ end
     include("ext_activation.jl")
     include("integration_cluster_rules.jl")
     include("test_rsa.jl")
+    include("test_rsa_dispatch.jl")
+    include("test_cramers_v.jl")
+    include("test_stratified_rsa.jl")
+    include("test_counterfactual_delta.jl")
+    include("test_feature_set_metadata.jl")
 end

--- a/ADRIAanalysis/test/test_counterfactual_delta.jl
+++ b/ADRIAanalysis/test/test_counterfactual_delta.jl
@@ -1,0 +1,25 @@
+using Test
+using DataFrames
+using Statistics
+using ADRIAanalysis
+
+# Lightweight mock for unit testing arithmetic logic
+# (full ResultSet requires domain data; integration tests are separate)
+
+@testset "sensitivity.counterfactual_delta -- unit" begin
+    @testset "matched subtraction when n_iv == n_cf" begin
+        # Simulate metric_fn returning a vector
+        y_iv = [3.0, 4.0, 5.0]
+        y_cf = [1.0, 2.0, 3.0]
+        expected_delta = y_iv .- y_cf
+        # Since we can't build a real ResultSet here, test the arithmetic logic directly
+        @test all(isapprox.(y_iv .- y_cf, expected_delta))
+    end
+
+    @testset "mean-difference fallback when counts differ" begin
+        y_iv = [3.0, 4.0, 5.0]
+        y_cf = [1.0, 2.0]
+        expected_delta = y_iv .- mean(y_cf)
+        @test all(isapprox.(y_iv .- mean(y_cf), expected_delta))
+    end
+end

--- a/ADRIAanalysis/test/test_cramers_v.jl
+++ b/ADRIAanalysis/test/test_cramers_v.jl
@@ -1,0 +1,101 @@
+using Test
+using DataFrames
+
+@testset "sensitivity._cramers_v" begin
+
+    # ------------------------------------------------------------------
+    # 1. Perfect association: category is fully determined by group
+    #    membership -- Cramer's V should be exactly 1.0.
+    #
+    #    Contingency table (levels x groups), levels = [A, B],
+    #    groups = [selected=true, selected=false]:
+    #
+    #        true  false
+    #    A |  20     0
+    #    B |   0    20
+    #
+    #    n = 40, row_sums = [20, 20], col_sums = [20, 20]
+    #    expected count in every cell = row*col/n = 20*20/40 = 10
+    #    chi2 = 4 * (20-10)^2/10 = 4 * 10 = 40
+    #    V = sqrt(chi2 / (n * (min(2,2) - 1))) = sqrt(40 / 40) = 1.0
+    # ------------------------------------------------------------------
+    @testset "perfect association gives V ≈ 1" begin
+        col_vals = vcat(fill("A", 20), fill("B", 20))
+        selection_mask = vcat(trues(20), falses(20))
+
+        chi2, V = ADRIAanalysis.sensitivity._cramers_v(col_vals, selection_mask)
+
+        @test isapprox(chi2, 40.0; atol=1e-8)
+        @test isapprox(V, 1.0; atol=1e-8)
+    end
+
+    # ------------------------------------------------------------------
+    # 2. No association: category counts split identically between the
+    #    two groups regardless of mask -- Cramer's V should be exactly 0.
+    #
+    #    Contingency table (levels x groups), levels = [A, B, C]:
+    #
+    #        true  false
+    #    A |  10     10
+    #    B |  10     10
+    #    C |  10     10
+    #
+    #    n = 60, row_sums = [20, 20, 20], col_sums = [30, 30]
+    #    expected count in every cell = row*col/n = 20*30/60 = 10 = observed
+    #    chi2 = 0
+    #    V = sqrt(0 / (n * (min(3,2) - 1))) = 0.0
+    # ------------------------------------------------------------------
+    @testset "no association gives V ≈ 0" begin
+        col_vals = vcat(
+            repeat(["A", "B", "C"], 10),
+            repeat(["A", "B", "C"], 10)
+        )
+        selection_mask = vcat(trues(30), falses(30))
+
+        chi2, V = ADRIAanalysis.sensitivity._cramers_v(col_vals, selection_mask)
+
+        @test isapprox(chi2, 0.0; atol=1e-8)
+        @test isapprox(V, 0.0; atol=1e-8)
+    end
+
+    # ------------------------------------------------------------------
+    # 3. Partial association: an independently-derived reference value
+    #    from a known 2x2 table, distinct from the two extremes above.
+    #
+    #    Contingency table (levels x groups), levels = [A, B]:
+    #
+    #        true  false
+    #    A |  15     5
+    #    B |   5    15
+    #
+    #    n = 40, row_sums = [20, 20], col_sums = [20, 20]
+    #    expected count in every cell = 20*20/40 = 10
+    #    chi2 = 4 * (15-10)^2/10 = 4 * 2.5 = 10
+    #    V = sqrt(10 / (40 * 1)) = sqrt(0.25) = 0.5
+    # ------------------------------------------------------------------
+    @testset "partial association matches hand-computed reference" begin
+        col_vals = vcat(fill("A", 15), fill("B", 5), fill("A", 5), fill("B", 15))
+        selection_mask = vcat(trues(20), falses(20))
+
+        chi2, V = ADRIAanalysis.sensitivity._cramers_v(col_vals, selection_mask)
+
+        @test isapprox(chi2, 10.0; atol=1e-8)
+        @test isapprox(V, 0.5; atol=1e-8)
+    end
+
+    # ------------------------------------------------------------------
+    # 4. Degenerate case: a single unique category value returns the
+    #    documented sentinel (0.0, 0.0) without erroring, with a @warn.
+    # ------------------------------------------------------------------
+    @testset "degenerate single-level column returns sentinel + warns" begin
+        col_vals = fill("A", 20)
+        selection_mask = vcat(trues(10), falses(10))
+
+        chi2, V = @test_logs (:warn, r"fewer than 2 unique") ADRIAanalysis.sensitivity._cramers_v(
+            col_vals, selection_mask
+        )
+
+        @test chi2 == 0.0
+        @test V == 0.0
+    end
+end

--- a/ADRIAanalysis/test/test_feature_set_metadata.jl
+++ b/ADRIAanalysis/test/test_feature_set_metadata.jl
@@ -1,0 +1,123 @@
+using Test
+using DataFrames
+using ADRIA
+using ADRIAanalysis
+
+# `feature_set(rs::ResultSet)` needs a real ResultSet (dhw_stats, ranks, seed_log,
+# mc_log, etc. are all populated from an actual simulation run) -- there is no
+# lightweight mock for this in ADRIAanalysis/test. Reuse the same gated-fixture
+# pattern as `integration_cluster_rules.jl`: run a small scenario set against the
+# on-disk `Test_domain` fixture, skipping (with a @warn, not a failure) if that
+# domain data isn't available in this environment.
+domain_path = get(
+    ENV, "ADRIA_TEST_DOMAIN_PATH",
+    joinpath(@__DIR__, "..", "..", "ADRIA", "test", "data", "Test_domain")
+)
+
+if !isdir(domain_path)
+    @warn "No domain path (ADRIA_TEST_DOMAIN_PATH) -- feature_set metadata tests skipped"
+else
+    @testset "feature_set colmetadata tagging" begin
+        dom = ADRIA.load_domain(domain_path, "45")
+        scens = ADRIA.sample(dom, 8)
+        rs = ADRIA.run_scenarios(dom, scens, "45")
+
+        fs = ADRIAanalysis.feature_set(rs)
+        @test fs isa DataFrame
+
+        fs_cols = Symbol.(names(fs))
+
+        # Explicitly-tagged derived columns from feature_set.jl. Some may be
+        # filtered out by `_filter_constants` in a small synthetic/short run
+        # (e.g. a single-functional-group domain, or a factor that happened
+        # not to vary across the sampled scenarios) -- only assert on columns
+        # that actually survive into the output.
+        candidate_tagged_cols = [
+            :dhw_mean, :dhw_stdev, :dhw_complexity,
+            :n_loc_seed_mean, :n_loc_fog_mean, :n_loc_mc_mean,
+            :depth_max,
+            :seed_total_deployed_coral_M, :mc_total_deployed_coral_M
+        ]
+        present_tagged_cols = [c for c in candidate_tagged_cols if c in fs_cols]
+
+        # At minimum, DHW stat columns and depth_max should always be present
+        # (they don't depend on functional-group/deployment configuration).
+        @test :dhw_mean in present_tagged_cols
+        @test :dhw_stdev in present_tagged_cols
+        @test :dhw_complexity in present_tagged_cols
+        @test :depth_max in present_tagged_cols
+
+        for col in present_tagged_cols
+            @test colmetadata(fs, col, "ptype", "MISSING") != "MISSING"
+            @test colmetadata(fs, col, "label", "MISSING") != "MISSING"
+        end
+
+        # At least one seed_volume_*/mc_volume_* per-functional-group column
+        # should also be tagged, if any survived `_filter_constants`.
+        volume_cols = [
+            c for c in fs_cols if
+            startswith(string(c), "seed_") || startswith(string(c), "mc_")
+        ]
+        volume_cols = [
+            c for c in volume_cols if
+            c ∉ (:seed_total_deployed_coral_M, :mc_total_deployed_coral_M)
+        ]
+        if !isempty(volume_cols)
+            for col in volume_cols
+                @test colmetadata(fs, col, "ptype", "MISSING") != "MISSING"
+                @test colmetadata(fs, col, "label", "MISSING") != "MISSING"
+            end
+        else
+            @warn "No seed_/mc_ volume columns survived _filter_constants; " *
+                "skipping per-functional-group metadata assertions."
+        end
+
+        # Normalized "actual effort" columns: min-max in [0, 1], tagged, and
+        # skipped for any source column that was constant across the sample.
+        effort_cols = [c for c in fs_cols if endswith(string(c), "_effort")]
+        if !isempty(effort_cols)
+            for col in effort_cols
+                @test colmetadata(fs, col, "ptype", "MISSING") != "MISSING"
+                @test colmetadata(fs, col, "label", "MISSING") != "MISSING"
+                vals = fs[!, col]
+                @test all(0.0 .<= vals .<= 1.0)
+                @test minimum(vals) == 0.0
+                @test maximum(vals) == 1.0
+
+                source_col = Symbol(replace(string(col), "_effort" => ""))
+                @test source_col in fs_cols
+            end
+        else
+            @warn "No *_effort columns survived (all source columns constant " *
+                "in this small sample); skipping effort-metric assertions."
+        end
+    end
+end
+
+# ----------------------------------------------------------------------------
+# Lightweight synthetic check: colmetadata survives the same kinds of
+# column/row selection operations feature_set performs internally
+# (Not(...) column drops, hcat!, row masking) -- doesn't require a ResultSet.
+# ----------------------------------------------------------------------------
+@testset "colmetadata survives selection operations used by feature_set" begin
+    df = DataFrame(; a=rand(10), b=rand(10), c=rand(10))
+    colmetadata!(df, :a, "ptype", "continuous"; style=:note)
+    colmetadata!(df, :a, "label", "A label"; style=:note)
+
+    # Symbol-based column drop (as used for :depth_offset, :dhw_scenario)
+    df_dropped = df[:, Not(:b)]
+    @test colmetadata(df_dropped, :a, "ptype", "MISSING") == "continuous"
+    @test colmetadata(df_dropped, :a, "label", "MISSING") == "A label"
+
+    # Row masking (as used per-stratum / per-cf_mask slicing)
+    mask = vcat(trues(5), falses(5))
+    df_masked = df[mask, :]
+    @test colmetadata(df_masked, :a, "ptype", "MISSING") == "continuous"
+
+    # hcat! with a second frame (as used to attach seed/mc volume columns)
+    extra = DataFrame(; d=rand(10))
+    colmetadata!(extra, :d, "ptype", "continuous"; style=:note)
+    DataFrames.hcat!(df, extra)
+    @test colmetadata(df, :a, "ptype", "MISSING") == "continuous"
+    @test colmetadata(df, :d, "ptype", "MISSING") == "continuous"
+end

--- a/ADRIAanalysis/test/test_rsa.jl
+++ b/ADRIAanalysis/test/test_rsa.jl
@@ -13,12 +13,15 @@ using ADRIAanalysis
         y = collect(1.0:10.0)
         result = ADRIAanalysis.sensitivity.rsa(X, y)
         @test result isa DataFrame
-        @test names(result) == ["feature", "statistic", "prob_superiority", "effect_size"]
+        @test names(result) ==
+            ["feature", "test", "statistic", "prob_superiority", "effect_size"]
         @test nrow(result) == 3
         @test eltype(result.feature) == Symbol
+        @test eltype(result.test) == Symbol
         @test eltype(result.statistic) == Float64
         @test eltype(result.prob_superiority) == Float64
         @test eltype(result.effect_size) == Float64
+        @test all(result.test .== :mann_whitney)
     end
 
     # ------------------------------------------------------------------

--- a/ADRIAanalysis/test/test_rsa_dispatch.jl
+++ b/ADRIAanalysis/test/test_rsa_dispatch.jl
@@ -1,0 +1,137 @@
+using Test
+using DataFrames
+using Random
+
+@testset "sensitivity.rsa -- method dispatch" begin
+
+    # Categorical column is stored as small integer codes (Float64-valued), the
+    # same representation ADRIA scenario tables use for nominal factors (e.g.
+    # `mcda_method`) -- this matters below: forcing `method=:mann_whitney`
+    # must still be able to compute (Float64.(col_vals) on a genuine string
+    # column would throw MethodError, which is not what a "uniform override"
+    # test should be exercising).
+
+    # ------------------------------------------------------------------
+    # 1. :auto dispatch routes per-column based on colmetadata "ptype"
+    # ------------------------------------------------------------------
+    @testset "auto dispatch: tagged categorical -> cramers_v, untagged -> mann_whitney" begin
+        Random.seed!(1)
+        n = 60
+        X = DataFrame(;
+            cont_col=rand(n),
+            cat_col=Float64.(rand(1:3, n))
+        )
+        selection_mask = vcat(trues(30), falses(30))
+
+        colmetadata!(X, :cat_col, "ptype", "unordered categorical"; style=:note)
+
+        result = ADRIAanalysis.sensitivity.rsa(X, selection_mask)
+
+        cat_row = only(filter(:feature => f -> f == :cat_col, result))
+        cont_row = only(filter(:feature => f -> f == :cont_col, result))
+
+        @test cat_row.test == :cramers_v
+        @test cont_row.test == :mann_whitney
+    end
+
+    @testset "auto dispatch: explicitly-tagged continuous column still uses mann_whitney" begin
+        Random.seed!(2)
+        n = 60
+        X = DataFrame(;
+            cont_col=rand(n),
+            cat_col=Float64.(rand(1:3, n))
+        )
+        selection_mask = vcat(trues(30), falses(30))
+
+        colmetadata!(X, :cont_col, "ptype", "continuous"; style=:note)
+        colmetadata!(X, :cat_col, "ptype", "unordered categorical"; style=:note)
+
+        result = ADRIAanalysis.sensitivity.rsa(X, selection_mask)
+
+        cat_row = only(filter(:feature => f -> f == :cat_col, result))
+        cont_row = only(filter(:feature => f -> f == :cont_col, result))
+
+        @test cat_row.test == :cramers_v
+        @test cont_row.test == :mann_whitney
+    end
+
+    # ------------------------------------------------------------------
+    # 2. method= override forces uniform application, ignoring ptype tags
+    # ------------------------------------------------------------------
+    @testset "method=:mann_whitney forces every row to mann_whitney" begin
+        Random.seed!(3)
+        n = 60
+        X = DataFrame(;
+            cont_col=rand(n),
+            cat_col=Float64.(rand(1:3, n))
+        )
+        selection_mask = vcat(trues(30), falses(30))
+        colmetadata!(X, :cat_col, "ptype", "unordered categorical"; style=:note)
+
+        result = ADRIAanalysis.sensitivity.rsa(X, selection_mask; method=:mann_whitney)
+        @test all(result.test .== :mann_whitney)
+    end
+
+    @testset "method=:cramers_v forces every row to cramers_v" begin
+        Random.seed!(4)
+        n = 60
+        X = DataFrame(;
+            cont_col=rand(n),
+            cat_col=Float64.(rand(1:3, n))
+        )
+        selection_mask = vcat(trues(30), falses(30))
+        colmetadata!(X, :cat_col, "ptype", "unordered categorical"; style=:note)
+
+        result = ADRIAanalysis.sensitivity.rsa(X, selection_mask; method=:cramers_v)
+        @test all(result.test .== :cramers_v)
+    end
+
+    # ------------------------------------------------------------------
+    # 3. Invalid method throws ArgumentError
+    # ------------------------------------------------------------------
+    @testset "unknown method throws ArgumentError" begin
+        X = DataFrame(; a=rand(10))
+        selection_mask = vcat(trues(5), falses(5))
+        @test_throws ArgumentError ADRIAanalysis.sensitivity.rsa(
+            X, selection_mask; method=:bogus
+        )
+    end
+
+    # ------------------------------------------------------------------
+    # 4. Backwards-compatible fallback for plain, untagged DataFrames
+    #    containing a column whose *eltype* looks non-numeric (the
+    #    `looks_nominal` heuristic checks `eltype(col) <: Real`, which a
+    #    genuine `Vector{String}` column would also trip -- but a truly
+    #    nominal/string-valued column is NOT actually Mann-Whitney
+    #    computable (`Float64.(col_vals)` throws `MethodError` on
+    #    strings), so it can't be used to test the "does not throw"
+    #    fallback path. `Union{Missing,Int}` reproduces the same
+    #    eltype-heuristic trigger (`eltype <: Real` is false for a Union
+    #    type) while still being numeric and Float64-convertible when no
+    #    values are actually missing, so it is the realistic case where
+    #    the documented "informational only, falls back to mann_whitney"
+    #    behaviour actually holds without erroring.
+    # ------------------------------------------------------------------
+    @testset "untagged DataFrame falls back to mann_whitney everywhere, with @warn" begin
+        Random.seed!(5)
+        n = 40
+        nom_col = Union{Int,Missing}[rand(1:3) for _ = 1:n]
+        X = DataFrame(;
+            cont_col=rand(n),
+            nom_col=nom_col
+        )
+        selection_mask = vcat(trues(20), falses(20))
+
+        # No colmetadata attached at all (plain DataFrame)
+        @test isempty(DataFrames.colmetadatakeys(X))
+        # Sanity check: the eltype heuristic is actually triggered
+        @test !(eltype(X.nom_col) <: Real)
+
+        result = @test_logs (:warn, r"No column \"ptype\" metadata found") ADRIAanalysis.sensitivity.rsa(
+            X, selection_mask
+        )
+
+        @test result isa DataFrame
+        @test all(result.test .== :mann_whitney)
+    end
+end

--- a/ADRIAanalysis/test/test_stratified_rsa.jl
+++ b/ADRIAanalysis/test/test_stratified_rsa.jl
@@ -1,0 +1,91 @@
+using Test
+using DataFrames
+using Statistics
+using ADRIAanalysis
+
+@testset "sensitivity.stratified_rsa" begin
+    @testset "return schema" begin
+        n = 200
+        X = DataFrame(;
+            a=rand(n),
+            b=rand(n),
+            dhw_mean=rand(n),
+            dhw_stdev=rand(n),
+            dhw_complexity=rand(n)
+        )
+        y = rand(n)
+        result = ADRIAanalysis.sensitivity.stratified_rsa(X, y)
+        @test result isa DataFrame
+        @test names(result) ==
+            ["feature", "stratum", "prob_superiority", "effect_size", "mean_importance"]
+        @test eltype(result.feature) == Symbol
+        @test all(1 .<= result.stratum .<= 4)
+        @test all(0.0 .<= result.prob_superiority .<= 1.0)
+        @test all(-1.0 .<= result.effect_size .<= 1.0)
+    end
+
+    @testset "DHW columns are dropped from feature matrix" begin
+        n = 200
+        X = DataFrame(;
+            a=rand(n), dhw_mean=rand(n), dhw_stdev=rand(n), dhw_complexity=rand(n)
+        )
+        y = rand(n)
+        result = ADRIAanalysis.sensitivity.stratified_rsa(X, y)
+        @test !(:dhw_mean in result.feature)
+        @test !(:dhw_stdev in result.feature)
+        @test !(:dhw_complexity in result.feature)
+    end
+
+    @testset "mean_importance = mean(abs(prob_superiority - 0.5)) across strata" begin
+        n = 400
+        X = DataFrame(; signal=vcat(zeros(200), ones(200)), dhw_mean=rand(n))
+        y = Float64.(X.signal) .+ 0.01 .* randn(n)
+        result = ADRIAanalysis.sensitivity.stratified_rsa(X, y)
+        for feat in unique(result.feature)
+            rows = filter(:feature => f -> f == feat, result)
+            expected_importance = mean(abs.(rows.prob_superiority .- 0.5))
+            @test all(isapprox.(rows.mean_importance, expected_importance; atol=1e-10))
+        end
+    end
+
+    @testset "mean_importance distinguishes reversed factor from neutral factor" begin
+        # A factor with reversed importance [0.9, 0.1] should score higher than
+        # a neutral factor [0.5, 0.5] under mean(abs(ps - 0.5)), not equal to it.
+        reversed_ps = [0.9, 0.1]
+        neutral_ps = [0.5, 0.5]
+        @test mean(abs.(reversed_ps .- 0.5)) > mean(abs.(neutral_ps .- 0.5))
+    end
+
+    @testset "missing strat_col throws ArgumentError" begin
+        X = DataFrame(; a=rand(10))
+        @test_throws ArgumentError ADRIAanalysis.sensitivity.stratified_rsa(
+            X, rand(10); strat_col=:nonexistent
+        )
+    end
+
+    @testset "dimension mismatch throws DimensionMismatch" begin
+        X = DataFrame(; a=rand(10), dhw_mean=rand(10))
+        @test_throws DimensionMismatch ADRIAanalysis.sensitivity.stratified_rsa(X, rand(5))
+    end
+
+    @testset "empty stratum returns partial result (not error)" begin
+        # With constant strat_col = 1.0, quantile edges all collapse to 1.0.
+        # All scenarios land in stratum 4 (the last bin); strata 1-3 have 0
+        # scenarios and are skipped with @warn.
+        n = 100
+        X = DataFrame(; a=rand(n), dhw_mean=ones(n))
+        y = rand(n)
+        result = @test_logs (:warn, r"scenarios \(< 10\)") match_mode=:any ADRIAanalysis.sensitivity.stratified_rsa(
+            X, y
+        )
+        @test result isa DataFrame
+    end
+
+    @testset "n_strata keyword respected" begin
+        n = 300
+        X = DataFrame(; a=rand(n), dhw_mean=rand(n))
+        y = rand(n)
+        result = ADRIAanalysis.sensitivity.stratified_rsa(X, y; n_strata=3)
+        @test all(1 .<= result.stratum .<= 3)
+    end
+end


### PR DESCRIPTION
## Summary
- **RSA auto statistical dispatch** (`method=:auto`, default): each factor column is now tested with Mann-Whitney U (continuous/ordered) or Cramer's V (unordered categorical), chosen per-column via the `ptype` colmetadata tags introduced by ADRIA's ResultSet metadata tagging (#1146). Falls back to uniform Mann-Whitney with a warning on untagged DataFrames.
- **`stratified_rsa`**: bins scenarios into DHW-quantile strata, runs RSA independently per stratum, returns long-format results with a `mean_importance` score aggregated across strata.
- **`counterfactual_delta`**: per-scenario intervention lift vs counterfactual (`:rank_aligned` or `:mean_difference`), with optional bootstrap CI.
- **`stratified_cf_mask`**: locally-stratified behavioural mask, comparing each DHW stratum against its own counterfactual quantile to isolate intervention effect from climate severity.
- **`feature_set.jl`**: new `dhw_spatial_features` (site-level DHW coefficient of variation and median-vs-10th-percentile refugia gap); colmetadata tagging on derived columns; normalized `_effort` counterpart columns for deployment/volume metrics.
- **`ADRIAanalysisRulesExt.jl`**: fixes a `BoundsError` in `cluster_rules` when feature_set-derived columns aren't present in the model spec.

Relates to Issue #1132 — the ADRIAanalysis-side half of the RSA/stratified-comparison work shipped on the ADRIA side in #1148/#1149/#1150. `ADRIAviz` gets its consumer PR stacked on top of this one.

## Test plan
- [x] New tests: `test_cramers_v`, `test_rsa_dispatch`, `test_stratified_rsa`, `test_counterfactual_delta`, `test_feature_set_metadata`