### PR TITLE
fix(ADRIAviz): correct _haversine_km unit/order bug and _nice_length range

### DIFF
--- a/ADRIAviz/ext/ADRIAvizMakieExt/viz/spatial.jl
+++ b/ADRIAviz/ext/ADRIAvizMakieExt/viz/spatial.jl
@@ -179,7 +179,7 @@ function _figure_size(n_rows::Int, n_cols::Int)::Tuple{Int,Int}
     if n_rows == 1 && n_cols == 1
         return (1000, 800)
     end
-    panel_w, panel_h, gap = 600, 400, 20
+    panel_w, panel_h, gap = 600, 500, 20
     width = n_cols * panel_w + (n_cols - 1) * gap
     height = n_rows * panel_h + (n_rows - 1) * gap
     return (width, height)

--- a/ADRIAviz/src/viz/spatial_utils.jl
+++ b/ADRIAviz/src/viz/spatial_utils.jl
@@ -80,17 +80,19 @@ end
 Great-circle distance between two lon/lat points (in degrees) in kilometres.
 """
 function _haversine_km(lon1::Real, lat1::Real, lon2::Real, lat2::Real)::Float64
-    haversine([deg2rad(lat1), deg2rad(lon1)], [deg2rad(lat2), deg2rad(lon2)])
+    # Distances.jl's haversine takes plain degrees (it uses sind/cosd internally)
+    # in (lon, lat) order, and returns metres by default -- not km.
+    haversine([lon1, lat1], [lon2, lat2], 6371.0)
 end
 
 """
     _nice_length(x::Real)::Int
 
 Round a distance down to a cartographically 'nice' scale-bar length (km).
-Capped at 250km for large-scale maps to ensure legibility.
+Capped at 1000km for large-scale maps to ensure legibility.
 """
 function _nice_length(x::Real)::Int
-    options = [1, 2, 5, 10, 20, 25, 50, 100, 200, 250]
+    options = [1, 2, 5, 10, 20, 25, 50, 100, 200, 500, 1000]
     idx = findlast(<=(x), options)
     return options[isnothing(idx) ? 1 : idx]
 end
@@ -174,9 +176,7 @@ function _get_populated_places(
         if pop >= min_population
             # Check distance to map extent
             d = minimum(
-                haversine(
-                    [deg2rad(lat), deg2rad(lon)], [deg2rad(lats[i]), deg2rad(lons[i])]
-                )
+                _haversine_km(lon, lat, lons[i], lats[i])
                 for i in eachindex(lons)
             )
             if d <= max_km

--- a/ADRIAviz/test/spatial_decorations.jl
+++ b/ADRIAviz/test/spatial_decorations.jl
@@ -35,7 +35,9 @@ using ADRIAviz.viz
     end
 
     @testset "Near-pole extent warns" begin
-        @test_logs (:warn,) validate_extent((0.0, 10.0, 80.0, 89.0))
+        # mean latitude must exceed the 85 deg threshold in validate_extent
+        # for the warning to fire; (80, 89) has a mean of 84.5 and never warns.
+        @test_logs (:warn,) validate_extent((0.0, 10.0, 82.0, 89.0))
     end
 end
 

--- a/ADRIAviz/test/spatial_utils.jl
+++ b/ADRIAviz/test/spatial_utils.jl
@@ -32,7 +32,7 @@ using ADRIAviz.viz
         # Antipodal points (opposite sides of Earth, ~20015 km)
         # Use points not exactly at poles to avoid singularities
         d_antipodal = _haversine_km(0.0, 45.0, 180.0, -45.0)
-        @test isapprox(d_antipodal, 14142; atol=100)  # Great circle distance
+        @test isapprox(d_antipodal, 20015; atol=100)  # Great circle distance
     end
 
     @testset "Nice Scale Bar Length" begin
@@ -72,7 +72,7 @@ using ADRIAviz.viz
             reef_siteid=[10, 20, 30],
             site_id=[1, 2, 3]
         )
-        @test_logs (:warn,) ids_ambig = _get_site_ids(df_ambiguous)
+        ids_ambig = @test_logs (:warn,) _get_site_ids(df_ambiguous)
         @test length(ids_ambig) == 3
 
         # Test fallback to row indices when no site_id columns present
@@ -83,7 +83,7 @@ using ADRIAviz.viz
 
     @testset "MapDecorationData Structure" begin
         # Test that MapDecorationData can be created and accessed
-        places = [(name="Test", lon=150.0, lat=-20.0)]
+        places = [(name="Test", lon=150.0, lat=-20.0, population=1000)]
         deco = MapDecorationData(
             places, 50, 0.45, 145.0, -25.0,
             [145.0, 155.0], [-25.0, -15.0]
@@ -104,12 +104,13 @@ using ADRIAviz.viz
         places = ADRIAviz.viz.GBR_COASTAL_PLACES
         @test length(places) > 0
 
-        # Each entry should be a 3-tuple of (name, lon, lat)
+        # Each entry should be a 4-tuple of (name, lon, lat, population)
         for place in places
-            @test length(place) == 3
+            @test length(place) == 4
             @test isa(place[1], String)  # name
             @test isa(place[2], Number)  # lon
             @test isa(place[3], Number)  # lat
+            @test isa(place[4], Number)  # population
 
             # Check reasonable coordinate ranges for Australia
             @test place[2] > 140 && place[2] < 155  # Longitude


### PR DESCRIPTION
## Summary

Follow-up to #1157, which fixed the CI infrastructure that was preventing `ADRIAviz`'s test suite from ever actually running. With that fixed, these real logic bugs surfaced:

- **`_haversine_km`** fed `deg2rad`'d radians into `Distances.jl`'s `haversine`, which internally uses `sind`/`cosd` (i.e. expects plain degrees), with `lon`/`lat` arguments swapped relative to `Distances.jl`'s `(lon, lat)` convention, and no explicit radius (so it defaulted to metres, not km). I verified against the installed `Distances.jl` source directly. The error isn't a clean scale factor -- it varies with the actual angular separation between points -- so e.g. a real city 57km from a reef centroid was being excluded from map "nearby places" labels while the filter's behaviour for other distances was effectively arbitrary. Both the scale bar and coastal-place-proximity features (`show_scale_bar`, `show_coastal_places`) default to `true` in `ADRIA.viz.map`, so this affected the default map rendering path in both the Makie and Plotly backends.
- **`_get_populated_places`** had an inline copy of the exact same broken pattern instead of calling `_haversine_km` -- replaced with a call to the (now fixed) shared helper, removing the duplication.
- **`_nice_length`**'s "nice number" progression was missing `500`/`1000` and had a spurious `250`, capping scale bars at 250km instead of scaling up to 1000km for large-extent maps.
- **`_figure_size`** (Makie extension) hardcoded a per-panel height of `400`px, contradicting its own docstring ("600 wide x 500 tall per panel") -- multi-panel Makie figures were rendering shorter than intended. Fixed to `500`.

Also fixes six stale/incorrect test assertions that were masking the above (`test/spatial_utils.jl` unless noted):
- A macro-hygiene bug (`@test_logs (:warn,) ids_ambig = ...` doesn't leak `ids_ambig` to the enclosing scope) causing `UndefVarError`.
- A mock `CoastalPlace` tuple missing the required `population` field, causing a `MethodError`.
- An assertion expecting 3-tuples for `GBR_COASTAL_PLACES` entries that are actually 4-tuples `(name, lon, lat, population)` per the constant's own docstring.
- An antipodal-distance assertion (`14142`) that contradicted its own comment (`~20015 km`) -- 20015 km is correct (half of Earth's circumference, `pi * 6371`).
- `test/spatial_decorations.jl`'s "Near-pole extent warns" test used extent `(0.0, 10.0, 80.0, 89.0)`, whose mean latitude (84.5) never actually exceeds `validate_extent`'s `> 85` warning threshold -- bumped to `(0.0, 10.0, 82.0, 89.0)` (mean 85.5).
- `_figure_size`'s own test assertions (`h2 == 500`, `h3 == 2*500+20`) were correct all along and caught the panel-height bug once they could actually run.

## Test plan

- [x] Full `ADRIAviz` test suite passes locally with `ADRIA_RUN_VIZ_TESTS=1` via `Pkg.test()`: 233/233
- [ ] CI green on `test-makie`/`test-plotly`