### PR TITLE
docs: sync analysis/cookbook examples with ADRIAanalysis API, add new viz recipes

### DIFF
--- a/ADRIA/docs/src/usage/analysis.md
+++ b/ADRIA/docs/src/usage/analysis.md
@@ -8,10 +8,21 @@ EditURL = "analysis.jl"
     This page covers functions provided by `ADRIAanalysis`. Ensure it is installed
     before running the examples (see [Getting Started](@ref)).
 
+!!! warning
+    Examples of analysis and visualizations are still being developed, so take the
+    examples below as illustrations of what analysis and visualizations are possible,
+    but not the intended quality. Caution is advised when interpreting results as they
+    are misleading without in-depth assessment.
+
 This section presents tools for analysing model generated data, including functions to
 extract metrics and plot graphs.
 
 ## Setup
+
+Plotly is recommended for quick visual assessment, however the Makie backend is more
+suitable for publication quality plots.
+
+While we use Plotly for the code here, the equivalent figures from Makie are shown.
 
 Install `PlotlyBase` alongside `ADRIAviz` and `ADRIAanalysis`:
 
@@ -45,6 +56,11 @@ rs = ADRIA.run_scenarios(dom, scens, rcp_45)
 
 s_tac = ADRIA.metrics.scenario_total_cover(rs)
 ADRIA.viz.scenarios(rs, s_tac)
+
+If using the Plotly backend, a separate call to display the figure is needed
+fig = ADRIA.viz.scenarios(rs, s_tac)
+ADRIA.viz.show_in_browser(fig)
+
 ```
 
 See the previous sections [Loading a Domain](@ref), [Generating scenarios](@ref) and
@@ -90,6 +106,7 @@ opts = Dict(
         :dhw_scenario,
         :wave_scenario,
         :guided,
+        :mcda_method,
         :N_seed_TA,
         :N_seed_CA,
         :fogging,
@@ -119,10 +136,7 @@ metrics.
 
 ```julia
 # Calculate frequencies with which each site was selected at each rank
-rank_freq = ADRIA.decision.ranks_to_frequencies(
-    rs.ranks[intervention=1];
-    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
-)
+rank_freq = ADRIA.decision.ranks_to_frequencies(ADRIA.metrics.seed_ranks(rs))
 
 # Plot 1st rank frequencies as a colormap
 rank_fig = ADRIA.viz.ranks_to_frequencies(rs, rank_freq, 1; fig_opts=Dict(:size=>(1200, 800)))
@@ -156,7 +170,8 @@ seed_pref = ADRIA.decision.SeedPreferences(dom, scen)
 sum_cover = vec(sum(dom.init_coral_cover; dims=1).data)
 dhw_scens = dom.dhw_scens[:, :, Int64(scen["dhw_scenario"])]
 plan_horizon = Int64(scen["plan_horizon"])
-decay = 0.99 .^ (1:(plan_horizon + 1)) .^ 2
+projection_confidence = scen["projection_confidence"]
+decay = ADRIA.decision.build_decay(plan_horizon, projection_confidence)
 dhw_projection = ADRIA.decision.weighted_projection(dhw_scens, 1, plan_horizon, decay, 75)
 area_weighted_conn = dom.conn.data .* ADRIA.loc_k_area(dom)
 conn_cache = similar(area_weighted_conn)
@@ -238,19 +253,19 @@ increasing number of samples. The result can then be plotted as band plots or a 
 using `viz.convergence`.
 
 ```julia
-outcome = dropdims(mean(ADRIA.metrics.scenario_total_cover(rs); dims=:timesteps), dims=:timesteps)
+outcome = dropdims(mean(s_tac; dims=:timesteps); dims=:timesteps)
 
 # Display convergence for specific factors of interest ("foi") within a single figure.
 # Bands represent the 95% confidence interval derived from the number of conditioning
 # points (default is 10 samples).
-foi = [:dhw_scenario, :wave_scenario, :guided]
+foi = [:dhw_scenario, :wave_scenario, :guided, :mcda_method]
 Si_conv = convergence(scens, outcome, foi)
 conv_series_fig = ADRIA.viz.convergence(Si_conv, foi)
 ADRIA.viz.savefig(conv_series_fig, "convergence_factors_series.html")
 
 # Convergence analysis of factors grouped by model component as a heat map
 components = [:EnvironmentalLayer, :Intervention, :Coral]
-Si_conv = convergence(rs, scens, outcome, components)
+Si_conv = convergence(scens, outcome, components)
 conv_hm_fig = ADRIA.viz.convergence(Si_conv, components; opts=Dict(:viz_type=>:heatmap))
 ADRIA.viz.savefig(conv_hm_fig, "convergence_components_heatmap.html")
 ```
@@ -397,23 +412,23 @@ n_clusters = 6
 clusters = cluster_scenarios(s_tac, n_clusters)
 
 # Identify cluster(s) with highest median temporal variability covering at least 1% of scenarios
-target_clusters = ADRIAanalysis.target_clusters(clusters, s_tac)
+tgt = target_clusters(clusters, s_tac)
 ```
 
 When the SIRUS Rule Induction algorithm produces rules involving two factors, they can be visualised as scatterplots.
 
 ```julia
-foi = ADRIA.component_params(rs, [Intervention, SeedCriteriaWeights]).fieldname
+rule_foi = ADRIA.component_params(rs, [Intervention, SeedCriteriaWeights]).fieldname
 
 max_rules = 10
 rules_iv = cluster_rules(
-    rs, target_clusters, scens, foi, max_rules; remove_duplicates=true
+    rs, tgt, scens, rule_foi, max_rules; remove_duplicates=true
 )
 
 rules_scatter_fig = ADRIA.viz.rules_scatter(
     rs,
     scens,
-    target_clusters,
+    tgt,
     rules_iv;
     fig_opts=fig_opts,
     opts=opts
@@ -445,110 +460,103 @@ For this dataset, according to this analysis:
 
 ### Regional Sensitivity Analysis
 
-Regional Sensitivity Analysis is a Monte Carlo filtering approach. The aim of RSA is to aid
-in identifying which (group of) factors drive model outputs and their active areas of
-factor space.
-
-This implementation divides factors into bins and compares the distribution of a selected outcome
-within each bin to the distribution outside the bin.
+Regional Sensitivity Analysis visualises how two factors jointly relate to an outcome.
+Scenarios are plotted as a 2D scatter of two factors of interest, coloured by outcome value.
 
 ```julia
+using ADRIAanalysis
+
 s_tac = ADRIA.metrics.scenario_total_cover(rs)
-mean_s_tac = dropdims(mean(s_tac, dims=1), dims=1)
+mean_s_tac = vec(mean(s_tac; dims=1))
 
-foi = [
-    :dhw_scenario,
-    :wave_scenario,
-    :N_seed_TA,
-    :N_seed_CA,
-    :fogging,
-    :SRM
-]
+# Build feature DataFrame (scenario inputs + environmental summary statistics)
+X = ADRIA.feature_set(rs)
 
-# Divide factors into 10 bins
-tac_rs = rsa(rs, mean_s_tac; S=10)
-rsa_fig = ADRIA.viz.rsa(rs, tac_rs, foi; opts, fig_opts)
+# Plot DHW scenario vs wave scenario, coloured by mean total cover
+rsa_fig = ADRIA.viz.rsa(X, mean_s_tac, (:dhw_scenario, :wave_scenario))
 ADRIA.viz.savefig(rsa_fig, "rsa.html")
 ```
 
 ![Plots of Regional Sensitivities](../assets/imgs/analysis/rsa.png)
 
-For this test data package, the results would suggest that bins that have very different coral cover to those outside that bin include:
+**How to read this figure:**
+Each point is one scenario. The x- and y-axes show the sampled values of the two
+chosen factors; the colour shows the outcome for that scenario (see colorbar).
+The contour fill interpolates the outcome surface across the factor space, making
+regional patterns easier to spot.
 
-- DHW Scenario: The 5 scenarios in the bin around scenario 30
-- Wave Scenario: The first 5 scenarios
-- Seeded Tabular Acropora and Seeded Corymbose Acropora: Low numbers of coral seeded
-- Fogging: Low effectiveness
-- SRM: Low and high levels of SRM. Scenarios with a DHW reduction of about 2.5 are most similar to those outside that bin.
-
-Results are likely to be dependent on how the sample of scenarios was obtained. A different sample might result in different sensitivities. Testing of convergence may be needed.
+- **Colour gradient along one axis** — that factor is the primary driver; the other
+  contributes little on its own.
+- **Colour gradient diagonal / interaction pattern** — both factors jointly influence
+  the outcome; no single factor dominates.
+- **Uniform colour throughout** — neither factor explains much of the outcome variance;
+  look elsewhere in the factor set.
+- **Sharp colour boundary** — a threshold exists: outcomes change abruptly once a
+  factor crosses a particular value.
 
 ### Outcome mapping
 
-As the name implies, outcome mapping aims to identify the relationship between model outputs and the region of factor space that led to those outputs.
-Similarly to Regional Sensitivity Analysis, it does this by filtering scenarios that match a specific outcome.
-
-This implementation then calculates the mean value of an outcome as a function of a factor.
-This is a form of scenario discovery that summarises scenarios matching an outcome in terms of values of a factor and the average value of one outcome.
-
-This example aims to identify DHW and wave scenarios and interventions which lead to top outcomes for coral cover. Note that it uses a test dataset rather than real data.
+Outcome mapping plots the value of each factor against a scalar outcome, allowing visual
+identification of which regions of factor space are associated with high or low outcomes.
+Pass a `Vector{Symbol}` to plot multiple factors as subplots.
 
 ```julia
 s_tac = ADRIA.metrics.scenario_total_cover(rs)
-mean_s_tac = dropdims(mean(s_tac, dims=1), dims=1)
+mean_s_tac = vec(mean(s_tac; dims=1))
 
-foi = [
-    :dhw_scenario,
-    :wave_scenario,
-    :N_seed_TA,
-    :N_seed_CA,
-    :fogging,
-    :SRM
-]
+X = ADRIA.feature_set(rs)
 
-# Indicate factor values that are in the top half of the range
-tac_top_50 = outcome_map(rs, mean_s_tac, x -> any(x .>= 0.5), foi; S=20)
-fig_top_50 = ADRIA.viz.outcome_map(
-    rs,
-    tac_top_50,
-    foi;
-    axis_opts=Dict(:title => "Regions which lead to Top 50th Percentile Outcomes", :ylabel => "TAC [m2]")
-)
-ADRIA.viz.savefig(fig_top_50, "outcome_map_top50.html")
+foi = [:dhw_scenario, :wave_scenario, :N_seed_TA, :N_seed_CA, :fogging, :SRM]
 
-# Indicate factor values that are in the top 30% of the range
-tac_top_30 = outcome_map(rs, mean_s_tac, x -> any(x .>= 0.7), foi; S=20)
-fig_top_30 = ADRIA.viz.outcome_map(
-    rs,
-    tac_top_30,
-    foi;
-    axis_opts=Dict(:title => "Regions which lead to Top 30th Percentile Outcomes", :ylabel => "TAC [m2]")
-)
-ADRIA.viz.savefig(fig_top_30, "outcome_map_top30.html")
+om_fig = ADRIA.viz.outcome_map(X, mean_s_tac, foi)
+ADRIA.viz.savefig(om_fig, "outcome_map.html")
 ```
 
 ![Outcome mapping](../assets/imgs/analysis/outcome_map.png)
 
-The figure shows the mean values of total coral cover (TAC) obtained as a function of each factor value, across scenarios in which outcomes in the top 50% or 30% of the range are obtained. The ribbon shows the estimated 95% confidence interval around the mean.
+**How to read this figure:**
+Each point is one scenario. The x-axis shows the factor value and the y-axis shows
+the outcome. The density fill (blue shading) shows where scenarios are most
+concentrated in (factor, outcome) space.
 
-There is less uncertainty in the mean for the top 30% because there were fewer scenarios in this group. The top 30% scenarios are a subset of the scenarios in the top 50%.
+- **Density gradient along one axis** — the factor positively or negatively influences
+  the outcome; scenarios with higher factor values tend to concentrate at higher or lower
+  outcomes respectively.
+- **Uniform density across factor values** — the factor has little marginal effect on
+  the outcome; other factors are likely more important.
+- **Wide vertical scatter at any given factor value** — high outcome variance that
+  cannot be explained by this factor alone; additional factors must be considered.
+- **Dense region offset from the bulk** — a subset of scenarios cluster away from
+  the main distribution, which may indicate an interaction with another factor.
 
-While this example uses a test data package rather than real data, we can still interpret the results:
+### Feature Ranking
 
-- DHW scenario: These are categorical values representing 50 different scenarios. There is no specific order to the scenarios - they are just interpreted individually. Note that as `S=20`, only 20 bins are shown - multiple scenarios have been aggregated. All 50 scenarios are represented in the top 50% of the range - it is possible to get results in the top half of the range in all scenarios.
-- Wave scenario: categorical variable representing each scenario in the test data package. Note that wave scenarios are no longer active as of ADRIA v0.7.0.
-- Seeded Tabular Acropora and Seeded Corymbose Acropora: Coral cover in the scenarios varies substantially as number of seeded corals increase. Outcomes are likely more heavily influenced by other factors in the scenario set.
-- Fogging: Similar to seeding, there is no clear pattern to coral cover as fogging effectiveness increases. Only scenarios with at least 0.1 fogging effectiveness are in the top 30% of the range.
-- SRM: As expected, coral cover increases with shade (decreases with DHW) in both groups of scenarios.
+Feature ranking uses the Mann-Whitney U test to score each factor by how well it
+discriminates between scenarios with high outcomes and all other scenarios.
+A higher `prob_superiority` indicates the factor more reliably separates high-outcome
+scenarios from the rest. `effect_size` is the rank-biserial correlation.
 
-For this test dataset, according to this analysis:
+```julia
+using ADRIAanalysis
 
-1) **Ensuring conditions for success**: Shade (SRM) is dominating the analysis. To be in the top 30% of the range, shade with at least ~4.5 DHW reduction is necessary. Fogging with an effectiveness of at least 0.1 is also needed.
-2) **Avoiding failure**: In some DHW scenarios, none of the sampled interventions are able to achieve performance in the top 30% of the range. Whether this is a problem depends on what those scenarios represent.
-3) **Planning for failure modes**: There are DHW scenarios for which high levels of SRM are not in the top 30% of the range - despite its cost, SRM has not delivered. This might warrant investigation as to why SRM was not sufficient in those scenarios.
-4) **Further deliberation**: High levels of SRM may be controversial both in terms of feasibility and cost. There is likely to be further debate about whether these scenarios should be considered, and whether top 30% of the range is an appropriate criteria for success.
+s_tac = ADRIA.metrics.scenario_total_cover(rs)
+mean_s_tac = vec(mean(s_tac; dims=1))
 
-Additional sampling may be needed to confirm findings where no matching scenarios were found.
+X = ADRIA.feature_set(rs)
+
+# Rank-based RSA: score each factor by how well it distinguishes the top 10% of outcomes
+ranking = ADRIAanalysis.sensitivity.rsa(X, mean_s_tac)
+```
+
+The returned `DataFrame` has columns `feature`, `statistic`, `prob_superiority`, and
+`effect_size`, sorted descending by `prob_superiority`.
+
+A `selection_mask` overload is available for custom outcome filters:
+
+```julia
+mask = mean_s_tac .>= quantile(mean_s_tac, 0.7)
+ranking = ADRIAanalysis.sensitivity.rsa(X, mask)
+```
 
 ### Data Envelopment Analysis
 
@@ -582,34 +590,37 @@ dom = ADRIA.load_domain("path to domain", "45")
 scens = ADRIA.sample(dom, 128)
 rs = ADRIA.run_scenarios(dom, scens, "45")
 
-n_scens = size(scens,1)
-
-# `cost` is the DEA input: one positive value per scenario representing the resources
-# consumed. Replace `cost_function` with your own cost/effort model. This simple example
-# uses deployed coral counts plus a non-zero baseline, so every scenario (including
-# counterfactuals with no deployment) carries a positive, comparably scaled cost.
-function cost_function(scens)
-    seed_cols = intersect(["N_seed_TA", "N_seed_CA"], names(scens))
-    deployed = isempty(seed_cols) ? zeros(nrow(scens)) :
-               vec(sum(Matrix(scens[:, seed_cols]); dims=2))
-    return deployed .+ (0.1 * maximum(deployed) + 1.0)  # baseline keeps inputs positive
+# Compute cost from seeded coral counts; ensure every scenario has a positive baseline
+seed_cols = String[c for c in ("N_seed_TA", "N_seed_CA") if c in names(scens)]
+cost = if isempty(seed_cols)
+    ones(Float64, nrow(scens))
+else
+    Float64.(vec(sum(Matrix(scens[:, seed_cols]); dims=2))) .+ 1.0
 end
 
-cost = cost_function(scens)
-
 # Get mean coral cover and shelter volume for each scenario
-s_tac = dropdims(
+s_tac_mean = dropdims(
     mean(ADRIA.metrics.scenario_total_cover(rs); dims=:timesteps); dims=:timesteps
 )
+asv = ADRIA.metrics.absolute_shelter_volume(rs)
 s_sv = dropdims(
-    mean(mean(ADRIA.metrics.absolute_shelter_volume(rs); dims=:timesteps); dims=:locations);
-    dims=(:timesteps,:locations)
+    mean(mean(asv; dims=:timesteps); dims=:locations);
+    dims=(:timesteps, :locations)
 )
+
+# Normalise inputs and outputs to [0, 1] before passing to DEA
+function _norm01(v::AbstractVector{Float64})
+    lo, hi = extrema(v)
+    return hi - lo < eps() ? ones(length(v)) : (v .- lo) ./ (hi - lo)
+end
+
+X = _norm01(cost)
+Y = hcat(_norm01(Array{Float64}(s_tac_mean)), _norm01(Array{Float64}(s_sv)))
 
 # Output oriented DEA analysis seeking to maximise cover and shelter volume for minimum
 # deployment cost
-DEA_scens = data_envelopment_analysis(cost, s_tac, s_sv)
-dea_fig = ADRIA.viz.data_envelopment_analysis(rs, DEA_scens)
+DEA_out = data_envelopment_analysis(X, Y)
+dea_fig = ADRIA.viz.data_envelopment_analysis(rs, DEA_out)
 ADRIA.viz.savefig(dea_fig, "dea.html")
 ```
 
@@ -630,3 +641,4 @@ ADRIA.viz.explore("path to Result Set")
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
+

--- a/ADRIA/docs/src/usage/cookbook.md
+++ b/ADRIA/docs/src/usage/cookbook.md
@@ -198,6 +198,142 @@ sel_score = selection_score(rs.ranks[intervention=1])
 sel_score = selection_score(rs.ranks[intervention=1]; dims=[:scenarios])
 ```
 
+## Taxonomy plot
+
+Relative cover by taxa group over time, summarised across scenarios.
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+scens = ADRIA.sample(dom, 128)
+rs = ADRIA.run_scenarios(dom, scens, "45")
+
+ADRIA.viz.taxonomy(rs)
+```
+
+![taxonomy](../assets/imgs/analysis/taxonomy.png)
+
+## Scenarios coloured by cluster
+
+Scenario trajectories with each scenario line coloured by its cluster membership.
+Useful for visually inspecting how clusters differ in trajectory shape.
+
+```julia
+using ADRIA
+using ADRIAviz
+using ADRIA.analysis: cluster_scenarios
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+scens = ADRIA.sample(dom, 128)
+rs = ADRIA.run_scenarios(dom, scens, "45")
+
+s_tac = ADRIA.metrics.scenario_total_cover(rs)
+clusters = cluster_scenarios(s_tac, 4)
+
+ADRIA.viz.scenarios(s_tac, clusters)
+```
+
+![scenarios_by_cluster](../assets/imgs/analysis/scenarios_by_cluster.png)
+
+## Connectivity graph
+
+Network graph of larval connectivity between locations in the domain.
+Node size reflects relative connectivity strength.
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+
+ADRIA.viz.connectivity(dom)
+```
+
+![connectivity](../assets/imgs/analysis/connectivity.png)
+
+## Selection frequency by intervention type
+
+Spatial map showing how often each location was selected, shown as a panel
+per intervention type (seeding, fogging, shading, moving corals).
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+scens = ADRIA.sample(dom, 128)
+rs = ADRIA.run_scenarios(dom, scens, "45")
+
+intervention_types = (:seed, :fog, :shade, :mc)
+labels = String[]
+freq_cols = Vector{Float64}[]
+for iv in intervention_types
+    freq = try
+        collect(Float64, ADRIA.decision.selection_frequency(rs.ranks, iv))
+    catch
+        continue
+    end
+    any(x -> isfinite(x) && x > 0, freq) || continue
+    push!(labels, titlecase(string(iv)))
+    push!(freq_cols, freq)
+end
+
+freq_matrix = reduce(hcat, freq_cols)
+ADRIA.viz.map(rs, freq_matrix, labels)
+```
+
+![ranks_by_intervention](../assets/imgs/analysis/ranks_by_intervention.png)
+
+## DHW scenario
+
+Degree heating weeks over time for a single environmental scenario.
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+
+# Show DHW projections for environmental scenario 1
+ADRIA.viz.dhw_scenario(dom, 1)
+```
+
+![dhw_scenario](../assets/imgs/analysis/dhw_scenario.png)
+
+## DHW scenarios (all)
+
+Summary of degree heating weeks across all environmental scenarios, showing
+the ensemble range and median.
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+
+ADRIA.viz.dhw_scenarios(dom)
+```
+
+![dhw_scenarios](../assets/imgs/analysis/dhw_scenarios.png)
+
+## Cyclone scenario
+
+Cyclone disturbance severity over time for a single environmental scenario.
+
+```julia
+using ADRIA
+using ADRIAviz
+
+dom = ADRIA.load_domain("path/to/domain", "45")
+
+# Show cyclone disturbance for environmental scenario 1
+ADRIA.viz.cyclone_scenario(dom, 1)
+```
+
+![cyclone_scenario](../assets/imgs/analysis/cyclone_scenario.png)
+
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*

--- a/ADRIA/docs/src/usage/cookbook.md
+++ b/ADRIA/docs/src/usage/cookbook.md
@@ -181,13 +181,7 @@ scens = ADRIA.sample(dom, 8)
 rs = ADRIA.run_scenarios(dom, scens, "45")
 
 # Get frequencies with which each site was selected for each rank
-rank_freq = ranks_to_frequencies(rs.ranks[intervention=1])  # with timesteps not aggregated
-
-# With timesteps aggregated
-rank_freq = ranks_to_frequencies(
-    rs.ranks[intervention=1];
-    agg_func=x -> dropdims(sum(x; dims=:timesteps); dims=:timesteps),
-)
+rank_freq = ranks_to_frequencies(ADRIA.metrics.seed_ranks(rs))
 
 # Get selection frequencies for set of runs
 selection_freq = location_selection_frequencies(rs.ranks[intervention=1])

--- a/ADRIA/docs/src/usage/getting_started.md
+++ b/ADRIA/docs/src/usage/getting_started.md
@@ -139,7 +139,7 @@ calling any `ADRIA.viz.*` function:
 
 ```julia
 using ADRIA, ADRIAviz, PlotlyBase
-ADRIAviz.activate(:plotly)
+ADRIAviz.activate("plotly")
 
 fig = ADRIA.viz.scenarios(rs, s_tc; axis_opts=Dict(:ylabel => "Absolute Cover"))
 ADRIA.viz.savefig(fig, "scenarios.html")


### PR DESCRIPTION
## Summary
- Fix `ADRIAviz.activate` example call to pass the backend as a string, not a symbol
- Update `analysis.md` and the `rank_freq` example in `cookbook.md` for the current `ADRIAanalysis` API: `rsa`/`outcome_map` now take an `ADRIA.feature_set(rs)` DataFrame, `convergence` no longer takes `rs`, and `ranks_to_frequencies` examples use `ADRIA.metrics.seed_ranks(rs)`. Also documents the new `sensitivity.rsa` feature-ranking function and adds a note that analysis/viz examples are still under active development.
- Add new cookbook recipes: taxonomy plot, cluster-coloured scenarios, connectivity graph, selection frequency by intervention type, DHW scenario/scenarios, cyclone scenario

## Test plan
- [ ] Docs build passes in CI
- [ ] Spot-check rendered `analysis.md` and `cookbook.md` pages for formatting