### PR TITLE
Add per-intervention revisit cadence for location deployment

### DIFF
--- a/ADRIA/src/decision/strategies/PeriodicStrategy.jl
+++ b/ADRIA/src/decision/strategies/PeriodicStrategy.jl
@@ -3,12 +3,32 @@
 
 Deploys at regular intervals starting from a specified year.
 
+Locations are filtered by `revisit_cadence`: a location deployed to within the last
+`revisit_cadence` timesteps is excluded from candidates, forcing spatial spread of
+deployments. If cadence filtering drops the eligible candidate count below
+`min_locations`, the pool is backfilled with the excluded locations that were deployed
+to longest ago (soonest to become eligible again), breaking ties by stable-sort order
+(i.e. `target_locations`'s original order), until `min_locations` is met or all target
+locations are included.
+
+Note: backfill operates on the aggregate `target_locations` pool, not per deployment
+share. A backfilled location — one still within its own cadence window — is included in
+the returned candidate list and so is legitimately eligible for selection by *any* share
+that contains it, not just a share short of its own `min_iv_locations`. This is the
+intended effect of aggregate-pool backfill, not a bug. Because `min_iv_locations`/
+`mc_min_iv_locations` is enforced per deployment share downstream (in `scenario.jl`, for
+seed/mc only — fog has no per-share loop), aggregate backfill does not guarantee any
+individual share clears its own minimum; that is a pre-existing limitation of
+`min_iv_locations` in the multi-share case, unrelated to and not worsened by cadence.
+
 # Fields
 - `target_locations::Vector{String}`: Optional list of location IDs to target
 - `start_year::Int64`: Year to begin deployments (relative to simulation start)
 - `duration::Int64`: Number of years to deploy for
 - `frequency::Int64`: Frequency (in years) between deployments (0 = deploy once)
 - `decision_years::Vector{Bool}`: Precomputed vector indicating deployment years
+- `revisit_cadence::Int64`: Minimum timesteps before a location can be re-selected (0 = no restriction)
+- `min_locations::Int64`: Minimum candidate locations to return; triggers backfill if cadence filtering drops below this
 """
 struct PeriodicStrategy <: DecisionStrategy
     target_locations::Vector{String}
@@ -16,16 +36,23 @@ struct PeriodicStrategy <: DecisionStrategy
     duration::Int64
     frequency::Union{Float64,Int64}  # in years
     decision_years::Vector{Bool}  # precomputed decision years
+    revisit_cadence::Int64
+    min_locations::Int64
 
     function PeriodicStrategy(
         target_locations::Vector{String},
         start_year::Int64,
         duration::Int64,
         frequency::Union{Float64,Int64},
-        timeframe::Int64
+        timeframe::Int64,
+        revisit_cadence::Int64,
+        min_locations::Int64
     )
         decision_years = decision_frequency(start_year, timeframe, duration, frequency)
-        return new(target_locations, start_year, duration, frequency, decision_years)
+        return new(
+            target_locations, start_year, duration, frequency, decision_years,
+            revisit_cadence, min_locations
+        )
     end
 end
 
@@ -65,27 +92,55 @@ end
         state::NamedTuple
     )::Vector{String}
 
-Return all target locations for periodic deployment strategy.
+Return target locations for periodic deployment strategy, filtered by revisit cadence.
 
 Periodic strategies deploy to all specified target locations whenever it is a decision
-year, without filtering based on environmental conditions.
+year, subject to `revisit_cadence`: locations deployed to within the last
+`revisit_cadence` timesteps are excluded, unless doing so would drop the candidate count
+below `min_locations`, in which case the pool is backfilled with the longest-idle
+excluded locations (see struct docstring).
 
 # Arguments
-- `strategy`: PeriodicStrategy containing target locations
+- `strategy`: PeriodicStrategy containing target locations, revisit_cadence and min_locations
 - `timestep`: Current simulation timestep
-- `_`: Unused `state` argument to maintain compatibility
+- `state`: NamedTuple with `last_deployment::Vector{Int64}`, aligned to
+  `unique(strategy.target_locations)`'s own order (see `build_state`)
 
 # Returns
-Vector of location IDs eligible for deployment (all target locations)
+Vector of location IDs eligible for deployment
 """
 function filter_candidate_locations(
     strategy::PeriodicStrategy,
     timestep::Int64,
-    _::Union{Nothing,NamedTuple}
+    state::Union{Nothing,NamedTuple}
 )::Vector{String}
     if !is_decision_year(strategy, timestep)
         return String[]
     end
 
-    return strategy.target_locations
+    targets = unique(strategy.target_locations)
+
+    if strategy.revisit_cadence <= 0 || isnothing(state)
+        return targets
+    end
+
+    eligible = revisit_cadence_mask(
+        state.last_deployment, timestep, strategy.revisit_cadence
+    )
+
+    if count(eligible) >= strategy.min_locations
+        return targets[eligible]
+    end
+
+    # Backfill with excluded locations, longest-idle first (stable sort preserves
+    # `targets`'s original order as the tie-break).
+    excluded_idx = findall(.!eligible)
+    idle_time = timestep .- state.last_deployment[excluded_idx]
+    order = sortperm(idle_time; rev=true)
+    backfill_idx = excluded_idx[order]
+
+    n_needed = strategy.min_locations - count(eligible)
+    n_backfill = min(n_needed, length(backfill_idx))
+
+    return vcat(targets[eligible], targets[backfill_idx[1:n_backfill]])
 end

--- a/ADRIA/src/decision/strategies/ReactiveStrategy.jl
+++ b/ADRIA/src/decision/strategies/ReactiveStrategy.jl
@@ -15,7 +15,7 @@ Evaluate conditions every timestep.
 - `loss_threshold::Float64`: Deploy when proportional loss > this (e.g., 0.30 = 30% loss)
 - `min_cover_remaining::Float64`: Don't deploy if cover below this (location unviable)
 - `response_delay::Int64`: Timesteps to wait after trigger before deployment
-- `cooldown_period::Int64`: Timesteps before location becomes eligible again (0 = no cooldown)
+- `revisit_cadence::Int64`: Timesteps before location becomes eligible again (0 = no restriction)
 """
 struct ReactiveStrategy <: DecisionStrategy
     target_locations::Vector{String}
@@ -25,7 +25,7 @@ struct ReactiveStrategy <: DecisionStrategy
     loss_threshold::Float64
     min_cover_remaining::Float64
     response_delay::Int64
-    cooldown_period::Int64
+    revisit_cadence::Int64
 end
 
 """
@@ -64,7 +64,7 @@ Returns locations where EITHER condition is met:
 1. Current cover is below absolute_threshold AND above min_cover_remaining
 2. Recent cover loss exceeds loss_threshold AND current cover above min_cover_remaining
 
-If cooldown_period > 0, excludes locations deployed within the cooldown period.
+If revisit_cadence > 0, excludes locations deployed within the cadence period.
 
 # Arguments
 - `strategy`: ReactiveStrategy with threshold parameters and target locations
@@ -72,15 +72,18 @@ If cooldown_period > 0, excludes locations deployed within the cooldown period.
 - `state`: NamedTuple containing data for target locations only:
     - `current_cover::Vector{Float64}`: Current coral cover at each target location
     - `recent_cover_losses::Matrix{Float64}`: Cover losses [timestep × target_location]
-    - `last_deployment::Vector{Int64}`: Timestep of most recent deployment (0 if never), only required if cooldown_period > 0
+    - `last_deployment::Vector{Int64}`: Timestep of most recent deployment (0 if never), only required if revisit_cadence > 0
 
 # Returns
 Vector of location IDs meeting deployment criteria (subset of target locations)
 
 # Notes
 Loss threshold check only occurs after response_delay timesteps have elapsed.
-When cooldown_period = 0, behaves as pure reactive strategy (no spatial spreading).
-When cooldown_period > 0, prevents repeated deployments to same locations.
+When revisit_cadence = 0, behaves as pure reactive strategy (no spatial spreading).
+When revisit_cadence > 0, prevents repeated deployments to same locations. Unlike
+`PeriodicStrategy`, there is no backfill here — a reactive strategy should only ever
+act on locations meeting its trigger conditions; cadence purely restricts that set
+further.
 """
 function filter_candidate_locations(
     strategy::ReactiveStrategy,
@@ -91,6 +94,8 @@ function filter_candidate_locations(
     if !is_decision_year(strategy, timestep)
         return String[]
     end
+
+    targets = unique(strategy.target_locations)
 
     # Absolute threshold condition
     absolute_mask = (
@@ -111,17 +116,16 @@ function filter_candidate_locations(
     # Combine reactive criteria with OR logic
     reactive_mask = absolute_mask .| loss_mask
 
-    # Apply cooldown filter if cooldown_period > 0
-    if strategy.cooldown_period > 0
-        time_since_deployment = timestep .- state.last_deployment
-        not_on_cooldown =
-            (time_since_deployment .>= strategy.cooldown_period) .|
-            (state.last_deployment .== 0)  # Never deployed
+    # Apply cadence filter if revisit_cadence > 0
+    if strategy.revisit_cadence > 0
+        not_on_cooldown = revisit_cadence_mask(
+            state.last_deployment, timestep, strategy.revisit_cadence
+        )
         candidate_mask = reactive_mask .& not_on_cooldown
     else
-        # No cooldown - pure reactive
+        # No cadence restriction - pure reactive
         candidate_mask = reactive_mask
     end
 
-    return strategy.target_locations[candidate_mask]
+    return targets[candidate_mask]
 end

--- a/ADRIA/src/decision/strategies/strategies.jl
+++ b/ADRIA/src/decision/strategies/strategies.jl
@@ -59,10 +59,33 @@ function is_periodic(strategy_idx::AbstractVector{T})::BitVector where {T<:Real}
     return is_periodic.(strategy_idx)
 end
 
+"""
+    revisit_cadence_mask(last_deployment, timestep, cadence)::BitVector
+
+Locations are eligible (`true`) when never deployed to, or when at least `cadence`
+timesteps have elapsed since their last deployment. `cadence <= 0` disables the
+restriction entirely (all locations eligible).
+"""
+function revisit_cadence_mask(last_deployment, timestep, cadence)::BitVector
+    cadence <= 0 && return trues(length(last_deployment))
+    return (timestep .- last_deployment .>= cadence) .| (last_deployment .== 0)
+end
+
+"""
+    build_state(domain, strategy, states)
+
+Build per-target-location state for `strategy`, aligned to `unique(strategy.target_locations)`'s
+own order (not `domain.loc_ids`'s order). This matters because `filter_candidate_locations`
+indexes the returned state's arrays against the deduplicated target-location list directly
+(see each strategy's `filter_candidate_locations`); indexing state computed in `domain.loc_ids`
+order against a target list in a different order would silently return the wrong locations
+whenever `strategy.target_locations` is not itself ordered consistently with `domain.loc_ids`
+(e.g. a multi-share config listing locations out of domain order).
+"""
 function build_state(domain, strategy, states)
-    targets = strategy.target_locations
-    mask = in.(domain.loc_ids, Ref(Set{String}(targets)))
-    return strategy_status(strategy, states, mask)
+    targets = unique(strategy.target_locations)
+    idx = indexin(targets, domain.loc_ids)
+    return strategy_status(strategy, states, idx)
 end
 
 function strategy_status(::DecisionStrategy, states, idx)
@@ -73,6 +96,14 @@ function strategy_status(::DecisionStrategy, states, idx)
 end
 
 function strategy_status(::ReactiveStrategy, states, idx)
+    return (
+        current_cover=@view(states.current_cover[idx]),
+        recent_cover_losses=@view(first(states.recent_cover_losses)[idx]),
+        last_deployment=@view(states.last_deployment[idx])
+    )
+end
+
+function strategy_status(::PeriodicStrategy, states, idx)
     return (
         current_cover=@view(states.current_cover[idx]),
         recent_cover_losses=@view(first(states.recent_cover_losses)[idx]),

--- a/ADRIA/src/decision/strategies/strategy_builder.jl
+++ b/ADRIA/src/decision/strategies/strategy_builder.jl
@@ -78,7 +78,10 @@ function build_strategy_params(prefix::String, params::YAXArray, domain::Domain,
         reactive_loss_threshold=Float64(params[At("reactive_loss_threshold")]),
         reactive_min_cover_remaining=Float64(params[At("reactive_min_cover_remaining")]),
         reactive_response_delay=Int64(params[At("reactive_response_delay")]),
-        reactive_cooldown_period=Int64(params[At("reactive_cooldown_period")])
+        revisit_cadence=Int64(params[At("$(prefix)_revisit_cadence")]),
+        min_locations=Int64(
+            params[At(prefix == "mc" ? "mc_min_iv_locations" : "min_iv_locations")]
+        )
     )
 end
 
@@ -90,7 +93,9 @@ function build_strategy(
         params.iv_year_start,
         params.iv_years,
         params.iv_deployment_freq,
-        params.timesteps
+        params.timesteps,
+        params.revisit_cadence,
+        params.min_locations
     )
 end
 function build_strategy(
@@ -104,6 +109,6 @@ function build_strategy(
         params.reactive_loss_threshold,
         params.reactive_min_cover_remaining,
         params.reactive_response_delay,
-        params.reactive_cooldown_period
+        params.revisit_cadence
     )
 end

--- a/ADRIA/src/interventions/Interventions.jl
+++ b/ADRIA/src/interventions/Interventions.jl
@@ -169,6 +169,14 @@ Base.@kwdef struct Intervention <: EcoModel
         name="Selection Frequency (Seed)",
         description="Frequency of seeding deployments (0 deploys once)."
     )
+    seed_revisit_cadence::Param = Factor(
+        0;
+        ptype="ordered categorical",
+        dist=DiscreteUniform,
+        dist_params=(0.0, 15.0),
+        name="Revisit Cadence (Seed)",
+        description="Minimum number of years before a location can be re-selected for seed deployment (0 = no restriction)."
+    )
     fog_deployment_freq::Param = Factor(
         5;
         ptype="ordered categorical",
@@ -176,6 +184,14 @@ Base.@kwdef struct Intervention <: EcoModel
         dist_params=(0.0, 15.0),
         name="Selection Frequency (Fog)",
         description="Frequency of fogging deployments (0 deploys once)."
+    )
+    fog_revisit_cadence::Param = Factor(
+        0;
+        ptype="ordered categorical",
+        dist=DiscreteUniform,
+        dist_params=(0.0, 15.0),
+        name="Revisit Cadence (Fog)",
+        description="Minimum number of years before a location can be re-selected for fog deployment (0 = no restriction)."
     )
     shade_deployment_freq::Param = Factor(
         1;
@@ -192,6 +208,14 @@ Base.@kwdef struct Intervention <: EcoModel
         dist_params=(0.0, 15.0),
         name="Deployment Frequency (Moving corals)",
         description="Frequency of moving corals deployments."
+    )
+    mc_revisit_cadence::Param = Factor(
+        0;
+        ptype="ordered categorical",
+        dist=DiscreteUniform,
+        dist_params=(0.0, 15.0),
+        name="Revisit Cadence (Moving corals)",
+        description="Minimum number of years before a location can be re-selected for mc deployment (0 = no restriction)."
     )
     seed_year_start::Param = Factor(
         2;
@@ -314,14 +338,6 @@ Base.@kwdef struct Intervention <: EcoModel
         dist_params=(0.0, 5.0),
         name="Response Delay",
         description="Timesteps to wait after trigger before deployment (for reactive strategy)"
-    )
-    reactive_cooldown_period::Param = Factor(
-        4.0;
-        ptype="ordered categorical",
-        dist=DiscreteUniform,
-        dist_params=(0.0, 10.0),
-        name="Reactive Cooldown Period",
-        description="Timesteps before location becomes eligible again; 0=no cooldown (for reactive strategy)"
     )
 end
 

--- a/ADRIA/src/io/sampling/sampling_dependencies.jl
+++ b/ADRIA/src/io/sampling/sampling_dependencies.jl
@@ -162,7 +162,7 @@ const _GROUP_MEMBERS = Dict{Symbol,Vector{Symbol}}(
         # excluded here — they belong exclusively to :strategy_group (see above).
         :reactive_absolute_threshold, :reactive_loss_threshold,
         :reactive_min_cover_remaining, :reactive_response_delay,
-        :reactive_cooldown_period
+        :seed_revisit_cadence, :fog_revisit_cadence, :mc_revisit_cadence
     ],
     :criteria_weights => [
         :seed_heat_stress, :seed_wave_stress, :seed_in_connectivity,

--- a/ADRIA/src/io/sampling/sampling_transforms.jl
+++ b/ADRIA/src/io/sampling/sampling_transforms.jl
@@ -207,8 +207,7 @@ const _TRANSFORM_GROUP_EXTRA_MEMBERS = Dict{Symbol,Vector{Symbol}}(
         :reactive_absolute_threshold,
         :reactive_loss_threshold,
         :reactive_min_cover_remaining,
-        :reactive_response_delay,
-        :reactive_cooldown_period
+        :reactive_response_delay
     ]
 )
 
@@ -423,8 +422,17 @@ Ordering is load-bearing:
 3. `gamma_to_dirichlet` on weight columns — must precede the zeroing rules
    below, which depend on the reparameterized values.
 4. `_apply_transform_dependencies!` — single-parent + gate zeroing rules.
-5. `_apply_transform_calls!` — mcda_normalize gates.
-6. `seed_wave_stress` zeroing — must run LAST: mcda_normalize normalizes seed
+5. Floor each `*_revisit_cadence` column at its paired `*_deployment_freq`
+   column (`max(cadence, freq)`) — must run AFTER step 4, since step 4 is what
+   settles each `*_deployment_freq` column to either its real sampled value or
+   `0.0` (via three different mechanisms across seed/fog/mc — the
+   `any_seeding` gate rule, and single-parent `_TRANSFORM_DEPENDENCIES` rows
+   for fog/mc — all applied inside step 4). Without this floor, sensitivity
+   analyses over the raw cadence factor would have a large inert region
+   whenever `deployment_freq` already exceeds it (cadence has zero effect on
+   model behaviour in that region).
+6. `_apply_transform_calls!` — mcda_normalize gates.
+7. `seed_wave_stress` zeroing — must run LAST: mcda_normalize normalizes seed
    weights (including seed_wave_stress) to sum=1 first; zeroing
    seed_wave_stress afterward deliberately leaves the remaining 7 weights
    summing to <1 for wave_scenario==0 rows, matching production behaviour.
@@ -456,6 +464,15 @@ function _apply_transforms!(spec::DataFrame, samples::DataFrame)::DataFrame
     end
 
     masks = _apply_transform_dependencies!(samples)
+
+    # Must run after _apply_transform_dependencies! (see docstring above, point 5).
+    for prefix in ("seed", "fog", "mc")
+        freq_col = Symbol("$(prefix)_deployment_freq")
+        cadence_col = Symbol("$(prefix)_revisit_cadence")
+        (freq_col in sample_cols && cadence_col in sample_cols) || continue
+        samples[:, cadence_col] .= max.(samples[:, cadence_col], samples[:, freq_col])
+    end
+
     _apply_transform_calls!(samples, masks)
 
     # Must run LAST (see docstring above, point 5). seed_wave_stress is a

--- a/ADRIA/src/scenario.jl
+++ b/ADRIA/src/scenario.jl
@@ -1455,7 +1455,10 @@ function run_model(
                     log_val = is_guided ? (1:length(selected_fog_ranks)) : 1.0
                     log_location_ranks[tstep, At(selected_fog_ranks), At(:fog)] .=
                         log_val
-                    last_fog_deployment[candidate_loc_indices] .= tstep
+                    selected_fog_loc_idx = findall(
+                        in.(domain.loc_ids, Ref(selected_fog_ranks))
+                    )
+                    last_fog_deployment[selected_fog_loc_idx] .= tstep
                 end
             end
         end
@@ -1542,7 +1545,10 @@ function run_model(
                         log_val = is_guided ? (1:length(selected_mc_ranks)) : 1.0
                         log_location_ranks[tstep, At(selected_mc_ranks), At(:mc)] .=
                             log_val
-                        last_mc_deployment[share_candidate_loc_idx] .= tstep
+                        selected_mc_loc_idx = findall(
+                            in.(domain.loc_ids, Ref(selected_mc_ranks))
+                        )
+                        last_mc_deployment[selected_mc_loc_idx] .= tstep
                     end
 
                     # Check if locations are selected
@@ -1728,7 +1734,10 @@ function run_model(
                         log_val = is_guided ? (1:length(selected_seed_ranks)) : 1.0
                         log_location_ranks[tstep, At(selected_seed_ranks), At(:seed)] .=
                             log_val
-                        last_seed_deployment[share_candidate_loc_idx] .= tstep
+                        selected_seed_loc_idx = findall(
+                            in.(domain.loc_ids, Ref(selected_seed_ranks))
+                        )
+                        last_seed_deployment[selected_seed_loc_idx] .= tstep
                     end
 
                     # Check if locations are selected (can reuse previous selection)

--- a/ADRIA/test/Project.toml
+++ b/ADRIA/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ADRIA = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/ADRIA/test/decisions/revisit_cadence.jl
+++ b/ADRIA/test/decisions/revisit_cadence.jl
@@ -1,0 +1,386 @@
+using Test
+using ADRIA
+using ADRIA.decision:
+    build_state,
+    strategy_status,
+    revisit_cadence_mask,
+    filter_candidate_locations,
+    PeriodicStrategy,
+    ReactiveStrategy
+using ADRIA: At
+
+using DataStructures: CircularBuffer
+
+if !@isdefined(ADRIA_DIR)
+    const ADRIA_DIR = pkgdir(ADRIA)
+    const TEST_DOMAIN_PATH = joinpath(ADRIA_DIR, "test", "data", "Test_domain")
+end
+
+if !@isdefined(ADRIA_DOM_45)
+    const ADRIA_DOM_45 = ADRIA.load_domain(TEST_DOMAIN_PATH, 45)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# revisit_cadence_mask
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "revisit_cadence_mask" begin
+    last_deployment = [10, 8, 0, 5]
+    timestep = 10
+
+    @testset "cadence <= 0 disables restriction" begin
+        @test all(revisit_cadence_mask(last_deployment, timestep, 0)) ||
+            "cadence == 0 should mark all locations eligible"
+        @test all(revisit_cadence_mask(last_deployment, timestep, -1)) ||
+            "negative cadence should mark all locations eligible"
+    end
+
+    @testset "eligibility threshold" begin
+        # timestep - last_deployment: [0, 2, 10, 5]; last_deployment==0 -> always eligible
+        mask = revisit_cadence_mask(last_deployment, timestep, 3)
+        @test mask == BitVector([false, false, true, true]) ||
+            "Expected only the never-deployed and long-idle locations to be eligible"
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_state ordering fix (Verification item 1)
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "build_state ordering" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    loc_ids = dom.loc_ids
+    n = length(loc_ids)
+
+    # Deliberately reorder a subset of loc_ids so the relative order differs from
+    # domain.loc_ids's own order (interleaved, not a contiguous first/second half).
+    reorder_idx = [5, 1, 4, 2, 3]
+    target_locations = loc_ids[reorder_idx]
+
+    # States keyed by domain.loc_ids's own order: value at position i identifies
+    # location i unambiguously (its 1-based index in loc_ids).
+    current_cover = Float64.(1:n)
+    recent_cover_losses = CircularBuffer{Vector{Float64}}(1)
+    push!(recent_cover_losses, Float64.(10 .* (1:n)))
+    last_deployment = collect(100 .* (1:n))
+
+    states = (
+        current_cover=current_cover,
+        recent_cover_losses=recent_cover_losses,
+        last_deployment=last_deployment
+    )
+
+    # Expected: for each location in unique(target_locations) (in its own order),
+    # the state values must correspond to THAT location's index in domain.loc_ids,
+    # not the position within target_locations/domain.loc_ids traversal order.
+    expected_domain_idx = [findfirst(==(loc), loc_ids) for loc in unique(target_locations)]
+
+    @testset "ReactiveStrategy" begin
+        strategy = ReactiveStrategy(target_locations, 0, 75, 0.2, 0.3, 0.0, 0, 0)
+        state = build_state(dom, strategy, states)
+
+        @test collect(state.current_cover) == Float64.(expected_domain_idx) ||
+            "current_cover not aligned to target_locations' own order for ReactiveStrategy"
+        @test collect(state.recent_cover_losses) == Float64.(10 .* expected_domain_idx) ||
+            "recent_cover_losses not aligned to target_locations' own order for ReactiveStrategy"
+        @test collect(state.last_deployment) == 100 .* expected_domain_idx ||
+            "last_deployment not aligned to target_locations' own order for ReactiveStrategy"
+
+        # Cross-check actual IDs: the location with the highest current_cover in the
+        # returned state must be the target with the highest index in domain.loc_ids.
+        max_pos = argmax(state.current_cover)
+        expected_loc = unique(target_locations)[argmax(expected_domain_idx)]
+        @test unique(target_locations)[max_pos] == expected_loc ||
+            "Wrong location ID returned at the max-cover position"
+    end
+
+    @testset "PeriodicStrategy" begin
+        strategy = PeriodicStrategy(target_locations, 0, 75, 1, 75, 0, 0)
+        state = build_state(dom, strategy, states)
+
+        @test collect(state.current_cover) == Float64.(expected_domain_idx) ||
+            "current_cover not aligned to target_locations' own order for PeriodicStrategy"
+        @test collect(state.recent_cover_losses) == Float64.(10 .* expected_domain_idx) ||
+            "recent_cover_losses not aligned to target_locations' own order for PeriodicStrategy"
+        @test collect(state.last_deployment) == 100 .* expected_domain_idx ||
+            "last_deployment not aligned to target_locations' own order for PeriodicStrategy"
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# filter_candidate_locations — PeriodicStrategy (Verification item 2)
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "filter_candidate_locations — PeriodicStrategy" begin
+    targets = ["A", "B", "C", "D", "E"]
+
+    @testset "cadence exclusion + backfill with stable tie-break" begin
+        timestep = 10
+        cadence = 3
+        min_locations = 4
+
+        # A, B, C deployed at t=10 (0 idle); D deployed at t=8 (idle=2); E never (idle=inf)
+        last_deployment = [10, 10, 10, 8, 0]
+
+        strategy = PeriodicStrategy(targets, 0, 75, 1, 75, cadence, min_locations)
+        state = (last_deployment=last_deployment,)
+
+        result = filter_candidate_locations(strategy, timestep, state)
+
+        # Only E is eligible outright (count=1 < min_locations=4). Backfill needed: 3 more.
+        # Excluded = [A,B,C,D], idle times = [0,0,0,2]. Sorted by idle desc, stable
+        # tie-break preserves original order among ties: D (idle=2) first, then A,B,C
+        # (tied at idle=0, in original order). Backfill picks the first 3: D, A, B.
+        @test result == ["E", "D", "A", "B"] ||
+            "Backfill did not select longest-idle locations with stable tie-break " *
+              "(got $result)"
+    end
+
+    @testset "no backfill needed when cadence-eligible count already meets minimum" begin
+        timestep = 10
+        cadence = 3
+        min_locations = 1
+
+        last_deployment = [10, 10, 10, 8, 0]
+        strategy = PeriodicStrategy(targets, 0, 75, 1, 75, cadence, min_locations)
+        state = (last_deployment=last_deployment,)
+
+        result = filter_candidate_locations(strategy, timestep, state)
+        @test result == ["E"] ||
+            "Expected only cadence-eligible locations when count meets min_locations " *
+              "(got $result)"
+    end
+
+    @testset "revisit_cadence == 0 is a no-op (no filtering)" begin
+        timestep = 10
+        min_locations = 100  # deliberately impossible, to prove cadence short-circuits first
+        last_deployment = [10, 10, 10, 10, 10]  # would all be excluded under any cadence > 0
+
+        strategy = PeriodicStrategy(targets, 0, 75, 1, 75, 0, min_locations)
+        state = (last_deployment=last_deployment,)
+
+        result = filter_candidate_locations(strategy, timestep, state)
+        @test result == targets ||
+            "revisit_cadence == 0 should return all target locations unfiltered " *
+              "(got $result)"
+    end
+
+    @testset "nothing state is also a no-op" begin
+        timestep = 10
+        strategy = PeriodicStrategy(targets, 0, 75, 1, 75, 5, 3)
+        result = filter_candidate_locations(strategy, timestep, nothing)
+        @test result == targets || "nothing state should return all target locations"
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# filter_candidate_locations — ReactiveStrategy (Verification item 2)
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "filter_candidate_locations — ReactiveStrategy" begin
+    targets = ["A", "B", "C", "D", "E"]
+
+    @testset "cadence excludes locations that would otherwise pass reactive thresholds, no backfill" begin
+        timestep = 10
+        cadence = 3
+        absolute_threshold = 0.2
+        loss_threshold = 0.3
+        min_cover_remaining = 0.0
+
+        # All locations pass the absolute-threshold reactive trigger.
+        current_cover = fill(0.1, 5)
+        recent_cover_losses = zeros(5)
+
+        # Same cadence setup as the periodic test: only E (never deployed) is eligible.
+        last_deployment = [10, 10, 10, 8, 0]
+
+        strategy = ReactiveStrategy(
+            targets, 0, 75, absolute_threshold, loss_threshold,
+            min_cover_remaining, 0, cadence
+        )
+        state = (
+            current_cover=current_cover,
+            recent_cover_losses=recent_cover_losses,
+            last_deployment=last_deployment
+        )
+
+        result = filter_candidate_locations(strategy, timestep, state)
+
+        # Reactive strategy does NOT backfill: even though only 1 of 5 locations is
+        # eligible, the result must stay at that reduced count.
+        @test result == ["E"] ||
+            "Cadence should exclude on-cooldown locations without backfill " *
+              "(got $result); NO_BACKFILL_BUG if a topped-up count is observed"
+        @test length(result) == 1 ||
+            "ReactiveStrategy must not backfill when cadence drops candidates below " *
+              "any threshold (got $(length(result)) candidates)"
+    end
+
+    @testset "revisit_cadence == 0 behaves as pure reactive (no cadence restriction)" begin
+        timestep = 10
+        absolute_threshold = 0.2
+        loss_threshold = 0.3
+        min_cover_remaining = 0.0
+
+        current_cover = fill(0.1, 5)
+        recent_cover_losses = zeros(5)
+        last_deployment = [10, 10, 10, 10, 10]  # would exclude everyone under cadence > 0
+
+        strategy = ReactiveStrategy(
+            targets, 0, 75, absolute_threshold, loss_threshold,
+            min_cover_remaining, 0, 0
+        )
+        state = (
+            current_cover=current_cover,
+            recent_cover_losses=recent_cover_losses,
+            last_deployment=last_deployment
+        )
+
+        result = filter_candidate_locations(strategy, timestep, state)
+        @test result == targets ||
+            "revisit_cadence == 0 should not restrict candidates by deployment recency " *
+              "(got $result)"
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-share end-to-end scenario test (Verification item 3)
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Multi-share revisit cadence — end-to-end" begin
+    dom = deepcopy(ADRIA_DOM_45)
+    loc_ids = dom.loc_ids
+    n_locs = length(loc_ids)  # 10 for Test_domain
+
+    half = n_locs ÷ 2
+    # Share 1: reversed order relative to domain.loc_ids (out-of-canonical-order share)
+    share_1_locs = reverse(loc_ids[1:half])
+    # Share 2: natural order
+    share_2_locs = loc_ids[(half + 1):end]
+
+    weight_1 = 0.5
+    weight_2 = 0.5
+
+    # cadence=2 with min_iv_locations=3 over a 10-location aggregate pool (below)
+    # guarantees at least 10-3=7 locations remain eligible every decision year
+    # (>= min_iv_locations), so Config A never needs to invoke PeriodicStrategy's
+    # backfill path — keeping this subtest a clean test of cadence exclusion alone.
+    cadence = 2
+    seed_year_start = 1
+    seed_years = 10
+
+    function _configure!(dom, min_iv_locations)
+        ADRIA.set_seed_target_locations!(
+            dom,
+            [
+                (weight=weight_1, target_locs=share_1_locs),
+                (weight=weight_2, target_locs=share_2_locs)
+            ]
+        )
+        ADRIA.fix_factor!(
+            dom;
+            N_seed_TA=500_000.0,
+            N_seed_CA=500_000.0,
+            N_seed_CNA=500_000.0,
+            N_seed_SM=500_000.0,
+            N_seed_LM=500_000.0,
+            seed_year_start=Float64(seed_year_start),
+            seed_years=Float64(seed_years),
+            seed_deployment_freq=1.0,  # decision every year
+            seed_revisit_cadence=Float64(cadence),
+            seed_strategy=Float64(ADRIA.DECISION_STRATEGY[:periodic]),
+            min_iv_locations=Float64(min_iv_locations)
+        )
+        return dom
+    end
+
+    num_samples = 2
+
+    # ── Config A: min_iv_locations set low relative to the 10-location aggregate
+    # pool, so that a clean 10/3-location round-robin can (in principle) satisfy
+    # both the per-share minimum and the cadence window without needing backfill
+    # on every decision year. Used to check cadence + correct-ID/ordering behaviour.
+    dom_a = _configure!(deepcopy(dom), 3)
+    scens_a = ADRIA.sample_guided(dom_a, num_samples)
+    rs_a = ADRIA.run_scenarios(dom_a, scens_a, "45")
+    # rs.ranks structure: (timesteps, locations, interventions, scenarios); rank > 0
+    # (stored as UInt16) indicates the location was selected for deployment at that
+    # timestep for that intervention type.
+    seed_ranks_a = rs_a.ranks[intervention = At(:seed)]
+
+    @testset "cadence is respected (no re-selection within the window)" begin
+        # Config A is deliberately sized so PeriodicStrategy's min_locations backfill
+        # (which intentionally re-offers on-cooldown locations when the eligible pool
+        # would otherwise drop below min_iv_locations — see PeriodicStrategy's
+        # docstring) never triggers here; this isolates cadence exclusion itself from
+        # the backfill escape hatch, which is separately exercised in Config B below.
+        for s = 1:num_samples
+            for loc_idx = 1:n_locs
+                deployed_ts = findall(
+                    >(0), collect(seed_ranks_a[locations = loc_idx, scenarios = At(s)])
+                )
+                deployed_ts = deployed_ts[
+                    seed_year_start .<= deployed_ts .<= (seed_year_start + seed_years - 1)
+                ]
+                isempty(deployed_ts) && continue
+                gaps = diff(sort(deployed_ts))
+                @test all(gaps .>= cadence) ||
+                    "Location $(loc_ids[loc_idx]) (scenario $s) was re-selected within " *
+                      "the $cadence-year cadence window (deployment timesteps: " *
+                      "$deployed_ts)"
+            end
+        end
+    end
+
+    @testset "correct location IDs selected despite non-canonical share ordering" begin
+        # Every location that was ever selected for seeding must belong to one of the
+        # two target-location sets (cross-checked by actual ID, not just index/count).
+        all_target_locs = Set(vcat(share_1_locs, share_2_locs))
+        for s = 1:num_samples
+            for loc_idx = 1:n_locs
+                any_deployment = any(
+                    >(0), collect(seed_ranks_a[locations = loc_idx, scenarios = At(s)])
+                )
+                if any_deployment
+                    @test loc_ids[loc_idx] in all_target_locs ||
+                        "Location $(loc_ids[loc_idx]) was seeded but is not part of any " *
+                          "configured target-location share"
+                end
+            end
+        end
+
+        # Reversed share_1 specifically: confirm at least one of its members (which sit
+        # at non-canonical positions in the aggregate target list) was actually seeded,
+        # proving the reversed ordering did not silently drop/misalign them.
+        share_1_idx = findall(in(share_1_locs), loc_ids)
+        share_1_deployed = any(
+            any(>(0), collect(seed_ranks_a[locations = li, scenarios = At(s)]))
+            for li in share_1_idx, s = 1:num_samples
+        )
+        @test share_1_deployed ||
+            "No location in the reversed-order share (share_1_locs) was ever seeded — " *
+              "possible ordering/alignment regression"
+    end
+
+    # ── Config B: min_iv_locations set high relative to the 10-location aggregate
+    # pool (unsustainable under a strict 3-year cadence round-robin), to force
+    # PeriodicStrategy's backfill path on essentially every decision year.
+    min_iv_locations_b = 8
+    dom_b = _configure!(deepcopy(dom), min_iv_locations_b)
+    scens_b = ADRIA.sample_guided(dom_b, num_samples)
+    rs_b = ADRIA.run_scenarios(dom_b, scens_b, "45")
+    seed_ranks_b = rs_b.ranks[intervention = At(:seed)]
+
+    @testset "Periodic backfill fills the aggregate pool when needed" begin
+        found_backfill_evidence = false
+        for s = 1:num_samples
+            for tstep = (seed_year_start + 1):(seed_year_start + seed_years - 1)
+                deployed_this_year = findall(
+                    >(0), collect(seed_ranks_b[timesteps = tstep, scenarios = At(s)])
+                )
+                if length(deployed_this_year) >= min_iv_locations_b
+                    found_backfill_evidence = true
+                end
+            end
+        end
+        @test found_backfill_evidence ||
+            "Expected at least one decision year where the aggregate selected-location " *
+              "count reached min_iv_locations ($min_iv_locations_b), evidencing " *
+              "PeriodicStrategy backfill"
+    end
+end

--- a/ADRIA/test/runtests.jl
+++ b/ADRIA/test/runtests.jl
@@ -60,6 +60,7 @@ tier3 = @testset "Tier 3: Spec & Domain Loads" begin
     @time include("sampling.jl")
     @time include("decisions/mcda.jl")
     @time include("decisions/location_spread.jl")
+    @time include("decisions/revisit_cadence.jl")
 end
 _abort_if_failed(tier3, "Tier 3 (Spec & Domain Loads)")
 


### PR DESCRIPTION
## Summary
- Replaces the single global `reactive_cooldown_period` factor with three independent factors (`seed_revisit_cadence`, `fog_revisit_cadence`, `mc_revisit_cadence`): a minimum number of years before the same location can be re-selected for deployment, set per intervention type.
- Applies to both `PeriodicStrategy` (with aggregate-pool backfill via longest-idle locations when cadence filtering would drop below `min_iv_locations`) and `ReactiveStrategy` (no backfill — cadence only further restricts the trigger-condition set).
- Fixes a pre-existing bug where `build_state`/`strategy_status` aligned per-location state to `domain.loc_ids`'s order instead of `strategy.target_locations`'s own order, silently returning wrong locations for multi-share configs listed out of domain order.
- Fixes a pre-existing bug in `scenario.jl` where the seed/fog/mc deployment loops stamped `last_*_deployment` for every candidate location *offered* to selection, not just the subset actually selected — permanently (and incorrectly) cadence-locking non-selected candidates.
- Wires the new factors into the sampling dependency-dag group membership, and adds a post-sampling floor step clamping each cadence column to its paired `deployment_freq` column so cadence isn't sampled into an inert region when `deployment_freq` already exceeds it.
- First commit on this branch carries forward the pre-existing (previously uncommitted) sampling dependency-dag framework (`sampling_dependencies.jl`/`sampling_transforms.jl`/`sampling_stratified.jl`) that this feature depends on — not authored in this session, included so the branch is self-contained and buildable.

## Test plan
- [x] New `ADRIA/test/decisions/revisit_cadence.jl` (59 tests): cadence mask helper, `build_state` ordering fix (deliberately reordered target list, both strategy types, verified by location ID not just count), `filter_candidate_locations` for both strategies (cadence, backfill, no-backfill), and a multi-share end-to-end scenario run confirming correct location IDs and cadence enforcement despite non-canonical share ordering.
- [x] Package compiles cleanly (`using ADRIA`).
- [ ] `test/sampling.jl` / `test/decisions/mcda.jl` still test older `guided`/`mcda_method` semantics predating the carried-forward dependency-dag framework — not updated here, flagged for separate consolidation (see commit message).