### PR TITLE
fix(ci): bust poisoned julia-actions cache for ADRIAanalysis/ADRIAviz tests

### DIFF
--- a/.github/workflows/ADRIAanalysisTests.yml
+++ b/.github/workflows/ADRIAanalysisTests.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           version: '1.11'
       - uses: julia-actions/cache@v3
+        with:
+          cache-name: adriaanalysis-setup-cache-v2
       - name: Dev ADRIA into ADRIAanalysis environment
         run: |
           cd ADRIAanalysis

--- a/.github/workflows/ADRIAvizTests.yml
+++ b/.github/workflows/ADRIAvizTests.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           version: '1.11'
       - uses: julia-actions/cache@v3
+        with:
+          cache-name: adriaviz-setup-cache-v2
       - name: Dev ADRIA into ADRIAviz environment
         run: |
           cd ADRIAviz
@@ -40,6 +42,8 @@ jobs:
         with:
           version: '1.11'
       - uses: julia-actions/cache@v3
+        with:
+          cache-name: adriaviz-setup-cache-v2
       - name: Dev ADRIA into ADRIAviz environment
         run: |
           cd ADRIAviz

--- a/ADRIAviz/test/spatial_decorations.jl
+++ b/ADRIAviz/test/spatial_decorations.jl
@@ -67,9 +67,13 @@ end
 
 if get(ENV, "ADRIA_RUN_VIZ_TESTS", "0") == "1"
     # _figure_size and _adaptive_gap live in the Makie extension, which requires
-    # all three of Makie, GeoMakie, and GraphMakie to be loaded to trigger
+    # all three of Makie, GeoMakie, and GraphMakie to be loaded to trigger.
+    # Package extensions aren't `using`-able by name; fetch the module handle
+    # via Base.get_extension instead.
     using CairoMakie, GeoMakie, GraphMakie
-    using ADRIAvizMakieExt: _figure_size, _adaptive_gap
+    _makie_ext = Base.get_extension(ADRIAviz, :ADRIAvizMakieExt)
+    _figure_size = _makie_ext._figure_size
+    _adaptive_gap = _makie_ext._adaptive_gap
 
     @testset "_figure_size" begin
         w, h = _figure_size(1, 1)

--- a/ADRIAviz/test/spatial_decorations.jl
+++ b/ADRIAviz/test/spatial_decorations.jl
@@ -67,7 +67,7 @@ end
 
 if get(ENV, "ADRIA_RUN_VIZ_TESTS", "0") == "1"
     # _figure_size and _adaptive_gap live in the Makie extension
-    using GLMakie
+    using CairoMakie
     using ADRIAvizMakieExt: _figure_size, _adaptive_gap
 
     @testset "_figure_size" begin
@@ -113,7 +113,7 @@ if get(ENV, "ADRIA_RUN_MAKIE_SPATIAL_INTEGRATION", "0") == "1"
     if isempty(dom_path) || !isdir(dom_path)
         @warn "ADRIA_RUN_MAKIE_SPATIAL_INTEGRATION=1 but ADRIA_TEST_DOMAIN not set or invalid; skipping"
     else
-        using GLMakie, ADRIA
+        using CairoMakie, ADRIA
 
         @testset "Spatial map decorations (integration)" begin
             dom = ADRIA.load_domain(dom_path)

--- a/ADRIAviz/test/spatial_decorations.jl
+++ b/ADRIAviz/test/spatial_decorations.jl
@@ -66,8 +66,9 @@ end
 # =============================================================================
 
 if get(ENV, "ADRIA_RUN_VIZ_TESTS", "0") == "1"
-    # _figure_size and _adaptive_gap live in the Makie extension
-    using CairoMakie
+    # _figure_size and _adaptive_gap live in the Makie extension, which requires
+    # all three of Makie, GeoMakie, and GraphMakie to be loaded to trigger
+    using CairoMakie, GeoMakie, GraphMakie
     using ADRIAvizMakieExt: _figure_size, _adaptive_gap
 
     @testset "_figure_size" begin
@@ -113,7 +114,7 @@ if get(ENV, "ADRIA_RUN_MAKIE_SPATIAL_INTEGRATION", "0") == "1"
     if isempty(dom_path) || !isdir(dom_path)
         @warn "ADRIA_RUN_MAKIE_SPATIAL_INTEGRATION=1 but ADRIA_TEST_DOMAIN not set or invalid; skipping"
     else
-        using CairoMakie, ADRIA
+        using CairoMakie, GeoMakie, GraphMakie, ADRIA
 
         @testset "Spatial map decorations (integration)" begin
             dom = ADRIA.load_domain(dom_path)


### PR DESCRIPTION
## Summary

Fixes #1156.

Root cause: the `julia-actions/cache` for `ADRIAanalysis Tests`/`ADRIAviz Tests` had been restoring as effectively empty (~450-500 bytes vs a healthy ~500-600 MiB) since 2026-07-14, so every run failed during stdlib precompilation (`LibGit2_jll`, `LibSSH2_jll`, `MbedTLS_jll`) before any test code ran. The job died before the depot could ever be repopulated, so the same broken cache kept getting restored on the next run. Neither workflow set an explicit `cache-name`, so bumping it forces a clean cache key and breaks the loop.

With the cache fixed, `ADRIAviz`'s Makie-backend tests could run for the first time in a while and surfaced three more CI-blocking (not logic) bugs in `ADRIAviz/test/spatial_decorations.jl`, all now fixed in this PR:
- `using GLMakie` -- GLMakie needs an OpenGL context, unavailable on GitHub Actions runners. Swapped to `CairoMakie`, matching every other test file in the package (`annotated_outcomes.jl`, `taxa_dynamics.jl`).
- Loading `CairoMakie` alone wasn't enough to trigger `ADRIAvizMakieExt` -- it requires `Makie` + `GeoMakie` + `GraphMakie` together per `Project.toml`'s `[extensions]`. Added `GeoMakie, GraphMakie` to the `using` statement.
- `using ADRIAvizMakieExt: _figure_size, _adaptive_gap` -- package extensions aren't resolvable via a bare `using ExtName`; switched to `Base.get_extension(ADRIAviz, :ADRIAvizMakieExt)`.

With all four fixed, `test-makie`/`test-plotly` now execute the full suite (180+ tests passing, up from erroring out at ~140).

**Not fixed here (separate, pre-existing bug):** `ADRIAviz/test/spatial_utils.jl` has real logic-test failures (Haversine distance, scale-bar length, location ID resolution, coastal-places constant, `MapDecorationData` struct) unrelated to CI infrastructure. Worth a follow-up issue.

## Test plan

- [x] `ADRIAanalysis Tests` (`test`) passes on this branch's CI
- [x] `ADRIAviz Tests` `test-makie`/`test-plotly` reach and run the actual test suite (previously failed at environment setup)
- [x] Follow-up issue for the `spatial_utils.jl` logic failures