### PR TITLE
feat(ADRIAviz): visualization support for stratified/CDF RSA comparisons

### DIFF
--- a/ADRIAviz/Project.toml
+++ b/ADRIAviz/Project.toml
@@ -1,6 +1,6 @@
 name = "ADRIAviz"
 uuid = "a7bb1955-b5ed-4954-ba3d-ac9734139a95"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["open-AIMS contributors"]
 
 [deps]

--- a/ADRIAviz/ext/ADRIAvizMakieExt/ADRIAvizMakieExt.jl
+++ b/ADRIAviz/ext/ADRIAvizMakieExt/ADRIAvizMakieExt.jl
@@ -26,7 +26,8 @@ using ADRIAviz:
     relative_sensitivities, outcome_probability,
     outcome_title, outcome_label, set_plot_opts!,
     OPT_TYPE, DEFAULT_OPT_TYPE,
-    _time_labels, _calc_gridsize, timesteps
+    _time_labels, _calc_gridsize, timesteps,
+    _outcome_mask, _empirical_cdf
 
 import ADRIA: timesteps as AD_timesteps
 

--- a/ADRIAviz/ext/ADRIAvizMakieExt/viz/sensitivity.jl
+++ b/ADRIAviz/ext/ADRIAvizMakieExt/viz/sensitivity.jl
@@ -5,14 +5,21 @@ using ADRIA: _is_discrete_factor
 """
     _get_guided_labels()::Vector{String}
 
-Returns labels for categories of the `guided` factor.
+Returns labels for categories of the `guided` factor (effort level: -1 no
+intervention/counterfactual, 0 unguided, 1 guided).
 """
 function _get_guided_labels()::Vector{String}
-    return [
-        "cf",
-        "unguided",
-        last.(split.(string.(ADRIA.decision.mcda_methods()), "."))...
-    ]
+    return ["cf", "unguided", "guided"]
+end
+
+"""
+    _get_mcda_method_labels()::Vector{String}
+
+Returns labels for categories of the `mcda_method` factor (which MCDA method
+is used for location selection; only meaningful when `guided` == 1).
+"""
+function _get_mcda_method_labels()::Vector{String}
+    return last.(split.(string.(ADRIA.decision.mcda_methods()), "."))
 end
 
 """
@@ -182,26 +189,40 @@ function ADRIA.viz.tsa(
 end
 
 """
-    ADRIA.viz.rsa!(g, X, y, foi; with_contour=true, opts=..., axis_opts=...)
-    ADRIA.viz.rsa(X, y, foi; with_contour=true, opts=..., fig_opts=..., axis_opts=...) -> Figure
+    ADRIA.viz.rsa!(g, X, y, foi; with_contour=true, with_density_contours=true, outcome_threshold=nothing, opts=..., axis_opts=...)
+    ADRIA.viz.rsa(X, y, foi; with_contour=true, with_density_contours=true, outcome_threshold=nothing, opts=..., fig_opts=..., axis_opts=...) -> Figure
 
 2D scatter of two input factors colored by outcome metric.
 
 # Arguments
-- `g`            : GridLayout or GridPosition to draw into
-- `X`            : Feature matrix (DataFrame, columns = factors)
-- `y`            : Outcome values per scenario
-- `foi`          : NTuple{2,Symbol} — (x-axis factor, y-axis factor)
-- `with_contour` : Add a tricontourf overlay. Exploratory only -- Delaunay-based
-                   interpolation can produce artefacts in sparse or irregularly sampled
-                   scenario spaces and is meaningless for discrete factors.
+- `g`                    : GridLayout or GridPosition to draw into
+- `X`                    : Feature matrix (DataFrame, columns = factors)
+- `y`                    : Outcome values per scenario
+- `foi`                  : NTuple{2,Symbol} — (x-axis factor, y-axis factor)
+- `with_contour`         : Overlay a 2D binned-average heatmap (colour = mean outcome
+                           per grid cell). O(N) and artefact-free.
+- `with_density_contours`: Overlay white iso-contour lines showing the count of
+                           scenarios that met the outcome threshold in each grid cell.
+                           High-contour regions are where desired outcomes are
+                           concentrated in factor space.
+                           Only active when `with_contour=true`.
+- `outcome_threshold`    : Controls which scenarios are counted for the contour.
+                           - `nothing` (default): counts scenarios where `y > median(y)`.
+                           - `Real`: counts scenarios where `y > outcome_threshold`.
+                           - `AbstractVector{Bool}`: a pre-computed binary mask
+                             (one entry per scenario, `true` = scenario met criteria).
+                           - `AbstractVector{<:Integer}`: indices of scenarios that
+                             met the criteria; converted to a boolean mask internally.
 """
 function ADRIA.viz.rsa!(
     g::Union{GridLayout,GridPosition},
     X::DataFrame,
     y::AbstractVector{<:Real},
     foi::NTuple{2,Symbol};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    with_density_contours::Bool=true,
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
     _add_colorbar::Bool=true,
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
@@ -214,19 +235,120 @@ function ADRIA.viz.rsa!(
 
     x_vals = Float64.(X[!, foi[1]])
     y_vals = Float64.(X[!, foi[2]])
+    outcome_f = Float64.(y)
 
-    if with_contour
-        tricontourf!(ax, x_vals, y_vals, y; colormap=:viridis, alpha=0.3)
-    end
+    if binary_mode
+        # Classic RSA: binary behavioural / non-behavioural scatter.
+        # Non-behavioural scenarios are drawn first as a grey backdrop; behavioural
+        # scenarios (those exceeding the outcome threshold) are drawn on top in a
+        # single accent colour.  An optional density contour traces where behavioural
+        # points concentrate in factor space without adding a competing colour channel.
+        behav = _outcome_mask(outcome_threshold, outcome_f)
+        non_behav = .!behav
 
-    scatter!(
-        ax, x_vals, y_vals;
-        color=y, colormap=:viridis,
-        strokewidth=0, alpha=0.5, markersize=10
-    )
+        any(non_behav) && scatter!(
+            ax, x_vals[non_behav], y_vals[non_behav];
+            color=(:grey70, 0.3), strokewidth=0, markersize=8
+        )
+        any(behav) && scatter!(
+            ax, x_vals[behav], y_vals[behav];
+            color=(:dodgerblue, 0.7), strokewidth=0, markersize=8
+        )
 
-    if _add_colorbar
-        Colorbar(g[1, 2]; colormap=:viridis, label="outcome")
+        if with_density_contours && any(behav)
+            n_bins = 15
+            bx = x_vals[behav]
+            by = y_vals[behav]
+            xe = range(extrema(x_vals)...; length=n_bins + 1)
+            ye = range(extrema(y_vals)...; length=n_bins + 1)
+            xc = (xe[1:(end - 1)] .+ xe[2:end]) ./ 2
+            yc = (ye[1:(end - 1)] .+ ye[2:end]) ./ 2
+            n_bin = Float64[
+                count(
+                    (bx .>= xe[i]) .& (bx .< xe[i + 1]) .&
+                    (by .>= ye[j]) .& (by .< ye[j + 1])
+                )
+                for i = 1:n_bins, j = 1:n_bins
+            ]
+            maximum(n_bin) > 0 && contour!(
+                ax, xc, yc, n_bin;
+                levels=5, colormap=:plasma, linewidth=1.5, alpha=0.8
+            )
+        end
+
+        if _add_colorbar
+            Legend(
+                g[1, 2],
+                [
+                    MarkerElement(;
+                        color=(:dodgerblue, 0.7), marker=:circle, markersize=10
+                    ),
+                    MarkerElement(; color=(:grey70, 0.5), marker=:circle, markersize=10)
+                ],
+                ["Behavioural", "Non-behavioural"]
+            )
+        end
+    else
+        if with_contour
+            # 2D binned grid shared by both the mean-outcome heatmap and the density
+            # contours — computed in one pass to avoid redundant work.
+            n_bins = 15
+            x_edges = range(extrema(x_vals)...; length=n_bins + 1)
+            ye_edges = range(extrema(y_vals)...; length=n_bins + 1)
+            x_centers = (x_edges[1:(end - 1)] .+ x_edges[2:end]) ./ 2
+            ye_centers = (ye_edges[1:(end - 1)] .+ ye_edges[2:end]) ./ 2
+
+            masks = [
+                (x_vals .>= x_edges[i]) .& (x_vals .< x_edges[i + 1]) .&
+                (y_vals .>= ye_edges[j]) .& (y_vals .< ye_edges[j + 1])
+                for i = 1:n_bins, j = 1:n_bins
+            ]
+
+            # Mean outcome per bin (colour channel)
+            z_bin = [
+                any(m) ? mean(outcome_f[m]) : NaN
+                for m in masks
+            ]
+
+            finite_z = filter(isfinite, vec(z_bin))
+            if !isempty(finite_z)
+                # heatmap! renders each bin as a solid rectangle — no triangulation
+                # artefacts (diagonal seams) and no NaN-induced white holes.
+                # nan_color=(:white,0) makes empty bins fully transparent so scatter
+                # points remain visible in all areas.
+                heatmap!(
+                    ax, x_centers, ye_centers, z_bin;
+                    colormap=:viridis, alpha=0.4,
+                    colorrange=extrema(finite_z),
+                    nan_color=(:white, 0)
+                )
+
+                if with_density_contours
+                    # Count of scenarios that met the outcome threshold per bin.
+                    # White iso-contour lines show where desired outcomes are concentrated
+                    # in factor space, independently of the mean-outcome colour channel.
+                    above_thresh = _outcome_mask(outcome_threshold, outcome_f)
+                    n_bin = Float64[count(m .& above_thresh) for m in masks]
+                    n_bin_max = maximum(n_bin)
+                    if n_bin_max > 0
+                        contour!(
+                            ax, x_centers, ye_centers, n_bin;
+                            levels=5, color=:white, linewidth=1, alpha=0.7
+                        )
+                    end
+                end
+            end
+        end
+
+        scatter!(
+            ax, x_vals, y_vals;
+            color=outcome_f, colormap=:viridis,
+            strokewidth=0, alpha=0.5, markersize=10
+        )
+
+        if _add_colorbar
+            Colorbar(g[1, 2]; colormap=:viridis, label="outcome")
+        end
     end
 
     return g
@@ -235,7 +357,10 @@ function ADRIA.viz.rsa(
     X::DataFrame,
     y::AbstractVector{<:Real},
     foi::NTuple{2,Symbol};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    with_density_contours::Bool=true,
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
@@ -244,7 +369,12 @@ function ADRIA.viz.rsa(
     set_figure_defaults(fig_opts)
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
-    ADRIA.viz.rsa!(g, X, y, foi; with_contour=with_contour, opts=opts, axis_opts=axis_opts)
+    ADRIA.viz.rsa!(
+        g, X, y, foi;
+        binary_mode=binary_mode, with_contour=with_contour,
+        with_density_contours=with_density_contours,
+        outcome_threshold=outcome_threshold, opts=opts, axis_opts=axis_opts
+    )
     return f
 end
 function ADRIA.viz.rsa!(
@@ -252,7 +382,10 @@ function ADRIA.viz.rsa!(
     X::DataFrame,
     y::AbstractVector{<:Real},
     factor_pairs::AbstractVector{<:NTuple{2,Symbol}};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    with_density_contours::Bool=true,
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
 )
@@ -265,10 +398,26 @@ function ADRIA.viz.rsa!(
         set_typography_defaults!(ax_opts; n_panels=n_pairs)
         ADRIA.viz.rsa!(
             g[row, col], X, y, pair;
-            with_contour=with_contour, _add_colorbar=false, opts=opts, axis_opts=ax_opts
+            binary_mode=binary_mode, with_contour=with_contour,
+            with_density_contours=with_density_contours,
+            outcome_threshold=outcome_threshold, _add_colorbar=false, opts=opts,
+            axis_opts=ax_opts
         )
     end
-    Colorbar(g[1:n_rows, n_cols + 1]; colormap=:viridis, label="outcome")
+    if binary_mode
+        Legend(
+            g[1:n_rows, n_cols + 1],
+            [
+                MarkerElement(;
+                    color=(:dodgerblue, 0.7), marker=:circle, markersize=12
+                ),
+                MarkerElement(; color=(:grey70, 0.5), marker=:circle, markersize=12)
+            ],
+            ["Behavioural", "Non-behavioural"]
+        )
+    else
+        Colorbar(g[1:n_rows, n_cols + 1]; colormap=:viridis, label="outcome")
+    end
     rg, cg = _adaptive_gap(n_pairs)
     if g isa GridLayout
         rowgap!(g, rg)
@@ -280,7 +429,10 @@ function ADRIA.viz.rsa(
     X::DataFrame,
     y::AbstractVector{<:Real},
     factor_pairs::AbstractVector{<:NTuple{2,Symbol}};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    with_density_contours::Bool=true,
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
     opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
     axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
@@ -291,7 +443,10 @@ function ADRIA.viz.rsa(
     f = Figure(; fig_opts...)
     g = f[1, 1] = GridLayout()
     ADRIA.viz.rsa!(
-        g, X, y, factor_pairs; with_contour=with_contour, opts=opts, axis_opts=axis_opts
+        g, X, y, factor_pairs;
+        binary_mode=binary_mode, with_contour=with_contour,
+        with_density_contours=with_density_contours,
+        outcome_threshold=outcome_threshold, opts=opts, axis_opts=axis_opts
     )
     return f
 end
@@ -349,6 +504,157 @@ function ADRIA.viz.rsa(
     g = f[1, 1] = GridLayout()
     ADRIA.viz.rsa!(
         g, X, y, factors; with_density=with_density, opts=opts, axis_opts=axis_opts
+    )
+    return f
+end
+
+"""
+    ADRIA.viz.rsa_cdf!(g, X, y, factor; outcome_threshold=nothing, _add_legend=true, opts=..., axis_opts=...)
+    ADRIA.viz.rsa_cdf(X, y, factor; ...) -> Figure
+    ADRIA.viz.rsa_cdf!(g, X, y, factors; outcome_threshold=nothing, opts=..., axis_opts=...)
+    ADRIA.viz.rsa_cdf(X, y, factors; ...) -> Figure
+
+Classic Hornberger-Spear RSA: empirical CDFs of behavioural vs non-behavioural scenarios
+for each input factor.
+
+For each factor, two empirical CDFs are drawn:
+- **Behavioural** (solid blue): scenarios where the outcome exceeded the threshold.
+- **Non-behavioural** (dashed grey): all remaining scenarios.
+
+A large vertical separation between the two CDFs indicates that the factor strongly
+discriminates between good and poor outcomes (high sensitivity).
+
+# Arguments
+- `g`                : GridLayout or GridPosition to draw into
+- `X`                : Feature matrix (DataFrame, columns = factors)
+- `y`                : Scalar outcome per scenario
+- `factor(s)`        : `Symbol` or `AbstractVector{Symbol}` selecting columns of `X`
+- `outcome_threshold`: Threshold for the behavioural / non-behavioural split:
+                       `nothing` (default) → `y > median(y)`;
+                       `Real` → `y > threshold`;
+                       `AbstractVector{Bool}` → pre-computed mask;
+                       `AbstractVector{<:Integer}` → indices of behavioural scenarios.
+- `_add_legend`      : Add an inline axis legend (suppressed in multi-factor layouts
+                       where a shared legend is placed to the right of the grid).
+"""
+function ADRIA.viz.rsa_cdf!(
+    g::Union{GridLayout,GridPosition},
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factor::Symbol;
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
+    _add_legend::Bool=true,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)
+    set_typography_defaults!(axis_opts)
+    xlabel = get(axis_opts, :xlabel, string(factor))
+    ylabel = get(axis_opts, :ylabel, "Cumulative Probability")
+
+    ax = Axis(g[1, 1]; xlabel=xlabel, ylabel=ylabel, axis_opts...)
+
+    outcome_f = Float64.(y)
+    behav = _outcome_mask(outcome_threshold, outcome_f)
+    non_behav = .!behav
+    x_col = Float64.(X[!, factor])
+
+    if any(non_behav)
+        sv_nb, cdf_nb = _empirical_cdf(x_col[non_behav])
+        lines!(
+            ax, sv_nb, cdf_nb;
+            color=(:grey50, 0.8), linewidth=2, linestyle=:dash,
+            label="Non-behavioural (n=$(count(non_behav)))"
+        )
+    end
+    if any(behav)
+        sv_b, cdf_b = _empirical_cdf(x_col[behav])
+        lines!(
+            ax, sv_b, cdf_b;
+            color=:dodgerblue, linewidth=2,
+            label="Behavioural (n=$(count(behav)))"
+        )
+    end
+
+    _add_legend && axislegend(ax; position=:lt, labelsize=11)
+
+    return g
+end
+function ADRIA.viz.rsa_cdf(
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factor::Symbol;
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Figure
+    get!(fig_opts, :size, (600, 400))
+    set_figure_defaults(fig_opts)
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+    ADRIA.viz.rsa_cdf!(
+        g, X, y, factor;
+        outcome_threshold=outcome_threshold, opts=opts, axis_opts=axis_opts
+    )
+    return f
+end
+function ADRIA.viz.rsa_cdf!(
+    g::Union{GridLayout,GridPosition},
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factors::AbstractVector{Symbol};
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)
+    n_factors = length(factors)
+    n_rows, n_cols = _calc_gridsize(n_factors)
+    for (idx, factor) in enumerate(factors)
+        row = div(idx - 1, n_cols) + 1
+        col = mod(idx - 1, n_cols) + 1
+        ax_opts = copy(axis_opts)
+        set_typography_defaults!(ax_opts; n_panels=n_factors)
+        ADRIA.viz.rsa_cdf!(
+            g[row, col], X, y, factor;
+            outcome_threshold=outcome_threshold, _add_legend=false,
+            opts=opts, axis_opts=ax_opts
+        )
+    end
+    # Shared legend placed to the right of the panel grid.
+    outcome_f = Float64.(y)
+    behav = _outcome_mask(outcome_threshold, outcome_f)
+    Legend(
+        g[1:n_rows, n_cols + 1],
+        [
+            LineElement(; color=:dodgerblue, linewidth=2, linestyle=:solid),
+            LineElement(; color=(:grey50, 0.8), linewidth=2, linestyle=:dash)
+        ],
+        ["Behavioural (n=$(count(behav)))", "Non-behavioural (n=$(count(.!behav)))"]
+    )
+    rg, cg = _adaptive_gap(n_factors)
+    if g isa GridLayout
+        rowgap!(g, rg)
+        colgap!(g, cg)
+    end
+    return g
+end
+function ADRIA.viz.rsa_cdf(
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factors::AbstractVector{Symbol};
+    outcome_threshold::Union{Real,AbstractVector{Bool},AbstractVector{<:Integer},Nothing}=nothing,
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Figure
+    n_factors = length(factors)
+    n_rows, n_cols = _calc_gridsize(n_factors)
+    set_figure_defaults(fig_opts; n_rows=n_rows, n_cols=n_cols)
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+    ADRIA.viz.rsa_cdf!(
+        g, X, y, factors;
+        outcome_threshold=outcome_threshold, opts=opts, axis_opts=axis_opts
     )
     return f
 end
@@ -415,6 +721,12 @@ function ADRIA.viz.outcome_map!(
 
     if factor == :guided
         fv_labels = _get_guided_labels()
+        unique_vals = sort(unique(x_f))
+        n_labels = min(length(fv_labels), length(unique_vals))
+        ax.xticks = (unique_vals[1:n_labels], fv_labels[1:n_labels])
+        ax.xticklabelrotation = pi / 4
+    elseif factor == :mcda_method
+        fv_labels = _get_mcda_method_labels()
         unique_vals = sort(unique(x_f))
         n_labels = min(length(fv_labels), length(unique_vals))
         ax.xticks = (unique_vals[1:n_labels], fv_labels[1:n_labels])
@@ -486,6 +798,85 @@ function ADRIA.viz.outcome_map(
     ADRIA.viz.outcome_map!(
         g, X, y, factors; with_density=with_density, opts=opts, axis_opts=axis_opts
     )
+    return f
+end
+
+"""
+    ADRIA.viz.stratified_rsa(result::DataFrame; opts=..., fig_opts=..., axis_opts=...) -> Figure
+    ADRIA.viz.stratified_rsa!(g, result::DataFrame; opts=..., axis_opts=...)
+
+Heatmap of DHW-stratified RSA results.
+
+Rows = factors sorted descending by `mean_importance` (mean abs(prob_superiority - 0.5)
+across strata). Columns = DHW strata (1 = lowest DHW, n = highest DHW).
+Cell colour = `prob_superiority` in [0, 1].
+
+# Arguments
+- `result`    : DataFrame returned by `ADRIAanalysis.sensitivity.stratified_rsa`.
+- `opts`      : Figure customization options
+    - `top_n` : Show only the top-N factors by `mean_importance` (default: all)
+- `fig_opts`  : Passed to `Figure()`
+- `axis_opts` : Passed to `Axis()`
+"""
+function ADRIA.viz.stratified_rsa!(
+    g::Union{GridLayout,GridPosition},
+    result::DataFrame;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)
+    set_typography_defaults!(axis_opts)
+    xtick_rot = get(axis_opts, :xticklabelrotation, 0.0)
+
+    top_n = get(opts, :top_n, nrow(result))
+
+    # Build factor order: sort by mean_importance descending, then apply top_n
+    cons_order = sort(
+        unique(result[:, [:feature, :mean_importance]]),
+        :mean_importance;
+        rev=true
+    )
+    n_show = min(top_n, nrow(cons_order))
+    factors_ordered = cons_order.feature[1:n_show]
+
+    strata = sort(unique(result.stratum))
+    n_strata = length(strata)
+    n_factors = length(factors_ordered)
+
+    # Build matrix: rows = factors (top->bottom), cols = strata (low->high DHW)
+    z = fill(NaN, n_factors, n_strata)
+    for (fi, feat) in enumerate(factors_ordered)
+        for (si, s) in enumerate(strata)
+            rows = filter(r -> r.feature == feat && r.stratum == s, result)
+            isempty(rows) || (z[fi, si] = rows.prob_superiority[1])
+        end
+    end
+
+    ax = Axis(
+        g[1, 1];
+        xticks=(1:n_strata, ["DHW Q$s" for s in strata]),
+        yticks=(1:n_factors, string.(factors_ordered)),
+        xticklabelrotation=xtick_rot,
+        xlabel=get(axis_opts, :xlabel, "DHW stratum"),
+        ylabel=get(axis_opts, :ylabel, "Factor"),
+        axis_opts...
+    )
+    ax.yreversed = true
+
+    heatmap!(ax, z'; colormap=:viridis, colorrange=(0.0, 1.0))
+    Colorbar(g[1, 2]; colormap=:viridis, colorrange=(0.0, 1.0), label="P(superiority)")
+
+    return g
+end
+function ADRIA.viz.stratified_rsa(
+    result::DataFrame;
+    opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    fig_opts::OPT_TYPE=DEFAULT_OPT_TYPE(),
+    axis_opts::OPT_TYPE=DEFAULT_OPT_TYPE()
+)::Figure
+    set_figure_defaults(fig_opts)
+    f = Figure(; fig_opts...)
+    g = f[1, 1] = GridLayout()
+    ADRIA.viz.stratified_rsa!(g, result; opts=opts, axis_opts=axis_opts)
     return f
 end
 

--- a/ADRIAviz/ext/ADRIAvizPlotlyExt/ADRIAvizPlotlyExt.jl
+++ b/ADRIAviz/ext/ADRIAvizPlotlyExt/ADRIAvizPlotlyExt.jl
@@ -3,7 +3,8 @@ module ADRIAvizPlotlyExt
 using ADRIA
 using ADRIAviz
 using ADRIAviz: AnnotatedOutcomes, _get_scenario_groups, _scenario_clusters,
-    _scenario_types, _scenario_rcps, COLORS, labels, _calc_gridsize
+    _scenario_types, _scenario_rcps, COLORS, labels, _calc_gridsize,
+    _outcome_mask, _empirical_cdf
 using PlotlyBase
 
 include("theme.jl")

--- a/ADRIAviz/ext/ADRIAvizPlotlyExt/viz/sensitivity.jl
+++ b/ADRIAviz/ext/ADRIAvizPlotlyExt/viz/sensitivity.jl
@@ -137,7 +137,9 @@ function ADRIA.viz.rsa(
     X::DataFrame,
     y::AbstractVector{<:Real},
     foi::NTuple{2,Symbol};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    outcome_threshold=nothing,
     title::String="Regional Sensitivity",
     kwargs...
 )::PlotlyBase.Plot
@@ -146,44 +148,85 @@ function ADRIA.viz.rsa(
     z_vals = Float64.(y)
 
     fsz = _plotly_font_sizes(1)
-
     traces = PlotlyBase.AbstractTrace[]
 
-    if with_contour
+    if binary_mode
+        # Classic RSA: binary behavioural / non-behavioural scatter.
+        behav = _outcome_mask(outcome_threshold, z_vals)
+        non_behav = .!behav
+
+        any(non_behav) && push!(
+            traces,
+            PlotlyBase.scatter(;
+                x=x_vals[non_behav], y=y_vals[non_behav], mode="markers",
+                name="Non-behavioural (n=$(count(non_behav)))",
+                marker=PlotlyBase.attr(;
+                    color="rgba(150,150,150,0.3)", size=5
+                ),
+                type="scatter"
+            )
+        )
+        any(behav) && push!(
+            traces,
+            PlotlyBase.scatter(;
+                x=x_vals[behav], y=y_vals[behav], mode="markers",
+                name="Behavioural (n=$(count(behav)))",
+                marker=PlotlyBase.attr(;
+                    color="rgba(30,144,255,0.7)", size=5
+                ),
+                type="scatter"
+            )
+        )
+        if with_contour && any(behav)
+            push!(
+                traces,
+                PlotlyBase.histogram2dcontour(;
+                    x=x_vals[behav], y=y_vals[behav],
+                    colorscale="Plasma",
+                    showscale=false, ncontours=5,
+                    contours=PlotlyBase.attr(; coloring="lines", showlines=true),
+                    line=PlotlyBase.attr(; width=1),
+                    type="histogram2dcontour"
+                )
+            )
+        end
+    else
+        if with_contour
+            push!(
+                traces,
+                PlotlyBase.histogram2dcontour(;
+                    x=x_vals,
+                    y=y_vals,
+                    z=z_vals,
+                    histfunc="avg",
+                    colorscale="Viridis",
+                    showscale=false,
+                    opacity=0.4,
+                    ncontours=15,
+                    contours=PlotlyBase.attr(; coloring="fill", showlines=false),
+                    type="histogram2dcontour"
+                )
+            )
+        end
+
         push!(
             traces,
-            PlotlyBase.histogram2dcontour(;
+            PlotlyBase.scatter(;
                 x=x_vals,
                 y=y_vals,
-                z=z_vals,
-                histfunc="avg",
-                colorscale="Viridis",
-                showscale=false,
-                opacity=0.4,
-                ncontours=15,
-                contours=PlotlyBase.attr(; coloring="fill", showlines=false),
-                type="histogram2dcontour"
+                mode="markers",
+                marker=PlotlyBase.attr(;
+                    color=z_vals,
+                    colorscale="Viridis",
+                    showscale=true,
+                    opacity=0.6,
+                    size=5,
+                    colorbar=PlotlyBase.attr(; title="outcome")
+                ),
+                type="scatter"
             )
         )
     end
-
-    push!(
-        traces,
-        PlotlyBase.scatter(;
-            x=x_vals,
-            y=y_vals,
-            mode="markers",
-            marker=PlotlyBase.attr(;
-                color=z_vals,
-                colorscale="Viridis",
-                showscale=true,
-                opacity=0.6,
-                size=5,
-                colorbar=PlotlyBase.attr(; title="outcome")
-            ),
-            type="scatter"
-        )
-    )
 
     layout = PlotlyBase.Layout(;
         ADRIA_LAYOUT_DEFAULTS...,
@@ -202,7 +245,9 @@ function ADRIA.viz.rsa(
     X::DataFrame,
     y::AbstractVector{<:Real},
     factor_pairs::AbstractVector{<:NTuple{2,Symbol}};
+    binary_mode::Bool=false,
     with_contour::Bool=true,
+    outcome_threshold=nothing,
     title::String="Regional Sensitivity",
     kwargs...
 )::PlotlyBase.Plot
@@ -211,6 +256,9 @@ function ADRIA.viz.rsa(
     fsz = _plotly_font_sizes(n_pairs)
     z_vals = Float64.(y)
 
+    behav = binary_mode ? _outcome_mask(outcome_threshold, z_vals) : nothing
+    non_behav = binary_mode ? .!behav : nothing
+
     traces = PlotlyBase.AbstractTrace[]
     layout = PlotlyBase.Layout(;
         ADRIA_LAYOUT_DEFAULTS...,
@@ -218,7 +266,7 @@ function ADRIA.viz.rsa(
         font=PlotlyBase.attr(; family="Open Sans, sans-serif", size=fsz.label),
         width=max(600, 500 * n_cols),
         height=max(400, 450 * n_rows),
-        showlegend=false
+        showlegend=binary_mode
     )
 
     for (i, pair) in enumerate(factor_pairs)
@@ -227,46 +275,84 @@ function ADRIA.viz.rsa(
         sfx = i == 1 ? "" : string(i)
         xd, yd, _, _ = domains[i]
 
-        if with_contour
+        if binary_mode
+            show_legend = (i == 1)
+            any(non_behav) && push!(
+                traces,
+                PlotlyBase.scatter(;
+                    x=x_vals[non_behav], y=y_vals[non_behav], mode="markers",
+                    name="Non-behavioural (n=$(count(non_behav)))",
+                    marker=PlotlyBase.attr(; color="rgba(150,150,150,0.3)", size=4),
+                    showlegend=show_legend, legendgroup="non_behav",
+                    xaxis="x$(sfx)", yaxis="y$(sfx)", type="scatter"
+                )
+            )
+            any(behav) && push!(
+                traces,
+                PlotlyBase.scatter(;
+                    x=x_vals[behav], y=y_vals[behav], mode="markers",
+                    name="Behavioural (n=$(count(behav)))",
+                    marker=PlotlyBase.attr(; color="rgba(30,144,255,0.7)", size=4),
+                    showlegend=show_legend, legendgroup="behav",
+                    xaxis="x$(sfx)", yaxis="y$(sfx)", type="scatter"
+                )
+            )
+            if with_contour && any(behav)
+                push!(
+                    traces,
+                    PlotlyBase.histogram2dcontour(;
+                        x=x_vals[behav], y=y_vals[behav],
+                        colorscale="Plasma",
+                        showscale=false, ncontours=5, showlegend=false,
+                        contours=PlotlyBase.attr(; coloring="lines", showlines=true),
+                        line=PlotlyBase.attr(; width=1),
+                        xaxis="x$(sfx)", yaxis="y$(sfx)",
+                        type="histogram2dcontour"
+                    )
+                )
+            end
+        else
+            if with_contour
+                push!(
+                    traces,
+                    PlotlyBase.histogram2dcontour(;
+                        x=x_vals,
+                        y=y_vals,
+                        z=z_vals,
+                        histfunc="avg",
+                        colorscale="Viridis",
+                        showscale=false,
+                        opacity=0.4,
+                        ncontours=15,
+                        contours=PlotlyBase.attr(; coloring="fill", showlines=false),
+                        xaxis="x$(sfx)",
+                        yaxis="y$(sfx)",
+                        type="histogram2dcontour"
+                    )
+                )
+            end
+
             push!(
                 traces,
-                PlotlyBase.histogram2dcontour(;
+                PlotlyBase.scatter(;
                     x=x_vals,
                     y=y_vals,
-                    z=z_vals,
-                    histfunc="avg",
-                    colorscale="Viridis",
-                    showscale=false,
-                    opacity=0.4,
-                    ncontours=15,
-                    contours=PlotlyBase.attr(; coloring="fill", showlines=false),
+                    mode="markers",
+                    marker=PlotlyBase.attr(;
+                        color=z_vals,
+                        colorscale="Viridis",
+                        showscale=(i == n_pairs),
+                        opacity=0.6,
+                        size=5,
+                        colorbar=PlotlyBase.attr(; title="outcome")
+                    ),
+                    showlegend=false,
                     xaxis="x$(sfx)",
                     yaxis="y$(sfx)",
-                    type="histogram2dcontour"
+                    type="scatter"
                 )
             )
         end
-
-        push!(
-            traces,
-            PlotlyBase.scatter(;
-                x=x_vals,
-                y=y_vals,
-                mode="markers",
-                marker=PlotlyBase.attr(;
-                    color=z_vals,
-                    colorscale="Viridis",
-                    showscale=(i == n_pairs),
-                    opacity=0.6,
-                    size=5,
-                    colorbar=PlotlyBase.attr(; title="outcome")
-                ),
-                showlegend=false,
-                xaxis="x$(sfx)",
-                yaxis="y$(sfx)",
-                type="scatter"
-            )
-        )
 
         layout[Symbol("xaxis$(sfx)")] = PlotlyBase.attr(;
             title_text=string(pair[1]), anchor="y$(sfx)", domain=xd,
@@ -281,7 +367,157 @@ function ADRIA.viz.rsa(
     return PlotlyBase.Plot(traces, layout)
 end
 
-# helper: compute the [x_domain, y_domain] rectangles for an n-panel subplot grid.
+"""
+    ADRIA.viz.rsa_cdf(X, y, factor; outcome_threshold=nothing, title, kwargs...) -> PlotlyBase.Plot
+    ADRIA.viz.rsa_cdf(X, y, factors; outcome_threshold=nothing, title, kwargs...) -> PlotlyBase.Plot
+
+Classic Hornberger-Spear RSA: empirical CDFs of behavioural vs non-behavioural scenarios
+for each input factor.
+
+For each factor, two empirical CDFs are plotted:
+- **Behavioural** (solid blue): scenarios where the outcome exceeded the threshold.
+- **Non-behavioural** (dashed grey): all remaining scenarios.
+
+A large vertical separation between the two CDFs indicates that the factor strongly
+discriminates between good and poor outcomes (high sensitivity).
+
+# Arguments
+- `X`                : Feature matrix (DataFrame, columns = factors)
+- `y`                : Scalar outcome per scenario
+- `factor(s)`        : `Symbol` or `AbstractVector{Symbol}` selecting columns of `X`
+- `outcome_threshold`: Threshold for the behavioural / non-behavioural split:
+                       `nothing` (default) → `y > median(y)`;
+                       `Real` → `y > threshold`;
+                       `AbstractVector{Bool}` → pre-computed mask.
+"""
+function ADRIA.viz.rsa_cdf(
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factor::Symbol;
+    outcome_threshold=nothing,
+    title::String="RSA: Empirical CDFs",
+    kwargs...
+)::PlotlyBase.Plot
+    outcome_f = Float64.(y)
+    behav = _outcome_mask(outcome_threshold, outcome_f)
+    non_behav = .!behav
+    x_col = Float64.(X[!, factor])
+
+    fsz = _plotly_font_sizes(1)
+    traces = PlotlyBase.AbstractTrace[]
+
+    if any(non_behav)
+        sv_nb, cdf_nb = _empirical_cdf(x_col[non_behav])
+        push!(
+            traces,
+            PlotlyBase.scatter(;
+                x=sv_nb, y=cdf_nb, mode="lines",
+                name="Non-behavioural (n=$(count(non_behav)))",
+                line=PlotlyBase.attr(; color="grey", dash="dash", width=2),
+                type="scatter"
+            )
+        )
+    end
+    if any(behav)
+        sv_b, cdf_b = _empirical_cdf(x_col[behav])
+        push!(
+            traces,
+            PlotlyBase.scatter(;
+                x=sv_b, y=cdf_b, mode="lines",
+                name="Behavioural (n=$(count(behav)))",
+                line=PlotlyBase.attr(; color="dodgerblue", width=2),
+                type="scatter"
+            )
+        )
+    end
+
+    layout = PlotlyBase.Layout(;
+        ADRIA_LAYOUT_DEFAULTS...,
+        title=PlotlyBase.attr(; text=title, font=PlotlyBase.attr(; size=fsz.title)),
+        font=PlotlyBase.attr(; family="Open Sans, sans-serif", size=fsz.label),
+        xaxis=PlotlyBase.attr(;
+            title_text=string(factor), tickfont=PlotlyBase.attr(; size=fsz.tick)
+        ),
+        yaxis=PlotlyBase.attr(;
+            title_text="Cumulative Probability", tickfont=PlotlyBase.attr(; size=fsz.tick)
+        )
+    )
+    return PlotlyBase.Plot(traces, layout)
+end
+function ADRIA.viz.rsa_cdf(
+    X::DataFrame,
+    y::AbstractVector{<:Real},
+    factors::AbstractVector{Symbol};
+    outcome_threshold=nothing,
+    title::String="RSA: Empirical CDFs",
+    kwargs...
+)::PlotlyBase.Plot
+    n_factors = length(factors)
+    domains, n_rows, n_cols = _grid_domains(n_factors)
+    fsz = _plotly_font_sizes(n_factors)
+
+    outcome_f = Float64.(y)
+    behav = _outcome_mask(outcome_threshold, outcome_f)
+    non_behav = .!behav
+    n_b = count(behav)
+    n_nb = count(non_behav)
+
+    traces = PlotlyBase.AbstractTrace[]
+    layout = PlotlyBase.Layout(;
+        ADRIA_LAYOUT_DEFAULTS...,
+        title=PlotlyBase.attr(; text=title, font=PlotlyBase.attr(; size=fsz.title)),
+        font=PlotlyBase.attr(; family="Open Sans, sans-serif", size=fsz.label),
+        width=max(600, 500 * n_cols),
+        height=max(400, 350 * n_rows),
+        showlegend=true
+    )
+
+    for (i, factor) in enumerate(factors)
+        x_col = Float64.(X[!, factor])
+        sfx = i == 1 ? "" : string(i)
+        xd, yd, _, _ = domains[i]
+        show_legend = (i == 1)
+
+        if any(non_behav)
+            sv_nb, cdf_nb = _empirical_cdf(x_col[non_behav])
+            push!(
+                traces,
+                PlotlyBase.scatter(;
+                    x=sv_nb, y=cdf_nb, mode="lines",
+                    name="Non-behavioural (n=$n_nb)",
+                    line=PlotlyBase.attr(; color="grey", dash="dash", width=2),
+                    showlegend=show_legend, legendgroup="non_behav",
+                    xaxis="x$(sfx)", yaxis="y$(sfx)", type="scatter"
+                )
+            )
+        end
+        if any(behav)
+            sv_b, cdf_b = _empirical_cdf(x_col[behav])
+            push!(
+                traces,
+                PlotlyBase.scatter(;
+                    x=sv_b, y=cdf_b, mode="lines",
+                    name="Behavioural (n=$n_b)",
+                    line=PlotlyBase.attr(; color="dodgerblue", width=2),
+                    showlegend=show_legend, legendgroup="behav",
+                    xaxis="x$(sfx)", yaxis="y$(sfx)", type="scatter"
+                )
+            )
+        end
+
+        layout[Symbol("xaxis$(sfx)")] = PlotlyBase.attr(;
+            title_text=string(factor), anchor="y$(sfx)", domain=xd,
+            tickfont=PlotlyBase.attr(; size=fsz.tick)
+        )
+        layout[Symbol("yaxis$(sfx)")] = PlotlyBase.attr(;
+            title_text=(i == 1 ? "Cumulative Probability" : ""),
+            anchor="x$(sfx)", domain=yd,
+            tickfont=PlotlyBase.attr(; size=fsz.tick)
+        )
+    end
+
+    return PlotlyBase.Plot(traces, layout)
+end
 # Panels fill left-to-right, top-to-bottom (panel 1 is top-left). Reuses
 # `_calc_gridsize` so the grid shape matches the rest of ADRIAviz.
 function _grid_domains(n::Int; x_gap::Float64=0.08, y_gap::Float64=0.12)
@@ -492,4 +728,92 @@ function ADRIA.viz.convergence(
         )
     )
     return PlotlyBase.Plot(traces, layout)
+end
+
+# ──────────────────────────────────────────────────────────────────────────────
+# stratified_rsa(result) — DHW-stratified RSA heatmap
+# ──────────────────────────────────────────────────────────────────────────────
+
+"""
+    ADRIA.viz.stratified_rsa(result::DataFrame; top_n=nothing, title, kwargs...) -> PlotlyBase.Plot
+
+Heatmap of DHW-stratified RSA results.
+
+Rows = factors sorted descending by `mean_importance` (mean abs(prob_superiority - 0.5)
+across strata). Columns = DHW strata (Q1 = lowest DHW, Qn = highest DHW).
+Cell colour = `prob_superiority` in [0, 1]; 0.5 = neutral, 1.0 = strongly behavioural.
+
+# Arguments
+- `result` : DataFrame returned by `ADRIAanalysis.sensitivity.stratified_rsa`.
+- `top_n`  : Show only the top-N factors by `mean_importance` (default: all).
+- `title`  : Plot title.
+"""
+function ADRIA.viz.stratified_rsa(
+    result::DataFrame;
+    top_n::Union{Int,Nothing}=nothing,
+    title::String="DHW-Stratified RSA",
+    kwargs...
+)::PlotlyBase.Plot
+    # Factor order: sort by mean_importance descending, apply top_n cap.
+    cons_order = sort(
+        unique(result[:, [:feature, :mean_importance]]),
+        :mean_importance;
+        rev=true
+    )
+    n_show = isnothing(top_n) ? nrow(cons_order) : min(top_n, nrow(cons_order))
+    factors_ordered = cons_order.feature[1:n_show]
+
+    strata = sort(unique(result.stratum))
+    n_factors = length(factors_ordered)
+
+    # Build z: Vector{Vector{Float64}} where z[row_i][col_j] = prob_superiority.
+    # Row i = factors_ordered[i], col j = strata[j].
+    z_plotly = [
+        Float64[
+            (rows=filter(r -> r.feature == feat && r.stratum == s, result);
+                isempty(rows) ? NaN : rows.prob_superiority[1])
+            for s in strata
+        ]
+        for feat in factors_ordered
+    ]
+
+    x_labels = ["DHW Q$s" for s in strata]
+    y_labels = string.(factors_ordered)
+
+    fsz = _plotly_font_sizes(1)
+    fig_height = max(350, 60 + 28 * n_factors)
+
+    trace = PlotlyBase.heatmap(;
+        x=x_labels,
+        y=y_labels,
+        z=z_plotly,
+        colorscale="Viridis",
+        zmin=0.0,
+        zmax=1.0,
+        colorbar=PlotlyBase.attr(;
+            title=PlotlyBase.attr(; text="P(superiority)", side="right"),
+            tickfont=PlotlyBase.attr(; size=fsz.tick)
+        ),
+        type="heatmap"
+    )
+
+    layout = PlotlyBase.Layout(;
+        ADRIA_LAYOUT_DEFAULTS...,
+        title=PlotlyBase.attr(; text=title, font=PlotlyBase.attr(; size=fsz.title)),
+        font=PlotlyBase.attr(; family="Open Sans, sans-serif", size=fsz.label),
+        height=fig_height,
+        xaxis=PlotlyBase.attr(;
+            title_text="DHW stratum",
+            tickfont=PlotlyBase.attr(; size=fsz.tick)
+        ),
+        yaxis=PlotlyBase.attr(;
+            title_text="Factor",
+            tickfont=PlotlyBase.attr(; size=fsz.tick),
+            # factors_ordered[1] is most important; Plotly places y[1] at the bottom
+            # by default, so reverse to put the most important factor at the top.
+            autorange="reversed",
+            automargin=true
+        )
+    )
+    return PlotlyBase.Plot([trace], layout)
 end

--- a/ADRIAviz/src/ADRIAviz.jl
+++ b/ADRIAviz/src/ADRIAviz.jl
@@ -17,6 +17,7 @@ using .viz:
     outcome_title, outcome_label, set_plot_opts!,
     OPT_TYPE, DEFAULT_OPT_TYPE,
     _time_labels, _calc_gridsize, set_typography_defaults!, timesteps,
+    _outcome_mask, _empirical_cdf,
     _loc_id_col, _get_site_ids, _site_ids, _haversine_km, _nice_length, validate_extent,
     GBR_COASTAL_PLACES, CoastalPlace, MapDecorationData, compute_map_decorations
 
@@ -26,6 +27,7 @@ export GBR_COASTAL_PLACES, CoastalPlace, MapDecorationData, compute_map_decorati
 export outcome_title, outcome_label, set_plot_opts!
 export OPT_TYPE, DEFAULT_OPT_TYPE
 export _time_labels, _calc_gridsize, set_typography_defaults!, timesteps
+export _outcome_mask, _empirical_cdf
 
 # Re-export theme and analysis helpers
 export COLORS, labels

--- a/ADRIAviz/src/activate.jl
+++ b/ADRIAviz/src/activate.jl
@@ -44,7 +44,8 @@ function activate(backend::Symbol)
         @warn "PlotlyKaleido is not installed — `ADRIA.viz.savefig` will not be available.\n" *
             "To enable static export: pkg> add PlotlyKaleido"
     else
-        Base.require(_KALEIDO_PKG_ID)
+        kaleido = Base.require(_KALEIDO_PKG_ID)
+        Base.invokelatest(kaleido.start)
     end
 
     return nothing

--- a/ADRIAviz/src/viz/viz.jl
+++ b/ADRIAviz/src/viz/viz.jl
@@ -1,6 +1,6 @@
 module viz
 
-using DataFrames, DimensionalData, YAXArrays
+using DataFrames, DimensionalData, Statistics, YAXArrays
 using ADRIA
 using ADRIA: axes_names, ResultSet, model_spec
 
@@ -95,6 +95,37 @@ end
 include("../outcome_metadata.jl")
 include("spatial_utils.jl")
 
+"""
+    _outcome_mask(outcome_threshold, y) -> BitVector
+
+Convert the `outcome_threshold` keyword to a `BitVector` marking "behavioural" scenarios.
+Dispatch on type keeps call sites free of branching.
+
+- `nothing`                  : scenarios where `y > median(y)`
+- `Real`                     : scenarios where `y > threshold`
+- `AbstractVector{Bool}`     : passed through unchanged
+- `AbstractVector{<:Integer}`: indices converted to a boolean mask
+"""
+_outcome_mask(::Nothing, y::AbstractVector{Float64}) = y .> median(y)
+_outcome_mask(t::Real, y::AbstractVector{Float64}) = y .> Float64(t)
+_outcome_mask(m::AbstractVector{Bool}, ::AbstractVector{Float64}) = m
+function _outcome_mask(idx::AbstractVector{<:Integer}, y::AbstractVector{Float64})
+    mask = falses(length(y))
+    mask[idx] .= true
+    return mask
+end
+
+"""
+    _empirical_cdf(v) -> (sorted_values, cumulative_probs)
+
+Return the sorted values and their empirical cumulative probabilities for a vector `v`.
+"""
+function _empirical_cdf(v::AbstractVector{<:Real})
+    sv = sort(v)
+    n = length(sv)
+    return sv, collect((1:n) ./ n)
+end
+
 # Export shared spatial utilities for use in extensions (after they're defined)
 export set_typography_defaults!
 export _loc_id_col, _get_site_ids, _site_ids, _haversine_km, _nice_length, validate_extent
@@ -104,5 +135,6 @@ export GBR_COASTAL_PLACES, CoastalPlace, MapDecorationData, compute_map_decorati
 export outcome_title, outcome_label, set_plot_opts!
 export OPT_TYPE, DEFAULT_OPT_TYPE
 export _time_labels, _calc_gridsize, timesteps
+export _outcome_mask, _empirical_cdf
 
 end  # module viz


### PR DESCRIPTION
## Summary
Stacked on #1154 (ADRIAanalysis RSA auto-dispatch/stratified/counterfactual work) — the visualization consumer of its new API:

Both Makie and Plotly `sensitivity.jl` extensions:
- `rsa!`/`rsa` gains `binary_mode` (behavioural vs non-behavioural scatter with optional density contours) and a continuous heatmap mode (binned mean-outcome heatmap, replacing `tricontourf`'s triangulation artefacts). `outcome_threshold` accepts `nothing` (median split), a `Real` threshold, a precomputed `Bool` mask, or `Integer` indices.
- New `rsa_cdf!`/`rsa_cdf`: empirical CDFs of behavioural vs non-behavioural scenarios per factor.
- New `stratified_rsa!`/`stratified_rsa`: heatmap of factors (ranked by `mean_importance`) × DHW stratum, coloured by `prob_superiority`.
- `_get_guided_labels()` simplified; new `_get_mcda_method_labels()` separates out MCDA method labels.

Core `ADRIAviz`: adds and exports `_outcome_mask`/`_empirical_cdf` utilities shared by both backend extensions; fixes PlotlyKaleido startup via `Base.invokelatest(kaleido.start)`.

These are the viz-side implementations that PR #1148's `viz_check_common.jl` extensions (`rsa_stratified`, `rsa_cdf`, guided-vs-unguided checks) actually call.

## Test plan
- [ ] Run the viz-check scripts against a real domain and confirm the new binary/heatmap/CDF/stratified RSA plots render on both backends