### PR TITLE
chore(ADRIAviz): regenerate Manifest.toml for Flatten/Serialization deps and 0.2.0 pin

### DIFF
--- a/ADRIAviz/Manifest.toml
+++ b/ADRIAviz/Manifest.toml
@@ -5,7 +5,7 @@ manifest_format = "2.0"
 project_hash = "597deec48145cc66b9a9bfab27c78c02e66cceab"
 
 [[deps.ADRIA]]
-deps = ["ADRIAIndicators", "ArchGDAL", "Bootstrap", "CSV", "Clustering", "Combinatorics", "CoralBlox", "CpuId", "DataFrames", "DataStructures", "Dates", "DimensionalData", "Distances", "Distributed", "Distributions", "FileIO", "GDAL_jll", "GeoDataFrames", "GeoFormatTypes", "GeoInterface", "Glob", "Graphs", "ImageIO", "Interpolations", "JMcDM", "JSON", "LERC_jll", "LinearAlgebra", "Logging", "ModelParameters", "NetCDF", "OnlineStats", "OrderedCollections", "Pkg", "PkgVersion", "PrecompileTools", "Printf", "ProgressMeter", "QuasiMonteCarlo", "Random", "Reexport", "RelocatableFolders", "Setfield", "SimpleWeightedGraphs", "SparseArrays", "SpecialFunctions", "StaticArrays", "Statistics", "StatsBase", "StatsFuns", "TOML", "YAXArrays", "Zarr"]
+deps = ["ADRIAIndicators", "ArchGDAL", "Bootstrap", "CSV", "Clustering", "Combinatorics", "CoralBlox", "CpuId", "DataFrames", "DataStructures", "Dates", "DimensionalData", "Distances", "Distributed", "Distributions", "FileIO", "Flatten", "GDAL_jll", "GeoDataFrames", "GeoFormatTypes", "GeoInterface", "Glob", "Graphs", "ImageIO", "Interpolations", "JMcDM", "JSON", "LERC_jll", "LinearAlgebra", "Logging", "ModelParameters", "NetCDF", "OnlineStats", "OrderedCollections", "Pkg", "PkgVersion", "PrecompileTools", "Printf", "ProgressMeter", "QuasiMonteCarlo", "Random", "Reexport", "RelocatableFolders", "Serialization", "Setfield", "SimpleWeightedGraphs", "SparseArrays", "SpecialFunctions", "StaticArrays", "Statistics", "StatsBase", "StatsFuns", "TOML", "YAXArrays", "Zarr"]
 path = "../ADRIA"
 uuid = "7dc409a7-fbe5-4c9d-b3e2-b0c19a6ba600"
 version = "0.17.0"
@@ -22,7 +22,7 @@ version = "0.2.1"
 deps = ["ADRIA", "ArchGDAL", "DataFrames", "DimensionalData", "Distances", "Distributions", "GeoFormatTypes", "GeoInterface", "Graphs", "ImageIO", "NaturalEarth", "OrderedCollections", "PrecompileTools", "Printf", "Random", "Reexport", "SimpleWeightedGraphs", "SparseArrays", "Statistics", "StatsBase", "YAXArrays"]
 path = "."
 uuid = "a7bb1955-b5ed-4954-ba3d-ac9734139a95"
-version = "0.1.0"
+version = "0.2.0"
 
     [deps.ADRIAviz.extensions]
     ADRIAvizMakieExt = ["Makie", "GeoMakie", "GraphMakie"]


### PR DESCRIPTION
## Summary
- Regenerates `ADRIAviz/Manifest.toml` to catch up with already-committed upstream changes: `ADRIA` gained `Flatten`/`Serialization` deps (from the Flatten.jl compile-cost fix), and `ADRIAviz` is pinned to its already-committed `0.2.0` version.
- No source or test changes; lockfile-only sync.

## Test plan
- [x] CI passes (Pkg resolve/instantiate + existing ADRIAviz test suite)